### PR TITLE
disable publishing of http2-support module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,6 @@ def gustavDir(kind: String) = Def.task {
 lazy val http2Support = project("http2-support")
   .settings(commonSettings)
   .settings(AutomaticModuleName.settings("pekko.http.http2"))
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .dependsOn(httpCore, httpTestkit % "test", httpCore % "test->test")
   .addPekkoModuleDependency("pekko-stream", "provided")
   .addPekkoModuleDependency("pekko-stream-testkit", "test")
@@ -208,8 +207,7 @@ lazy val http2Support = project("http2-support")
         Seq(h2spec)
       })
   }
-  .enablePlugins(BootstrapGenjavadoc)
-  .enablePlugins(ReproducibleBuildsPlugin)
+  .enablePlugins(NoPublish) // only contains tests these days
   .disablePlugins(MimaPlugin) // experimental module still
 
 lazy val httpTestkit = project("http-testkit")


### PR DESCRIPTION
This used to carry the http2 implementation but we moved the implementation to http-core a long time ago. We continued publishing to avoid people missing the module but it doesn't seem to make sense to keep publishing for pekko-http.