### PR TITLE
run nightly test matrix against pekko versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,11 +14,7 @@ jobs:
       matrix:
         SCALA_VERSION: [2.12, 2.13]
         JABBA_JDK: [8, 11, 17]
-        AKKA_VERSION: [master, default, 2.6.18]
-        exclude:
-          # 2.5 is not compatible with JDK 17
-          - JABBA_JDK: 17
-            AKKA_VERSION: default
+        PEKKO_VERSION: [default]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -42,14 +38,14 @@ jobs:
           key: build-target-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/**/*.scala') }}
 
       - name: Compile everything
-        run: sbt -Dakka.http.build.akka.version=${{ matrix.AKKA_VERSION }} ++${{ matrix.SCALA_VERSION }} Test/compile
+        run: sbt -Dakka.http.build.akka.version=${{ matrix.PEKKO_VERSION }} ++${{ matrix.SCALA_VERSION }} Test/compile
 
-      - name: Run all tests JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}, Akka ${{ matrix.AKKA_VERSION }}
-        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 -Dakka.http.build.akka.version=${{ matrix.AKKA_VERSION }} ++${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues test
+      - name: Run all tests JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}, Akka ${{ matrix.PEKKO_VERSION }}
+        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 -Dakka.http.build.akka.version=${{ matrix.PEKKO_VERSION }} ++${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues test
 
       - name: Upload test results
         uses: actions/upload-artifact@v2  # upload test results
         if: success() || failure()        # run this step even if previous step failed
         with:
-          name: test-results-${{ matrix.JABBA_JDK }}-${{ matrix.SCALA_VERSION }}-${{ matrix.AKKA_VERSION }}
+          name: test-results-${{ matrix.JABBA_JDK }}-${{ matrix.SCALA_VERSION }}-${{ matrix.PEKKO_VERSION }}
           path: '**/target/test-reports/*.xml'

--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,7 @@ lazy val httpCore = project("http-core")
     "pekko-stream-testkit",
     "test",
     pekko =
-      if (System.getProperty("pekko.http.test-against-pekko-main", "false") == "true") PekkoDependency.masterSnapshot
+      if (System.getProperty("pekko.http.test-against-pekko-main", "false") == "true") PekkoDependency.mainSnapshot
       else PekkoDependency.default)
   .settings(Dependencies.httpCore)
   .settings(VersionGenerator.versionSettings)

--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -30,7 +30,7 @@ object PekkoDependency {
         Sources(pekkoSources)
       case None =>
         Option(System.getProperty("pekko.http.build.pekko.version")) match {
-          case Some("master")      => masterSnapshot
+          case Some("main")        => mainSnapshot
           case Some("release-1.0") =>
             // Don't 'downgrade' building even if pekko.sources asks for it
             // (typically for the docs that require 2.6)
@@ -40,7 +40,7 @@ object PekkoDependency {
           case Some(other)     => Artifact(other, true)
           case None            =>
             // TODO: Revert to Artifact(defaultVersion) when release of Pekko is made
-            Artifact(determineLatestSnapshot("0.0.0"), true)
+            mainSnapshot
         }
     }
   }
@@ -51,7 +51,7 @@ object PekkoDependency {
   val minimumExpectedPekko26Version = "1.0.0"
   val docs = pekkoDependency(defaultVersion = minimumExpectedPekko26Version)
 
-  lazy val masterSnapshot = Artifact(determineLatestSnapshot(), true)
+  lazy val mainSnapshot = Artifact(determineLatestSnapshot("0.0.0"), true)
 
   val pekkoVersion: String = default match {
     case Artifact(version, _) => version


### PR DESCRIPTION
which for now is only the main branch snapshot