### PR TITLE
Add git blame ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# scalafmt
+90f8bf7e6d6f7a2d6c63313944613a95ff60091a


### PR DESCRIPTION
Similar to pekko core, adds a `.git-blame-ignore-revs` which contains the hashes for the previous scalafmt commits.