### PR TITLE
Rename akka-http user-agent plus server header to pekko-http

### DIFF
--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
@@ -64,7 +64,7 @@ class ConnectionPoolBenchmark extends CommonBenchmark {
            pekko.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
            akka.http.host-connection-pool.max-connections = ${maxConnections}
            akka.http.host-connection-pool.max-open-requests = 16384
-           akka.http.client.user-agent = akka-http-bench
+           akka.http.client.user-agent = pekko-http-bench
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
@@ -72,7 +72,7 @@ class ConnectionPoolBenchmark extends CommonBenchmark {
 
     val responseBytes = ByteString(
       """HTTP/1.1 200 OK
-        |Server: akka-http/test
+        |Server: pekko-http/test
         |Date: Wed, 01 Jul 2020 13:26:33 GMT
         |Content-Length: 0
         |

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ServerProcessingBenchmark.scala
@@ -49,7 +49,7 @@ class ServerProcessingBenchmark extends CommonBenchmark {
       ConfigFactory.parseString(
         """
            pekko.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
-           akka.http.server.server-header = "akka-http-bench"
+           akka.http.server.server-header = "pekko-http-bench"
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/StreamServerProcessingBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/StreamServerProcessingBenchmark.scala
@@ -99,7 +99,7 @@ class StreamServerProcessingBenchmark extends CommonBenchmark {
     }
 
     val response = HttpResponse(
-      headers = headers.Server("akka-http-bench") :: Nil,
+      headers = headers.Server("pekko-http-bench") :: Nil,
       entity = entity)
 
     httpFlow =

--- a/http-core/src/main/resources/reference.conf
+++ b/http-core/src/main/resources/reference.conf
@@ -16,7 +16,7 @@ akka.http {
     # explicit `Server`-header was included in a response.
     # If this value is the empty string and no header was included in
     # the request, no `Server` header will be rendered at all.
-    server-header = akka-http/${pekko.http.version}
+    server-header = pekko-http/${pekko.http.version}
 
     # "PREVIEW" features that are not yet fully production ready.
     # These flags can change or be removed between patch releases.
@@ -337,7 +337,7 @@ akka.http {
     # explicit `User-Agent`-header was included in a request.
     # If this value is the empty string and no header was included in
     # the request, no `User-Agent` header will be rendered at all.
-    user-agent-header = akka-http/${pekko.http.version}
+    user-agent-header = pekko-http/${pekko.http.version}
 
     # The time period within which the TCP connecting process must be completed.
     connecting-timeout = 10s

--- a/http-core/src/test/scala/org/apache/pekko/http/ConfigSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/ConfigSpec.scala
@@ -22,7 +22,7 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.fin
 
       config.getString("pekko.http.version") should ===(Version.current)
 
-      val versionString = "akka-http/" + Version.current
+      val versionString = "pekko-http/" + Version.current
       val serverSettings = ServerSettings(system)
       serverSettings.serverHeader should ===(Some(Server(versionString)))
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -54,7 +54,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
         expectWireData(
           """PUT / HTTP/1.1
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |Content-Type: application/octet-stream
             |Content-Length: 8
             |
@@ -156,7 +156,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
           """GET / HTTP/1.1
             |Connection: close
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |Transfer-Encoding: chunked
             |Content-Type: text/plain; charset=UTF-8
             |
@@ -180,11 +180,11 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
       }
 
       "has a request with a overridden User-Agent RawHeader" in new TestSetup {
-        val request = HttpRequest().addHeader(RawHeader("User-Agent", "akka-http/test-overridden"))
+        val request = HttpRequest().addHeader(RawHeader("User-Agent", "pekko-http/test-overridden"))
         requestsSub.sendNext(request)
         expectWireData(
           """GET / HTTP/1.1
-            |User-Agent: akka-http/test-overridden
+            |User-Agent: pekko-http/test-overridden
             |Host: example.com
             |
             |""")
@@ -209,7 +209,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
         expectWireData(
           """GET / HTTP/1.1
             |Host: testhost.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |
             |""")
 
@@ -233,7 +233,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
         expectWireData(
           """GET / HTTP/1.1
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |
             |""")
 
@@ -261,7 +261,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
       expectWireData(
         """GET / HTTP/1.1
           |Host: example.com
-          |User-Agent: akka-http/test
+          |User-Agent: pekko-http/test
           |
           |""")
 
@@ -301,7 +301,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
         expectWireData(
           """GET / HTTP/1.1
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |
             |""")
 
@@ -326,7 +326,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
         expectWireData(
           """GET / HTTP/1.1
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |
             |""")
 
@@ -365,7 +365,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
         expectWireData(
           """GET / HTTP/1.1
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |
             |""")
         requestsSub.sendComplete()
@@ -484,7 +484,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
         expectWireData(
           """PUT / HTTP/1.1
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |Content-Type: application/octet-stream
             |Content-Length: 8
             |
@@ -515,7 +515,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
         expectWireData(
           """PUT / HTTP/1.1
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |Content-Type: application/octet-stream
             |Content-Length: 8
             |
@@ -817,7 +817,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
           """POST / HTTP/1.1
             |Expect: 100-continue
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 6
             |
@@ -854,7 +854,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
           """POST / HTTP/1.1
             |Expect: 100-continue
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |Content-Type: application/octet-stream
             |Content-Length: 8
             |
@@ -891,7 +891,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
           """POST / HTTP/1.1
             |Expect: 100-continue
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 6
             |
@@ -922,7 +922,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
           """POST / HTTP/1.1
             |Expect: 100-continue
             |Host: example.com
-            |User-Agent: akka-http/test
+            |User-Agent: pekko-http/test
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 6
             |
@@ -975,7 +975,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
       expectWireData(
         """HEAD / HTTP/1.1
           |Host: example.com
-          |User-Agent: akka-http/test
+          |User-Agent: pekko-http/test
           |
           |""")
       sendWireData(
@@ -1004,7 +1004,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
     def settings = {
       val s = ClientConnectionSettings(
         ConfigFactory.parseString(config).withFallback(system.settings.config)).withUserAgentHeader(
-        Some(`User-Agent`(List(ProductVersion("akka-http", "test")))))
+        Some(`User-Agent`(List(ProductVersion("pekko-http", "test")))))
       if (maxResponseContentLength < 0) s
       else s.withParserSettings(s.parserSettings.withMaxContentLength(maxResponseContentLength))
     }
@@ -1055,7 +1055,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
       expectWireData(
         """GET / HTTP/1.1
           |Host: example.com
-          |User-Agent: akka-http/test
+          |User-Agent: pekko-http/test
           |
           |""")
     }

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/RequestRendererSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/RequestRendererSpec.scala
@@ -42,7 +42,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
         HttpRequest(GET, "/abc") should renderTo {
           """GET /abc HTTP/1.1
             |Host: test.com:8080
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |
             |"""
         }
@@ -52,7 +52,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
         HttpRequest(GET, "/abc<def") should renderTo {
           """GET /abc%3Cdef HTTP/1.1
             |Host: test.com:8080
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |
             |"""
         }
@@ -62,7 +62,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
         HttpRequest(GET, uri = "/abc") should renderTo {
           """GET /abc HTTP/1.1
             |Host: [0:0:0:0:0:0:0:1]:8080
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |
             |"""
         }
@@ -78,7 +78,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
             |X-Fancy: naa
             |Link: <http://akka.io>; rel=first
             |Host: spray.io:9999
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |Content-Length: 0
             |
             |"""
@@ -95,7 +95,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
             |X-Fancy: naa
             |Cache-Control: public
             |Host: spray.io
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 19
             |
@@ -114,7 +114,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
             |X-Fancy: naa
             |Cache-Control: public
             |Host: spray.io
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |Content-Length: 19
             |
             |The content please!"""
@@ -127,7 +127,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
           """PUT /abc/xyz HTTP/1.1
               |Transfer-Encoding: fancy
               |Host: test.com:8080
-              |User-Agent: akka-http/1.0.0
+              |User-Agent: pekko-http/1.0.0
               |Content-Type: text/plain; charset=UTF-8
               |Content-Length: 19
               |
@@ -139,7 +139,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
         HttpRequest(DELETE, "/abc") should renderTo {
           """DELETE /abc HTTP/1.1
             |Host: test.com:8080
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |
             |"""
         }
@@ -152,7 +152,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
         HttpRequest(PUT, "/abc/xyz", entity = Chunked(ContentTypes.`text/plain(UTF-8)`, Source.empty)) should renderTo {
           """PUT /abc/xyz HTTP/1.1
             |Host: test.com:8080
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 0
             |
@@ -167,7 +167,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
             source("XXXX", "ABCDEFGHIJKLMNOPQRSTUVWXYZ"))) should renderTo {
           """POST /abc/xyz HTTP/1.1
               |Host: test.com:8080
-              |User-Agent: akka-http/1.0.0
+              |User-Agent: pekko-http/1.0.0
               |Transfer-Encoding: chunked
               |Content-Type: text/plain; charset=UTF-8
               |
@@ -194,7 +194,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
             Source(chunks))) should renderTo {
           """POST /abc/xyz HTTP/1.1
             |Host: test.com:8080
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |Transfer-Encoding: chunked
             |Content-Type: text/plain; charset=UTF-8
             |
@@ -222,7 +222,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
             Source(chunks))) should renderTo {
           """POST /abc/xyz HTTP/1.1
             |Host: test.com:8080
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |Transfer-Encoding: chunked
             |Content-Type: text/plain; charset=UTF-8
             |
@@ -243,7 +243,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
           """POST /abc/xyz HTTP/1.1
               |Transfer-Encoding: fancy, chunked
               |Host: test.com:8080
-              |User-Agent: akka-http/1.0.0
+              |User-Agent: pekko-http/1.0.0
               |Content-Type: text/plain; charset=UTF-8
               |
               |4
@@ -313,7 +313,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
         HttpRequest(GET, "/abc", List(`Raw-Request-URI`("/def"))) should renderTo {
           """GET /def HTTP/1.1
             |Host: test.com:8080
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |
             |"""
         }
@@ -323,7 +323,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
         HttpRequest(GET, "/abc", List(`Raw-Request-URI`("/def%80%fe%ff"))) should renderTo {
           """GET /def%80%fe%ff HTTP/1.1
             |Host: test.com:8080
-            |User-Agent: akka-http/1.0.0
+            |User-Agent: pekko-http/1.0.0
             |
             |"""
         }
@@ -334,7 +334,7 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
   override def afterAll() = TestKit.shutdownActorSystem(system)
 
   class TestSetup(
-      val userAgent: Option[`User-Agent`] = Some(`User-Agent`("akka-http/1.0.0")),
+      val userAgent: Option[`User-Agent`] = Some(`User-Agent`("pekko-http/1.0.0")),
       serverAddress: InetSocketAddress = new InetSocketAddress("test.com", 8080))
       extends HttpRequestRendererFactory(userAgent, requestHeaderSizeHint = 64, NoLogging) {
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -42,7 +42,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
       "status 200 and no headers" in new TestSetup() {
         HttpResponse(200) should renderTo {
           """HTTP/1.1 200 OK
-            |Server: akka-http/1.0.0
+            |Server: pekko-http/1.0.0
             |Date: Thu, 25 Aug 2011 09:10:29 GMT
             |Content-Length: 0
             |
@@ -54,7 +54,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
         HttpResponse(200, List(Date(DateTime(2011, 8, 26, 10, 11, 59)))) should renderTo {
           """HTTP/1.1 200 OK
             |Date: Fri, 26 Aug 2011 10:11:59 GMT
-            |Server: akka-http/1.0.0
+            |Server: pekko-http/1.0.0
             |Content-Length: 0
             |
             |"""
@@ -66,7 +66,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
           """HTTP/1.1 304 Not Modified
             |X-Fancy: of course
             |Age: 0
-            |Server: akka-http/1.0.0
+            |Server: pekko-http/1.0.0
             |Date: Thu, 25 Aug 2011 09:10:29 GMT
             |
             |"""
@@ -75,7 +75,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
       "a custom status code and no headers" in new TestSetup() {
         HttpResponse(ServerOnTheMove) should renderTo {
           """HTTP/1.1 330 Server on the move
-            |Server: akka-http/1.0.0
+            |Server: pekko-http/1.0.0
             |Date: Thu, 25 Aug 2011 09:10:29 GMT
             |Content-Length: 0
             |
@@ -89,7 +89,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
           extraMillis = millis
           HttpResponse(200) should renderTo {
             s"""HTTP/1.1 200 OK
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:0${extraMillis / 1000 % 60} GMT
               |Content-Length: 0
               |
@@ -108,7 +108,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
             entity = "Small f*ck up overhere!")) should renderTo(
           """HTTP/1.1 200 OK
               |Age: 30
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Type: text/plain; charset=UTF-8
               |Content-Length: 23
@@ -126,7 +126,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
               Source.single(ByteString("Foo"))))) should renderTo(
           """HTTP/1.1 200 OK
               |Age: 30
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Type: text/plain; charset=UTF-8
               |
@@ -143,7 +143,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
               Source.single(HttpEntity.Chunk(ByteString("Foo")))))) should renderTo(
           """HTTP/1.1 200 OK
               |Age: 30
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Transfer-Encoding: chunked
               |Content-Type: text/plain; charset=UTF-8
@@ -159,7 +159,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
             entity = HttpEntity.Default(ContentTypes.`text/plain(UTF-8)`, 100, Source.empty))) should renderTo(
           """HTTP/1.1 200 OK
               |Age: 30
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Type: text/plain; charset=UTF-8
               |Content-Length: 100
@@ -173,7 +173,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
         HttpResponse(400, List(Age(30), Connection("Keep-Alive")), "Small f*ck up overhere!") should renderTo {
           """HTTP/1.1 400 Bad Request
             |Age: 30
-            |Server: akka-http/1.0.0
+            |Server: pekko-http/1.0.0
             |Date: Thu, 25 Aug 2011 09:10:29 GMT
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 23
@@ -187,7 +187,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
           HttpEntity(ContentTypes.NoContentType, ByteString("Small f*ck up overhere!"))) should renderTo {
           """HTTP/1.1 400 Bad Request
               |Age: 30
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Length: 23
               |
@@ -201,7 +201,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
           entity = "All good") should renderTo {
           """HTTP/1.1 200 OK
               |Transfer-Encoding: fancy
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Type: text/plain; charset=UTF-8
               |Content-Length: 8
@@ -218,7 +218,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
               source(ByteString("Small f*ck up overhere!")))) should renderTo {
           """HTTP/1.1 400 Bad Request
               |Age: 30
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Type: text/plain; charset=UTF-8
               |Content-Length: 23
@@ -253,7 +253,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
               ContentTypes.`application/json`,
               source(ByteString.empty)))) should renderTo(
           """HTTP/1.1 200 OK
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Connection: close
               |Content-Type: application/json
@@ -267,7 +267,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
               ContentTypes.`application/json`,
               source(ByteString("abc"), ByteString("defg"))))) should renderTo(
           """HTTP/1.1 200 OK
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Connection: close
               |Content-Type: application/json
@@ -282,7 +282,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
           Chunked(ContentTypes.NoContentType, Source.empty)) should renderTo {
           """HTTP/1.1 200 OK
               |Age: 30
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |
               |"""
@@ -294,7 +294,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
           Chunked(ContentTypes.`application/json`, Source.empty)) should renderTo {
           """HTTP/1.1 200 OK
               |Age: 30
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Type: application/json
               |
@@ -307,7 +307,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
           ContentTypes.`text/plain(UTF-8)`,
           source("Yahoooo"))) should renderTo {
           """HTTP/1.1 200 OK
-            |Server: akka-http/1.0.0
+            |Server: pekko-http/1.0.0
             |Date: Thu, 25 Aug 2011 09:10:29 GMT
             |Transfer-Encoding: chunked
             |Content-Type: text/plain; charset=UTF-8
@@ -327,7 +327,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
             Chunk(ByteString("body123"), """key=value;another="tl;dr""""),
             LastChunk("foo=bar", List(Age(30), RawHeader("Cache-Control", "public")))))) should renderTo {
           """HTTP/1.1 200 OK
-            |Server: akka-http/1.0.0
+            |Server: pekko-http/1.0.0
             |Date: Thu, 25 Aug 2011 09:10:29 GMT
             |Transfer-Encoding: chunked
             |Content-Type: text/plain; charset=UTF-8
@@ -349,7 +349,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
             Chunk(ByteString("body123"), """key=value;another="tl;dr""""),
             LastChunk("foo=bar", List(Age(30), RawHeader("Cache-Control", "public"))), LastChunk))) should renderTo {
           """HTTP/1.1 200 OK
-            |Server: akka-http/1.0.0
+            |Server: pekko-http/1.0.0
             |Date: Thu, 25 Aug 2011 09:10:29 GMT
             |Transfer-Encoding: chunked
             |Content-Type: text/plain; charset=UTF-8
@@ -370,7 +370,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
           entity = Chunked(ContentTypes.`text/plain(UTF-8)`, source("Yahoooo"))) should renderTo {
           """HTTP/1.1 200 OK
               |Transfer-Encoding: fancy, chunked
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Type: text/plain; charset=UTF-8
               |
@@ -391,7 +391,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
             ContentTypes.`application/json`,
             source(Chunk("abc"), Chunk("defg"))))) should renderTo(
           """HTTP/1.1 200 OK
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Connection: close
               |Content-Type: application/json
@@ -408,7 +408,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
               Chunk(ByteString("body123"), """key=value;another="tl;dr""""),
               LastChunk("foo=bar", List(Age(30), RawHeader("Cache-Control", "public"))))))) should renderTo(
           """HTTP/1.1 200 OK
-              |Server: akka-http/1.0.0
+              |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Connection: close
               |Content-Type: text/plain; charset=UTF-8
@@ -475,7 +475,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
     "render headers safely" - {
       val defaultResponse =
         """HTTP/1.1 200 OK
-          |Server: akka-http/1.0.0
+          |Server: pekko-http/1.0.0
           |Date: Thu, 25 Aug 2011 09:10:29 GMT
           |Content-Length: 0
           |
@@ -668,7 +668,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
           requestProtocol = reqProto,
           closeRequested = closing(HttpMessage.connectionCloseExpected(reqProto, reqCH))) should renderTo(
           s"""${resProto.value} 200 OK
-                 |Server: akka-http/1.0.0
+                 |Server: pekko-http/1.0.0
                  |Date: Thu, 25 Aug 2011 09:10:29 GMT
                  |${renCH.fold("")(_.toString + "\n")}Content-Type: text/plain; charset=UTF-8
                  |${if (resCD) "" else "Content-Length: 6\n"}
@@ -678,7 +678,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
 
-  class TestSetup(val serverHeader: Option[Server] = Some(Server("akka-http/1.0.0"))) {
+  class TestSetup(val serverHeader: Option[Server] = Some(Server("pekko-http/1.0.0"))) {
     private val rendererFactory = new HttpResponseRendererFactory(serverHeader, responseHeaderSizeHint = 64, NoLogging,
       new DateHeaderRendering {
         override def renderHeaderPair(): (String, String) = ???

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerBug21008Spec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerBug21008Spec.scala
@@ -41,7 +41,7 @@ class HttpServerBug21008Spec extends AkkaSpecWithMaterializer(
 
             expectResponseWithWipedDate(
               """HTTP/1.1 100 Continue
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |
               |""")
@@ -73,7 +73,7 @@ class HttpServerBug21008Spec extends AkkaSpecWithMaterializer(
             // and the client should still get that ok
             expectResponseWithWipedDate(
               """HTTP/1.1 200 OK
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |Connection: close
               |Content-Type: text/plain; charset=UTF-8

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerSpec.scala
@@ -101,7 +101,7 @@ class HttpServerSpec extends AkkaSpec(
 
       expectResponseWithWipedDate(
         """HTTP/1.1 505 HTTP Version Not Supported
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Connection: close
           |Content-Type: text/plain; charset=UTF-8
@@ -141,7 +141,7 @@ class HttpServerSpec extends AkkaSpec(
 
           expectResponseWithWipedDate(
             """HTTP/1.1 400 Bad Request
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |Connection: close
               |Content-Type: text/plain; charset=UTF-8
@@ -510,7 +510,7 @@ class HttpServerSpec extends AkkaSpec(
               ByteString("abcd"))))
             expectResponseWithWipedDate(
               """|HTTP/1.1 200 OK
-               |Server: akka-http/test
+               |Server: pekko-http/test
                |Date: XXXX
                |Content-Type: text/plain; charset=UTF-8
                |Content-Length: 4
@@ -538,7 +538,7 @@ class HttpServerSpec extends AkkaSpec(
             dataSub.expectCancellation()
             expectResponseWithWipedDate(
               """|HTTP/1.1 200 OK
-               |Server: akka-http/test
+               |Server: pekko-http/test
                |Date: XXXX
                |Content-Type: text/plain; charset=UTF-8
                |Content-Length: 4
@@ -566,7 +566,7 @@ class HttpServerSpec extends AkkaSpec(
             dataSub.expectCancellation()
             expectResponseWithWipedDate(
               """|HTTP/1.1 200 OK
-               |Server: akka-http/test
+               |Server: pekko-http/test
                |Date: XXXX
                |Content-Type: text/plain; charset=UTF-8
                |
@@ -595,7 +595,7 @@ class HttpServerSpec extends AkkaSpec(
             dataSub.expectCancellation()
             expectResponseWithWipedDate(
               """|HTTP/1.1 200 OK
-               |Server: akka-http/test
+               |Server: pekko-http/test
                |Date: XXXX
                |Transfer-Encoding: chunked
                |Content-Type: text/plain; charset=UTF-8
@@ -645,7 +645,7 @@ class HttpServerSpec extends AkkaSpec(
           dataSub.request(1) // triggers `100 Continue` response
           expectResponseWithWipedDate(
             """HTTP/1.1 100 Continue
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |
               |""")
@@ -657,7 +657,7 @@ class HttpServerSpec extends AkkaSpec(
           responses.sendNext(HttpResponse(entity = "Yeah"))
           expectResponseWithWipedDate(
             """HTTP/1.1 200 OK
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |Content-Type: text/plain; charset=UTF-8
               |Content-Length: 4
@@ -686,7 +686,7 @@ class HttpServerSpec extends AkkaSpec(
             dataSub.request(1) // triggers `100 Continue` response
             expectResponseWithWipedDate(
               """HTTP/1.1 100 Continue
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |
               |""")
@@ -700,7 +700,7 @@ class HttpServerSpec extends AkkaSpec(
             responses.sendNext(HttpResponse(entity = "Yeah"))
             expectResponseWithWipedDate(
               """HTTP/1.1 200 OK
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |Content-Type: text/plain; charset=UTF-8
               |Content-Length: 4
@@ -728,7 +728,7 @@ class HttpServerSpec extends AkkaSpec(
 
         expectResponseWithWipedDate(
           """HTTP/1.1 200 OK
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Content-Type: text/plain; charset=UTF-8
           |Content-Length: 4
@@ -753,7 +753,7 @@ class HttpServerSpec extends AkkaSpec(
 
         expectResponseWithWipedDate(
           """HTTP/1.1 200 OK
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Content-Type: text/plain; charset=UTF-8
           |Content-Length: 4
@@ -777,7 +777,7 @@ class HttpServerSpec extends AkkaSpec(
 
         expectResponseWithWipedDate(
           """HTTP/1.1 200 OK
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Content-Type: text/plain; charset=UTF-8
           |Content-Length: 4
@@ -804,7 +804,7 @@ class HttpServerSpec extends AkkaSpec(
           dataSub.request(2) // triggers `100 Continue` response
           expectResponseWithWipedDate(
             """HTTP/1.1 100 Continue
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |
               |""")
@@ -821,7 +821,7 @@ class HttpServerSpec extends AkkaSpec(
           responses.sendNext(HttpResponse(entity = "Yeah"))
           expectResponseWithWipedDate(
             """HTTP/1.1 200 OK
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |Content-Type: text/plain; charset=UTF-8
               |Content-Length: 4
@@ -847,7 +847,7 @@ class HttpServerSpec extends AkkaSpec(
             responses.sendNext(HttpResponse(entity = "Yeah"))
             expectResponseWithWipedDate(
               """HTTP/1.1 200 OK
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |Connection: close
               |Content-Type: text/plain; charset=UTF-8
@@ -879,7 +879,7 @@ class HttpServerSpec extends AkkaSpec(
 
         expectResponseWithWipedDate(
           """HTTP/1.1 100 Continue
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |
           |""")
@@ -891,7 +891,7 @@ class HttpServerSpec extends AkkaSpec(
         responses.sendNext(HttpResponse(entity = outEntity))
         expectResponseWithWipedDate(
           """HTTP/1.1 200 OK
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Connection: close
           |Content-Type: text/plain; charset=UTF-8
@@ -927,7 +927,7 @@ class HttpServerSpec extends AkkaSpec(
         responses.sendNext(HttpResponse(entity = outEntity))
         expectResponseWithWipedDate(
           """HTTP/1.1 200 OK
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Connection: close
           |Content-Type: text/plain; charset=UTF-8
@@ -964,7 +964,7 @@ class HttpServerSpec extends AkkaSpec(
 
       expectResponseWithWipedDate(
         """HTTP/1.1 500 Internal Server Error
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Connection: close
           |Content-Length: 0
@@ -991,7 +991,7 @@ class HttpServerSpec extends AkkaSpec(
       responses.sendNext(HttpResponse(entity = outEntity))
       expectResponseWithWipedDate(
         """HTTP/1.1 200 OK
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Transfer-Encoding: chunked
           |Content-Type: application/octet-stream
@@ -1037,7 +1037,7 @@ class HttpServerSpec extends AkkaSpec(
 
         expectResponseWithWipedDate(
           """HTTP/1.1 500 Internal Server Error
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Content-Type: text/plain; charset=UTF-8
           |Content-Length: 35
@@ -1060,7 +1060,7 @@ class HttpServerSpec extends AkkaSpec(
 
       expectResponseWithWipedDate(
         """HTTP/1.1 200 OK
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Connection: close
           |Content-Type: application/octet-stream
@@ -1099,7 +1099,7 @@ class HttpServerSpec extends AkkaSpec(
 
       expectResponseWithWipedDate(
         """HTTP/1.1 200 OK
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Transfer-Encoding: chunked
           |Content-Type: application/octet-stream
@@ -1148,7 +1148,7 @@ class HttpServerSpec extends AkkaSpec(
 
       expectResponseWithWipedDate(
         """|HTTP/1.1 400 Bad Request
-           |Server: akka-http/test
+           |Server: pekko-http/test
            |Date: XXXX
            |Connection: close
            |Content-Type: text/plain; charset=UTF-8
@@ -1288,7 +1288,7 @@ class HttpServerSpec extends AkkaSpec(
 
       expectResponseWithWipedDate(
         """HTTP/1.1 507 Insufficient Storage
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Connection: close
           |Content-Length: 0
@@ -1315,7 +1315,7 @@ class HttpServerSpec extends AkkaSpec(
 
         expectResponseWithWipedDate(
           """HTTP/1.1 507 Insufficient Storage
-          |Server: akka-http/test
+          |Server: pekko-http/test
           |Date: XXXX
           |Connection: close
           |Content-Length: 0
@@ -1385,7 +1385,7 @@ class HttpServerSpec extends AkkaSpec(
 
                 expectResponseWithWipedDate(
                   s"""HTTP/1.1 413 Payload Too Large
-                      |Server: akka-http/test
+                      |Server: pekko-http/test
                       |Date: XXXX
                       |Connection: close
                       |Content-Type: text/plain; charset=UTF-8
@@ -1409,7 +1409,7 @@ class HttpServerSpec extends AkkaSpec(
 
                 expectResponseWithWipedDate(
                   s"""HTTP/1.1 413 Payload Too Large
-                    |Server: akka-http/test
+                    |Server: pekko-http/test
                     |Date: XXXX
                     |Connection: close
                     |Content-Type: text/plain; charset=UTF-8
@@ -1541,7 +1541,7 @@ class HttpServerSpec extends AkkaSpec(
 
       expectResponseWithWipedDate(
         """|HTTP/1.1 400 Bad Request
-           |Server: akka-http/test
+           |Server: pekko-http/test
            |Date: XXXX
            |Connection: close
            |Content-Type: text/plain; charset=UTF-8
@@ -1563,7 +1563,7 @@ class HttpServerSpec extends AkkaSpec(
 
       expectResponseWithWipedDate(
         """|HTTP/1.1 400 Bad Request
-           |Server: akka-http/test
+           |Server: pekko-http/test
            |Date: XXXX
            |Connection: close
            |Content-Type: text/plain; charset=UTF-8
@@ -1586,7 +1586,7 @@ class HttpServerSpec extends AkkaSpec(
 
         expectResponseWithWipedDate(
           """|HTTP/1.1 400 Bad Request
-           |Server: akka-http/test
+           |Server: pekko-http/test
            |Date: XXXX
            |Connection: close
            |Content-Type: text/plain; charset=UTF-8
@@ -1611,7 +1611,7 @@ class HttpServerSpec extends AkkaSpec(
 
       expectResponseWithWipedDate(
         """|HTTP/1.1 418 I'm a teapot
-           |Server: akka-http/test
+           |Server: pekko-http/test
            |Date: XXXX
            |Connection: close
            |Content-Type: text/plain; charset=UTF-8

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -28,7 +28,7 @@ abstract class HttpServerTestSetupBase {
   val responses = TestPublisher.probe[HttpResponse]()
 
   def settings = ServerSettings(system)
-    .withServerHeader(Some(Server(List(ProductVersion("akka-http", "test")))))
+    .withServerHeader(Some(Server(List(ProductVersion("pekko-http", "test")))))
 
   // hook to modify server, for example add attributes
   def modifyServer(server: Http.ServerLayer): Http.ServerLayer = server
@@ -79,7 +79,7 @@ abstract class HttpServerTestSetupBase {
     responses.sendNext(HttpResponse())
     expectResponseWithWipedDate(
       """HTTP/1.1 200 OK
-        |Server: akka-http/test
+        |Server: pekko-http/test
         |Date: XXXX
         |Content-Length: 0
         |

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerWithExplicitSchedulerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerWithExplicitSchedulerSpec.scala
@@ -31,7 +31,7 @@ class HttpServerWithExplicitSchedulerSpec extends AkkaSpecWithMaterializer(
         scheduler.timePasses(20.millis)
         expectResponseWithWipedDate(
           """HTTP/1.1 503 Service Unavailable
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Date: XXXX
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 105
@@ -57,7 +57,7 @@ class HttpServerWithExplicitSchedulerSpec extends AkkaSpecWithMaterializer(
         responses.sendNext(HttpResponse(headers = Connection("close") :: Nil))
         expectResponseWithWipedDate(
           """HTTP/1.1 200 OK
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Date: XXXX
             |Connection: close
             |Content-Length: 0
@@ -86,7 +86,7 @@ class HttpServerWithExplicitSchedulerSpec extends AkkaSpecWithMaterializer(
         scheduler.timePasses(100.millis)
         expectResponseWithWipedDate(
           """HTTP/1.1 503 Service Unavailable
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Date: XXXX
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 105
@@ -115,7 +115,7 @@ class HttpServerWithExplicitSchedulerSpec extends AkkaSpecWithMaterializer(
         scheduler.timePasses(10.millis)
         expectResponseWithWipedDate(
           """HTTP/1.1 503 Service Unavailable
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Date: XXXX
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 105
@@ -143,7 +143,7 @@ class HttpServerWithExplicitSchedulerSpec extends AkkaSpecWithMaterializer(
         scheduler.timePasses(500.millis)
         expectResponseWithWipedDate(
           """HTTP/1.1 500 Internal Server Error
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Date: XXXX
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 5

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WSClientAutobahnTest.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WSClientAutobahnTest.scala
@@ -22,7 +22,7 @@ object WSClientAutobahnTest extends App {
   import system.dispatcher
   implicit val materializer = ActorMaterializer()
 
-  val Agent = "akka-http"
+  val Agent = "pekko-http"
   val Parallelism = 4
 
   val getCaseCountUri: Uri =

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketClientSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketClientSpec.scala
@@ -33,7 +33,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
       sendWireData("""HTTP/1.1 101 Switching Protocols
                      |Upgrade: wEbSOckET
                      |Sec-WebSocket-Accept: ujmZX4KXZqjwy6vi1aQFH5p4Ygk=
-                     |Server: akka-http/test
+                     |Server: pekko-http/test
                      |Sec-WebSocket-Version: 13
                      |Connection: upgrade
                      |
@@ -49,7 +49,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
       sendWireData("""Switching Protocols
                      |Upgrade: websocket
                      |Sec-WebSocket-Accept: ujmZX4KXZqjwy6vi1aQFH5p4Ygk=
-                     |Server: akka-http/test
+                     |Server: pekko-http/test
                      |Sec-WebSocket-Version: 13
                      |Connection: upgrade
                      |
@@ -65,7 +65,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
 
         sendWireData(
           """HTTP/1.1 404 Not Found
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Content-Length: 0
             |
             |""")
@@ -81,7 +81,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
           """HTTP/1.1 101 Switching Protocols
             |Upgrade: websocket
             |Sec-WebSocket-Version: 13
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Connection: upgrade
             |
             |""")
@@ -98,7 +98,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
             |Upgrade: websocket
             |Sec-WebSocket-Accept: s3pPLMBiTxhZRbK+xOo=
             |Sec-WebSocket-Version: 13
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Connection: upgrade
             |
             |""")
@@ -114,7 +114,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
           """HTTP/1.1 101 Switching Protocols
             |Sec-WebSocket-Accept: ujmZX4KXZqjwy6vi1aQFH5p4Ygk=
             |Sec-WebSocket-Version: 13
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Connection: upgrade
             |
             |""")
@@ -131,7 +131,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
             |Upgrade: websocket
             |Sec-WebSocket-Accept: ujmZX4KXZqjwy6vi1aQFH5p4Ygk=
             |Sec-WebSocket-Version: 13
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |
             |""")
 
@@ -205,7 +205,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
           |Sec-WebSocket-Version: 13
           |Sec-WebSocket-Protocol: v2
           |Host: example.org
-          |User-Agent: akka-http/test
+          |User-Agent: pekko-http/test
           |
           |""")
         sendWireData(
@@ -213,7 +213,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
             |Upgrade: websocket
             |Sec-WebSocket-Accept: ujmZX4KXZqjwy6vi1aQFH5p4Ygk=
             |Sec-WebSocket-Version: 13
-            |Server: akka-http/test
+            |Server: pekko-http/test
             |Connection: upgrade
             |Sec-WebSocket-Protocol: v2
             |
@@ -234,7 +234,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
               |Sec-WebSocket-Version: 13
               |Sec-WebSocket-Protocol: v2, v3
               |Host: example.org
-              |User-Agent: akka-http/test
+              |User-Agent: pekko-http/test
               |
               |""")
           sendWireData(
@@ -242,7 +242,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
               |Upgrade: websocket
               |Sec-WebSocket-Accept: ujmZX4KXZqjwy6vi1aQFH5p4Ygk=
               |Sec-WebSocket-Version: 13
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Connection: upgrade
               |Sec-WebSocket-Protocol: v3
               |
@@ -264,7 +264,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
               |Sec-WebSocket-Version: 13
               |Sec-WebSocket-Protocol: v2
               |Host: example.org
-              |User-Agent: akka-http/test
+              |User-Agent: pekko-http/test
               |
               |""")
           sendWireData(
@@ -272,7 +272,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
               |Upgrade: websocket
               |Sec-WebSocket-Accept: ujmZX4KXZqjwy6vi1aQFH5p4Ygk=
               |Sec-WebSocket-Version: 13
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Connection: upgrade
               |
               |""")
@@ -292,7 +292,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
               |Sec-WebSocket-Version: 13
               |Sec-WebSocket-Protocol: v2
               |Host: example.org
-              |User-Agent: akka-http/test
+              |User-Agent: pekko-http/test
               |
               |""")
           sendWireData(
@@ -301,7 +301,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
               |Sec-WebSocket-Accept: ujmZX4KXZqjwy6vi1aQFH5p4Ygk=
               |Sec-WebSocket-Protocol: v3
               |Sec-WebSocket-Version: 13
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Connection: upgrade
               |
               |""")
@@ -321,7 +321,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
       |Sec-WebSocket-Key: YLQguzhR2dR6y5M9vnA5mw==
       |Sec-WebSocket-Version: 13
       |Host: example.org
-      |User-Agent: akka-http/test
+      |User-Agent: pekko-http/test
       |
       |""".stripMarginWithNewline("\r\n")
   }
@@ -330,7 +330,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
     """HTTP/1.1 101 Switching Protocols
       |Upgrade: websocket
       |Sec-WebSocket-Accept: ujmZX4KXZqjwy6vi1aQFH5p4Ygk=
-      |Server: akka-http/test
+      |Server: pekko-http/test
       |Sec-WebSocket-Version: 13
       |Connection: upgrade
       |
@@ -349,7 +349,7 @@ class WebSocketClientSpec extends AkkaSpecWithMaterializer("akka.http.client.web
 
     val random = new Random(0)
     def settings = ClientConnectionSettings(system)
-      .withUserAgentHeader(Some(`User-Agent`(List(ProductVersion("akka-http", "test")))))
+      .withUserAgentHeader(Some(`User-Agent`(List(ProductVersion("pekko-http", "test")))))
       .withWebsocketRandomFactory(() => random)
 
     def targetUri: Uri = "ws://example.org/ws"

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketServerSpec.scala
@@ -46,7 +46,7 @@ class WebSocketServerSpec extends AkkaSpecWithMaterializer("akka.http.server.web
             """HTTP/1.1 101 Switching Protocols
               |Upgrade: websocket
               |Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |Connection: upgrade
               |
@@ -89,7 +89,7 @@ class WebSocketServerSpec extends AkkaSpecWithMaterializer("akka.http.server.web
             """HTTP/1.1 101 Switching Protocols
               |Upgrade: websocket
               |Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |Connection: upgrade
               |
@@ -149,7 +149,7 @@ class WebSocketServerSpec extends AkkaSpecWithMaterializer("akka.http.server.web
             """HTTP/1.1 101 Switching Protocols
               |Upgrade: websocket
               |Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
-              |Server: akka-http/test
+              |Server: pekko-http/test
               |Date: XXXX
               |Connection: upgrade
               |


### PR DESCRIPTION
Currently the `User-Agent` and server headers are set to `akka-http`, this PR changes it to `pekko-http`.