### PR TITLE
Change akka typesafe conf to pekko

### DIFF
--- a/docs/src/main/paradox/client-side/client-transport.md
+++ b/docs/src/main/paradox/client-side/client-transport.md
@@ -48,7 +48,7 @@ The proxy transport can also be setup using `ClientTransport.httpsProxy()` or `C
 In order to define the transport as such, you will need to set the proxy host / port in your `conf` file like the following.
 
 ```
-akka.http.client.proxy {
+pekko.http.client.proxy {
  https {
    host = ""
    port = 443

--- a/docs/src/main/paradox/client-side/configuration.md
+++ b/docs/src/main/paradox/client-side/configuration.md
@@ -2,8 +2,8 @@
 
 HTTP client settings are split into different sections  
  
- * `akka.http.client`: basic client settings
- * `akka.http.host-connection-pool`: pool settings
+ * `pekko.http.client`: basic client settings
+ * `pekko.http.host-connection-pool`: pool settings
  
 ## Basic Client Settings
 
@@ -13,7 +13,7 @@ These settings influence the basic library behavior for each HTTP connection. Wh
 Basic client settings can be overridden in multiple ways:
 
  * by passing custom @apidoc[ClientConnectionSettings] instances to APIs in @apidoc[Http$]
- * by overriding settings in `akka.http.host-connection-pool.client`, these overrides will take effect whenever a pool is used
+ * by overriding settings in `pekko.http.host-connection-pool.client`, these overrides will take effect whenever a pool is used
    like with `Http().singleRequest`
  * by putting custom @apidoc[ClientConnectionSettings] into @apidoc[ConnectionPoolSettings] and passing those to APIs in `Http`
  * by using [per-host overrides](#per-host-overrides)
@@ -36,7 +36,7 @@ Pool settings can be overridden on a [per-target-host](#per-host-overrides) basi
 ## Per Host Overrides
 
 Settings can be overridden on a per-host basis by creating a list of `host-patterns` together with overridden settings
-in the `akka.http.host-connection-pool.per-host-override` setting.
+in the `pekko.http.host-connection-pool.per-host-override` setting.
 
 Note that only the first matching entry is selected and used even if multiple entries would match.
 
@@ -47,5 +47,5 @@ Note that only the first matching entry is selected and used even if multiple en
 When using pool APIs, settings take precedence like this (highest precedence first):
 
  * client settings in first `per-host-override` entry whose `host-pattern` matches the given target host
- * settings in `akka.http.host-connection-pool.client`
- * settings in `akka.http.client`
+ * settings in `pekko.http.host-connection-pool.client`
+ * settings in `pekko.http.client`

--- a/docs/src/main/paradox/client-side/host-level.md
+++ b/docs/src/main/paradox/client-side/host-level.md
@@ -31,7 +31,7 @@ first connection to the target endpoint until the first request has arrived.
 
 Apart from the connection-level config settings and socket options there are a number of settings that allow you to
 influence the behavior of the connection pool logic itself.
-Check out the `akka.http.host-connection-pool` section of the Apache Pekko HTTP @ref[Configuration](../configuration.md) for
+Check out the `pekko.http.host-connection-pool` section of the Apache Pekko HTTP @ref[Configuration](../configuration.md) for
 more information about which settings are available and what they mean.
 
 Note that, if you request pools with different configurations for the same target host you will get *independent* pools.
@@ -123,7 +123,7 @@ In these cases, as well as when all retries have not yielded a proper response, 
 
 If a request fails during connecting to the server, for example, because the DNS name cannot be resolved or the server
 is currently unavailable, retries are attempted with exponential backoff delay. See the documentation of the
-`akka.http.host-connection-pool.base-connection-backoff` setting in the @ref[configuration](../configuration.md).
+`pekko.http.host-connection-pool.base-connection-backoff` setting in the @ref[configuration](../configuration.md).
 
 
 ## Pool Shutdown

--- a/docs/src/main/paradox/client-side/pool-overflow.md
+++ b/docs/src/main/paradox/client-side/pool-overflow.md
@@ -2,7 +2,7 @@
 
 @ref[Request-Level Client-Side API](request-level.md) and @ref[Host-Level Client-Side API](host-level.md)
 use a connection pool underneath. The connection pool will open a limited number of concurrent connections to one host
-(see the `akka.http.host-connection-pool.max-connections` setting). This will limit the rate of requests a pool
+(see the `pekko.http.host-connection-pool.max-connections` setting). This will limit the rate of requests a pool
 to a single host can handle.
 
 When you use the @ref[stream-based host-level API](host-level.md#using-the-host-level-api-in-a-streaming-fashion)

--- a/docs/src/main/paradox/client-side/request-level.md
+++ b/docs/src/main/paradox/client-side/request-level.md
@@ -59,7 +59,7 @@ if you don't care about the response entity.
 Read the @ref[Implications of the streaming nature of Request/Response Entities](../implications-of-streaming-http-entity.md) section for more details.
 
 If the application doesn't subscribe to the response entity within 
-`akka.http.host-connection-pool.response-entity-subscription-timeout`, the stream will fail with a 
+`pekko.http.host-connection-pool.response-entity-subscription-timeout`, the stream will fail with a 
 `TimeoutException: Response entity was not subscribed after ...`.
 @@@
 

--- a/docs/src/main/paradox/client-side/websocket-support.md
+++ b/docs/src/main/paradox/client-side/websocket-support.md
@@ -139,7 +139,7 @@ Similar to the @ref[server-side kee-alive Ping support](../server-side/websocket
 it is possible to configure the client-side to perform automatic keep-alive using Ping (or Pong) frames.
 
 This is supported in a transparent way via configuration by setting the: 
-`akka.http.client.websocket.periodic-keep-alive-max-idle = 1 second` to a specified max idle timeout. The keep-alive triggers
+`pekko.http.client.websocket.periodic-keep-alive-max-idle = 1 second` to a specified max idle timeout. The keep-alive triggers
 when no other messages are in-flight during the such configured period. Apache Pekko HTTP will then automatically send
 a [`Ping` frame](https://tools.ietf.org/html/rfc6455#section-5.5.2) for each of such idle intervals.
 
@@ -164,4 +164,4 @@ A Ping response will always be replied to by the client-side with an appropriate
 It is also possible to configure the keep-alive mechanism to send `Pong` frames instead of `Ping` frames, 
 which enables an [uni-directional heartbeat](https://tools.ietf.org/html/rfc6455#section-5.5.3) mechanism (in which case 
 the client side will *not* reply to such heartbeat). You can configure this mode by setting: 
-`akka.http.client.websocket.periodic-keep-alive-mode = pong`.
+`pekko.http.client.websocket.periodic-keep-alive-mode = pong`.

--- a/docs/src/main/paradox/common/caching.md
+++ b/docs/src/main/paradox/common/caching.md
@@ -73,7 +73,7 @@ for longer than expected.
 @@@
 
 For simple cases, configure the capacity and expiration settings in your
-`application.conf` file via the settings under `akka.http.caching` and use
+`application.conf` file via the settings under `pekko.http.caching` and use
 @java[`LfuCache.create()`]@scala[`LfuCache.apply()`] to create the cache.
 For more advanced usage you can create an @apidoc[LfuCache$] with settings
 specialized for your use case:

--- a/docs/src/main/paradox/common/http-model.md
+++ b/docs/src/main/paradox/common/http-model.md
@@ -246,10 +246,10 @@ content-length. If the entity is transformed in a way that changes the content-l
 then the previous limit will be applied against the previous content-length.
 Generally this behavior should be in line with your expectations.
 
-> <a id="1" href="#^1">[1]</a> *akka.http.parsing.max-content-length* (applying to server- as well as client-side),
-*akka.http.server.parsing.max-content-length* (server-side only),
-*akka.http.client.parsing.max-content-length* (client-side only) or
-*akka.http.host-connection-pool.client.parsing.max-content-length* (only host-connection-pools)
+> <a id="1" href="#^1">[1]</a> *pekko.http.parsing.max-content-length* (applying to server- as well as client-side),
+*pekko.http.server.parsing.max-content-length* (server-side only),
+*pekko.http.client.parsing.max-content-length* (client-side only) or
+*pekko.http.host-connection-pool.client.parsing.max-content-length* (only host-connection-pools)
 
 ### Special processing for HEAD requests
 
@@ -318,12 +318,12 @@ response will not be rendered onto the wire and trigger a warning being logged i
 
 Server
 : A `Server` header is usually added automatically to any response and its value can be configured via the
-`akka.http.server.server-header` setting. Additionally an application can override the configured header with a
+`pekko.http.server.server-header` setting. Additionally an application can override the configured header with a
 custom one by adding it to the response's `header` sequence.
 
 User-Agent
 : A `User-Agent` header is usually added automatically to any request and its value can be configured via the
-`akka.http.client.user-agent-header` setting. Additionally an application can override the configured header with a
+`pekko.http.client.user-agent-header` setting. Additionally an application can override the configured header with a
 custom one by adding it to the request's `header` sequence.
 
 Date
@@ -408,16 +408,16 @@ Parsing and rendering of HTTP data structures is heavily optimized and for most 
 provided to parse (or render to) Strings or byte arrays.
 
 @@@ note
-Various parsing and rendering settings are available to tweak in the configuration under `akka.http.client[.parsing]`,
-`akka.http.server[.parsing]` and `akka.http.host-connection-pool[.client.parsing]`, with defaults for all of these
-being defined in the `akka.http.parsing` configuration section.
+Various parsing and rendering settings are available to tweak in the configuration under `pekko.http.client[.parsing]`,
+`pekko.http.server[.parsing]` and `pekko.http.host-connection-pool[.client.parsing]`, with defaults for all of these
+being defined in the `pekko.http.parsing` configuration section.
 
-For example, if you want to change a parsing setting for all components, you can set the `akka.http.parsing.illegal-header-warnings = off`
-value. However this setting can be still overridden by the more specific sections, like for example `akka.http.server.parsing.illegal-header-warnings = on`.
+For example, if you want to change a parsing setting for all components, you can set the `pekko.http.parsing.illegal-header-warnings = off`
+value. However this setting can be still overridden by the more specific sections, like for example `pekko.http.server.parsing.illegal-header-warnings = on`.
 
 In this case both `client` and `host-connection-pool` APIs will see the setting `off`, however the server will see `on`.
 
-In the case of `akka.http.host-connection-pool.client` settings, they default to settings set in `akka.http.client`,
+In the case of `pekko.http.host-connection-pool.client` settings, they default to settings set in `pekko.http.client`,
 and can override them if needed. This is useful, since both `client` and `host-connection-pool` APIs,
 such as the Client API @scala[`Http().outgoingConnection`]@java[`Http.get(sys).outgoingConnection`] or the Host Connection Pool APIs @scala[`Http().singleRequest`]@java[`Http.get(sys).singleRequest`]
 or @scala[`Http().superPool`]@java[`Http.get(sys).superPool`], usually need the same settings, however the `server` most likely has a very different set of settings.

--- a/docs/src/main/paradox/common/timeouts.md
+++ b/docs/src/main/paradox/common/timeouts.md
@@ -18,9 +18,9 @@ an indefinite time.
 The setting works the same way for server and client connections and it is configurable independently using the following keys:
 
 ```
-akka.http.server.idle-timeout
-akka.http.client.idle-timeout
-akka.http.host-connection-pool.client.idle-timeout
+pekko.http.server.idle-timeout
+pekko.http.client.idle-timeout
+pekko.http.host-connection-pool.client.idle-timeout
 ```
 
 ## Server timeouts
@@ -38,14 +38,14 @@ The default @apidoc[HttpResponse] that is written when a request timeout is exce
 @@snip [HttpServerBluePrint.scala](/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala) { #default-request-timeout-httpresponse }
 
 A default request timeout is applied globally to all routes and can be configured using the
-`akka.http.server.request-timeout` setting (which defaults to 20 seconds).
+`pekko.http.server.request-timeout` setting (which defaults to 20 seconds).
 
 The request timeout can be configured at run-time for a given route using the any of the @ref[TimeoutDirectives](../routing-dsl/directives/timeout-directives/index.md).
 
 ### Bind timeout
 
 The bind timeout is the time period within which the TCP binding process must be completed (using any of the `Http().bind*` methods).
-It can be configured using the `akka.http.server.bind-timeout` setting.
+It can be configured using the `pekko.http.server.bind-timeout` setting.
 
 ### Linger timeout
 
@@ -69,14 +69,14 @@ The connecting timeout is the time period within which the TCP connecting proces
 Tweaking it should rarely be required, but it allows erroring out the connection in case a connection
 is unable to be established for a given amount of time.
 
-It can be configured using the `akka.http.client.connecting-timeout` setting.
+It can be configured using the `pekko.http.client.connecting-timeout` setting.
 
 ## Client pool timeouts
 
 ### Keep-alive timeout
 
 HTTP connections are commonly used for multiple requests, that is, they are kept alive between requests. The
-`akka.http.host-connection-pool.keep-alive-timeout` setting configures how long a pool keeps a connection alive between
+`pekko.http.host-connection-pool.keep-alive-timeout` setting configures how long a pool keeps a connection alive between
 requests before it closes the connection (and eventually reestablishes it).
 
 A common scenario where this setting is useful is to prevent a race-condition inherent in HTTP: in most cases, a server
@@ -97,11 +97,11 @@ Set to `infinite` to allow the connection to remain open indefinitely (or be clo
 This timeout configures a maximum amount of time, while the connection can be kept open. This is useful, when you reach
 the server through a load balancer and client reconnecting helps the process of rebalancing between service instances.
 
-It can be configured using the `akka.http.host-connection-pool.max-connection-lifetime` setting.
+It can be configured using the `pekko.http.host-connection-pool.max-connection-lifetime` setting.
 
 ### Pool Idle timeout
 
-A connection pool to a target host will be shut down after the timeout given as `akka.http.host-connection-pool.idle-timeout`. This frees
+A connection pool to a target host will be shut down after the timeout given as `pekko.http.host-connection-pool.idle-timeout`. This frees
 resources like open but idle pool connections and management structures.
 
 If the application connects to only a limited set of target hosts over its lifetime and resource usage for the pool is of no concern, the

--- a/docs/src/main/paradox/common/uri-model.md
+++ b/docs/src/main/paradox/common/uri-model.md
@@ -80,7 +80,7 @@ To extract URI components with directives, see following references:
 
 Sometimes it may be needed to obtain the "raw" value of an incoming URI, without applying any escaping or parsing to it.
 While this use case is rare, it comes up every once in a while. It is possible to obtain the "raw" request URI in Apache Pekko
-HTTP Server side by turning on the `akka.http.server.raw-request-uri-header` flag.
+HTTP Server side by turning on the `pekko.http.server.raw-request-uri-header` flag.
 When enabled, a `Raw-Request-URI` header will be added to each request. This header will hold the original raw request's
 URI that was used. For an example check the reference configuration.
 

--- a/docs/src/main/paradox/handling-blocking-operations-in-pekko-http-routes.md
+++ b/docs/src/main/paradox/handling-blocking-operations-in-pekko-http-routes.md
@@ -46,7 +46,7 @@ Java
 :   @@snip [BlockingInHttpExamples.java](/docs/src/test/java/docs/http/javadsl/server/BlockingInHttpExamples.java) { #blocking-example-in-default-dispatcher }
 
 Here the app is exposed to a load of continuous GET requests and large numbers
-of akka.actor.default-dispatcher threads are handling requests. The orange
+of pekko.actor.default-dispatcher threads are handling requests. The orange
 portion of the thread shows that it is idle. Idle threads are fine -
 they're ready to accept new work. However, large amounts of Turquoise (sleeping) threads are very bad!
 

--- a/docs/src/main/paradox/implications-of-streaming-http-entity.md
+++ b/docs/src/main/paradox/implications-of-streaming-http-entity.md
@@ -14,7 +14,7 @@ entities (and pulling them through the network) in a streaming fashion, and only
 ready to consume the bytes. Therefore, you have to explicitly consume or discard the entity. 
 
 On a client, for example, if the application doesn't subscribe to the response entity within 
-`akka.http.host-connection-pool.response-entity-subscription-timeout`, the stream will fail with a 
+`pekko.http.host-connection-pool.response-entity-subscription-timeout`, the stream will fail with a 
 `TimeoutException: Response entity was not subscribed after ...`.
 
 @@@ warning

--- a/docs/src/main/paradox/routing-dsl/directives/basic-directives/extractStrictEntity.md
+++ b/docs/src/main/paradox/routing-dsl/directives/basic-directives/extractStrictEntity.md
@@ -17,7 +17,7 @@ A timeout parameter is given and if the stream isn't completed after the timeout
 @@@ warning
 
 The directive will read the request entity into memory within the size limit(8M by default) and effectively disable streaming.
-The size limit can be configured globally with `akka.http.parsing.max-content-length` or
+The size limit can be configured globally with `pekko.http.parsing.max-content-length` or
 overridden by wrapping with @ref[withSizeLimit](../misc-directives/withSizeLimit.md) or @ref[withoutSizeLimit](../misc-directives/withoutSizeLimit.md) directive.
 
 @@@

--- a/docs/src/main/paradox/routing-dsl/directives/basic-directives/toStrictEntity.md
+++ b/docs/src/main/paradox/routing-dsl/directives/basic-directives/toStrictEntity.md
@@ -17,7 +17,7 @@ A timeout parameter is given and if the stream isn't completed after the timeout
 @@@ warning
 
 The directive will read the request entity into memory within the size limit(8M by default) and effectively disable streaming.
-The size limit can be configured globally with `akka.http.parsing.max-content-length` or
+The size limit can be configured globally with `pekko.http.parsing.max-content-length` or
 overridden by wrapping with @ref[withSizeLimit](../misc-directives/withSizeLimit.md) or @ref[withoutSizeLimit](../misc-directives/withoutSizeLimit.md) directive.
 
 @@@

--- a/docs/src/main/paradox/routing-dsl/directives/cache-condition-directives/conditional.md
+++ b/docs/src/main/paradox/routing-dsl/directives/cache-condition-directives/conditional.md
@@ -28,4 +28,4 @@ it is usually used quite deep down in the route structure (i.e. close to the lea
 targeted by the request has already been established and the respective ETag/Last-Modified values can be determined.
 
 The @ref[FileAndResourceDirectives](../file-and-resource-directives/index.md) internally use the `conditional` directive for ETag and Last-Modified support
-(if the `akka.http.routing.file-get-conditional` setting is enabled).
+(if the `pekko.http.routing.file-get-conditional` setting is enabled).

--- a/docs/src/main/paradox/routing-dsl/directives/coding-directives/decodeRequest.md
+++ b/docs/src/main/paradox/routing-dsl/directives/coding-directives/decodeRequest.md
@@ -12,7 +12,7 @@
 
 Decompresses the incoming request if it is `gzip` or `deflate` compressed. Uncompressed requests are passed through untouched.
 If the request encoded with another encoding the request is rejected with an @apidoc[UnsupportedRequestEncodingRejection].
-If the request entity after decoding exceeds `akka.http.routing.decode-max-size` the stream fails with an
+If the request entity after decoding exceeds `pekko.http.routing.decode-max-size` the stream fails with an
 @scala[@scaladoc[EntityStreamSizeException](org.apache.pekko.http.scaladsl.model.EntityStreamSizeException)]@java[@javadoc[EntityStreamSizeException](org.apache.pekko.http.scaladsl.model.EntityStreamSizeException)].
 
 

--- a/docs/src/main/paradox/routing-dsl/directives/coding-directives/decodeRequestWith.md
+++ b/docs/src/main/paradox/routing-dsl/directives/coding-directives/decodeRequestWith.md
@@ -12,7 +12,7 @@
 
 Decodes the incoming request if it is encoded with one of the given encoders.
 If the request encoding doesn't match one of the given encoders the request is rejected with an @apidoc[UnsupportedRequestEncodingRejection]. If no decoders are given the default encoders (`Gzip`, `Deflate`, `NoCoding`) are used.
-If the request entity after decoding exceeds `akka.http.routing.decode-max-size` the stream fails with an
+If the request entity after decoding exceeds `pekko.http.routing.decode-max-size` the stream fails with an
 @scala[@scaladoc[EntityStreamSizeException](org.apache.pekko.http.scaladsl.model.EntityStreamSizeException)]@java[@javadoc[EntityStreamSizeException](org.apache.pekko.http.scaladsl.model.EntityStreamSizeException)].
 
 

--- a/docs/src/main/paradox/routing-dsl/directives/file-and-resource-directives/getFromBrowseableDirectory.md
+++ b/docs/src/main/paradox/routing-dsl/directives/file-and-resource-directives/getFromBrowseableDirectory.md
@@ -42,4 +42,4 @@ and renders a listing which looks like this:
 Example page rendered by the `defaultDirectoryRenderer`.
 
 It's possible to turn off rendering the footer stating which version of Apache Pekko HTTP is rendering this page by configuring
-the `akka.http.routing.render-vanity-footer` configuration option to `off`.
+the `pekko.http.routing.render-vanity-footer` configuration option to `off`.

--- a/docs/src/main/paradox/routing-dsl/directives/method-directives/head.md
+++ b/docs/src/main/paradox/routing-dsl/directives/method-directives/head.md
@@ -19,7 +19,7 @@ by the default @ref[RejectionHandler](../../rejections.md#the-rejectionhandler).
 
 @@@ note
 Apache Pekko HTTP can handle HEAD requests transparently by dispatching a GET request to the handler and
-stripping off the result body. See the `akka.http.server.transparent-head-requests` setting for how to enable
+stripping off the result body. See the `pekko.http.server.transparent-head-requests` setting for how to enable
 this behavior.
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/misc-directives/extractClientIP.md
+++ b/docs/src/main/paradox/routing-dsl/directives/misc-directives/extractClientIP.md
@@ -11,8 +11,8 @@
 ## Description
 
 Provides the value of the `X-Forwarded-For` or `X-Real-IP` header.
-If neither of those is found it will fall back to the value of the synthetic `RemoteAddress` header (`akka.http.server.remote-address-header` setting is `on`)
-or the value of the @apidoc[AttributeKeys.remoteAddress](AttributeKeys$) @ref[attribute](../../../common/http-model.md#attributes)  (if the `akka.http.server.remote-address-attribute` setting is `on`)
+If neither of those is found it will fall back to the value of the synthetic `RemoteAddress` header (`pekko.http.server.remote-address-header` setting is `on`)
+or the value of the @apidoc[AttributeKeys.remoteAddress](AttributeKeys$) @ref[attribute](../../../common/http-model.md#attributes)  (if the `pekko.http.server.remote-address-attribute` setting is `on`)
 
 If no valid IP address is encountered, this extractor will return RemoteAddress.Unknown`.
 

--- a/docs/src/main/paradox/routing-dsl/directives/misc-directives/withSizeLimit.md
+++ b/docs/src/main/paradox/routing-dsl/directives/misc-directives/withSizeLimit.md
@@ -11,10 +11,10 @@
 ## Description
 
 Fails the stream with `EntityStreamSizeException` if its request entity size exceeds given limit. Limit given
-as parameter overrides limit configured with `akka.http.parsing.max-content-length`.
+as parameter overrides limit configured with `pekko.http.parsing.max-content-length`.
 
 The whole mechanism of entity size checking is intended to prevent certain Denial-of-Service attacks.
-So suggested setup is to have `akka.http.parsing.max-content-length` relatively low and use `withSizeLimit`
+So suggested setup is to have `pekko.http.parsing.max-content-length` relatively low and use `withSizeLimit`
 directive for endpoints which expects bigger entities.
 
 See also @ref[withoutSizeLimit](withoutSizeLimit.md) for skipping request entity size check.

--- a/docs/src/main/paradox/routing-dsl/directives/misc-directives/withoutSizeLimit.md
+++ b/docs/src/main/paradox/routing-dsl/directives/misc-directives/withoutSizeLimit.md
@@ -13,7 +13,7 @@
 Skips request entity size verification.
 
 The whole mechanism of entity size checking is intended to prevent certain Denial-of-Service attacks.
-So suggested setup is to have `akka.http.parsing.max-content-length` relatively low and use `withoutSizeLimit`
+So suggested setup is to have `pekko.http.parsing.max-content-length` relatively low and use `withoutSizeLimit`
 directive just for endpoints for which size verification should not be performed.
 
 @@@ warning { title="Caution" }

--- a/docs/src/main/paradox/routing-dsl/directives/range-directives/withRangeSupport.md
+++ b/docs/src/main/paradox/routing-dsl/directives/range-directives/withRangeSupport.md
@@ -29,7 +29,7 @@ ranges with a @apidoc[TooManyRangesRejection].
 Requests with unsatisfiable ranges are rejected with an @apidoc[UnsatisfiableRangeRejection].
 
 The `withRangeSupport()` form (without parameters) uses the `range-coalescing-threshold` and `range-count-limit`
-settings from the `akka.http.routing` configuration.
+settings from the `pekko.http.routing` configuration.
 
 This directive is transparent to non-`GET` requests.
 

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -12,7 +12,7 @@ This means it is ready to be evaluated, but the APIs and behavior are likely to 
 HTTP/2 can then be enabled through configuration:
 
 ```
-akka.http.server.preview.enable-http2 = on
+pekko.http.server.preview.enable-http2 = on
 ```
 
 ## Use `newServerAt(...).bind()` and HTTPS

--- a/docs/src/main/paradox/server-side/low-level-api.md
+++ b/docs/src/main/paradox/server-side/low-level-api.md
@@ -149,14 +149,14 @@ relying on HTTP pipelining to send several requests on one connection without wa
 cases the client controls the number of ongoing requests. To prevent being overloaded by too many requests, Apache Pekko HTTP
 can limit the number of requests it handles in parallel.
 
-To limit the number of simultaneously open connections, use the `akka.http.server.max-connections` setting. This setting
+To limit the number of simultaneously open connections, use the `pekko.http.server.max-connections` setting. This setting
 applies to all of `Http.bindAndHandle*` methods. If you use `Http.bind`, incoming connections are represented by
 a @apidoc[Source[IncomingConnection, ...]]. Use Apache Pekko Stream's combinators to apply backpressure to control the flow of
 incoming connections, e.g. by using `throttle` or `mapAsync`.
 
 HTTP pipelining is generally discouraged (and [disabled by most browsers](https://en.wikipedia.org/w/index.php?title=HTTP_pipelining&oldid=700966692#Implementation_in_web_browsers)) but
 is nevertheless fully supported in Apache Pekko HTTP. The limit is applied on two levels. First, there's the
-`akka.http.server.pipelining-limit` config setting which prevents that more than the given number of outstanding requests
+`pekko.http.server.pipelining-limit` config setting which prevents that more than the given number of outstanding requests
 is ever given to the user-supplied handler-flow. On the other hand, the handler flow itself can apply any kind of throttling
 itself. If you use the `Http.bindAndHandleAsync`
 entry-point, you can specify the `parallelism` argument (which defaults to `1`, which means that pipelining is disabled) to control the

--- a/docs/src/main/paradox/server-side/websocket-support.md
+++ b/docs/src/main/paradox/server-side/websocket-support.md
@@ -159,7 +159,7 @@ connection remains usable even after no data frames are communicated over a long
 initiated by either side of the connection, and the choice which side performs the heart beating is use-case dependent. 
 
 This is supported in a transparent way via configuration in Apache Pekko HTTP, and you can enable it by setting the: 
-`akka.http.server.websocket.periodic-keep-alive-max-idle = 1 second` to a specified max idle timeout. The keep alive triggers
+`pekko.http.server.websocket.periodic-keep-alive-max-idle = 1 second` to a specified max idle timeout. The keep alive triggers
 when no other messages are in-flight during the such configured period. Apache Pekko HTTP will then automatically send
 a [`Ping` frame](https://tools.ietf.org/html/rfc6455#section-5.5.2) for each of such idle intervals.
 
@@ -184,4 +184,4 @@ A Ping response will always be replied to by the client-side with an appropriate
 It is also possible to configure the keep-alive mechanism to send `Pong` frames instead of `Ping` frames, 
 which enables an [uni-directional heartbeat](https://tools.ietf.org/html/rfc6455#section-5.5.3) mechanism (in which case 
 the client side will *not* reply to such heartbeat). You can configure this mode by setting: 
-`akka.http.server.websocket.periodic-keep-alive-mode = pong`.
+`pekko.http.server.websocket.periodic-keep-alive-mode = pong`.

--- a/docs/src/main/paradox/troubleshooting/unsupported-http-method-pri.md
+++ b/docs/src/main/paradox/troubleshooting/unsupported-http-method-pri.md
@@ -7,6 +7,6 @@ Illegal request, responding with status '501 Not Implemented': Unsupported HTTP 
 This indicates that an HTTP/2 request was received, but the server was not
 correctly set up to handle those. You may have to:
 
-* Make sure the @ref[`akka.http.server.preview.enable-http2` option](../server-side/http2.md#enable-http-2-support) is enabled
+* Make sure the @ref[`pekko.http.server.preview.enable-http2` option](../server-side/http2.md#enable-http-2-support) is enabled
 * Make sure you are running @ref[at least JDK version 8u252](../server-side/http2.md)
 * Make sure you are not using @apidoc[Http().bindAndHandle()](Http$) or @apidoc[Http().newServerAt().bindFlow()](ServerBuilder), but @apidoc[Http().newServerAt().bind()](ServerBuilder).

--- a/docs/src/test/java/docs/http/javadsl/Http2ClientApp.java
+++ b/docs/src/test/java/docs/http/javadsl/Http2ClientApp.java
@@ -36,8 +36,8 @@ public class Http2ClientApp {
     Config config =
         ConfigFactory.parseString(
             "#pekko.loglevel = debug\n" +
-               "akka.http.client.http2.log-frames = true\n" +
-               "akka.http.client.parsing.max-content-length = 20m"
+               "pekko.http.client.http2.log-frames = true\n" +
+               "pekko.http.client.parsing.max-content-length = 20m"
         ).withFallback(ConfigFactory.load());
 
     ActorSystem system = ActorSystem.create("Http2ClientApp", config);

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -131,7 +131,7 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
     };
 
     // tests:
-    // will work even if you have configured akka.http.parsing.max-content-length = 500
+    // will work even if you have configured pekko.http.parsing.max-content-length = 500
     testRoute(route).run(withEntityOfSize.apply(501))
       .assertStatusCode(StatusCodes.OK);
     //#withoutSizeLimitExample

--- a/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
@@ -36,7 +36,7 @@ import static org.apache.pekko.http.javadsl.server.Directives.withRangeSupport;
 public class RangeDirectivesExamplesTest extends JUnitRouteTest {
     @Override
     public Config additionalConfig() {
-        return ConfigFactory.parseString("akka.http.routing.range-coalescing-threshold=2");
+        return ConfigFactory.parseString("pekko.http.routing.range-coalescing-threshold=2");
     }
 
     @Test
@@ -60,7 +60,7 @@ public class RangeDirectivesExamplesTest extends JUnitRouteTest {
                 .assertStatusCode(StatusCodes.PARTIAL_CONTENT)
                 .assertEntity("DE");
 
-        // we set "akka.http.routing.range-coalescing-threshold = 2"
+        // we set "pekko.http.routing.range-coalescing-threshold = 2"
         // above to make sure we get two BodyParts
         final TestRouteResult response = testRoute(route).run(HttpRequest.GET("/")
                 .addHeader(Range.create(RangeUnits.BYTES,

--- a/docs/src/test/scala/docs/http/scaladsl/Http2ClientApp.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2ClientApp.scala
@@ -29,8 +29,8 @@ object Http2ClientApp extends App {
     ConfigFactory.parseString(
       """
          # pekko.loglevel = debug
-         akka.http.client.http2.log-frames = true
-         akka.http.client.parsing.max-content-length = 20m
+         pekko.http.client.http2.log-frames = true
+         pekko.http.client.parsing.max-content-length = 20m
       """).withFallback(ConfigFactory.defaultApplication())
 
   implicit val system = ActorSystem("Http2ClientApp", config)

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
@@ -192,7 +192,7 @@ class MiscDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     def entityOfSize(size: Int) =
       HttpEntity(ContentTypes.`text/plain(UTF-8)`, "0" * size)
 
-    // will work even if you have configured akka.http.parsing.max-content-length = 500
+    // will work even if you have configured pekko.http.parsing.max-content-length = 500
     Post("/abc", entityOfSize(501)) ~> route ~> check {
       status shouldEqual StatusCodes.OK
     }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/RangeDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/RangeDirectivesExamplesSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
 class RangeDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
   override def testConfig: Config =
-    ConfigFactory.parseString("akka.http.routing.range-coalescing-threshold=2").withFallback(super.testConfig)
+    ConfigFactory.parseString("pekko.http.routing.range-coalescing-threshold=2").withFallback(super.testConfig)
 
   "withRangeSupport" in {
     // #withRangeSupport
@@ -32,7 +32,7 @@ class RangeDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
       responseAs[String] shouldEqual "DE"
     }
 
-    // we set "akka.http.routing.range-coalescing-threshold = 2"
+    // we set "pekko.http.routing.range-coalescing-threshold = 2"
     // above to make sure we get two BodyParts
     Get() ~> addHeader(Range(ByteRange(0, 1), ByteRange(1, 2), ByteRange(6, 7))) ~> route ~> check {
       headers.collectFirst { case `Content-Range`(_, _) => true } shouldBe None

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -26,19 +26,19 @@ class TimeoutDirectivesExamplesSpec extends RoutingSpec
 
   implicit val timeout: RouteTestTimeout = RouteTestTimeout(3.seconds)
   override def testConfigSource: String =
-    "akka.http.server.request-timeout = infinite\n" +
+    "pekko.http.server.request-timeout = infinite\n" +
     super.testConfigSource
 
   def slowFuture(): Future[String] = Future.never
   // #testSetup
 
-  // demonstrates that timeout is correctly set despite infinite initial value of akka.http.server.request-timeout
+  // demonstrates that timeout is correctly set despite infinite initial value of pekko.http.server.request-timeout
   "Request Timeout" should {
     "be configurable in routing layer despite infinite initial value of request-timeout" in {
       // #withRequestTimeout-plain
       val route =
         path("timeout") {
-          withRequestTimeout(1.seconds) { // modifies the global akka.http.server.request-timeout for this request
+          withRequestTimeout(1.seconds) { // modifies the global pekko.http.server.request-timeout for this request
             val response: Future[String] = slowFuture() // very slow
             complete(response)
           }
@@ -143,12 +143,12 @@ class TimeoutDirectivesFiniteTimeoutExamplesSpec extends RoutingSpec
     with ScalaFutures with CompileOnlySpec {
   implicit val timeout: RouteTestTimeout = RouteTestTimeout(3.seconds)
   override def testConfigSource: String =
-    "akka.http.server.request-timeout = 1000s\n" +
+    "pekko.http.server.request-timeout = 1000s\n" +
     super.testConfigSource
 
   def slowFuture(): Future[String] = Future.never
 
-  // demonstrates that timeout is correctly modified for finite initial values of akka.http.server.request-timeout
+  // demonstrates that timeout is correctly modified for finite initial values of pekko.http.server.request-timeout
   "Request Timeout" should {
     "be configurable in routing layer for finite initial value of request-timeout" in {
       val route =

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
@@ -62,9 +62,9 @@ class ConnectionPoolBenchmark extends CommonBenchmark {
       ConfigFactory.parseString(
         s"""
            pekko.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
-           akka.http.host-connection-pool.max-connections = ${maxConnections}
-           akka.http.host-connection-pool.max-open-requests = 16384
-           akka.http.client.user-agent = pekko-http-bench
+           pekko.http.host-connection-pool.max-connections = ${maxConnections}
+           pekko.http.host-connection-pool.max-open-requests = 16384
+           pekko.http.client.user-agent = pekko-http-bench
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HeaderParserBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HeaderParserBenchmark.scala
@@ -47,7 +47,7 @@ private[engine] class HeaderParserBenchmark {
 
   private def settings() = {
     val root = ConfigFactory.load()
-    val settings = ParserSettingsImpl.fromSubConfig(root, root.getConfig("akka.http.server.parsing"))
+    val settings = ParserSettingsImpl.fromSubConfig(root, root.getConfig("pekko.http.server.parsing"))
     if (withCustomMediaTypes == "no") settings
     else settings.withCustomMediaTypes(
       MediaType.customWithOpenCharset("application", "json"))

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ServerProcessingBenchmark.scala
@@ -49,7 +49,7 @@ class ServerProcessingBenchmark extends CommonBenchmark {
       ConfigFactory.parseString(
         """
            pekko.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
-           akka.http.server.server-header = "pekko-http-bench"
+           pekko.http.server.server-header = "pekko-http-bench"
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2RequestResponseBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2RequestResponseBenchmark.scala
@@ -57,10 +57,10 @@ trait H2RequestResponseBenchmark extends HPackEncodingSupport {
     ConfigFactory.parseString(
       s"""
            pekko.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
-           akka.http.server.http2.max-concurrent-streams = $numRequests # needs to be >= `numRequests`
-           akka.http.server.http2.min-collect-strict-entity-size = $minStrictEntitySize
+           pekko.http.server.http2.max-concurrent-streams = $numRequests # needs to be >= `numRequests`
+           pekko.http.server.http2.min-collect-strict-entity-size = $minStrictEntitySize
            #pekko.loglevel = debug
-           #akka.http.server.log-unencrypted-network-bytes = 100
+           #pekko.http.server.log-unencrypted-network-bytes = 100
          """)
       .withFallback(ConfigFactory.load())
 

--- a/http-caching/src/main/resources/reference.conf
+++ b/http-caching/src/main/resources/reference.conf
@@ -5,7 +5,7 @@
 # This is the reference config file that contains all the default settings.
 # Make your edits/overrides in your application.conf.
 
-akka.http.caching {
+pekko.http.caching {
 
   # Default configuration values for LfuCache
   lfu-cache {

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/impl/settings/CachingSettingsImpl.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/impl/settings/CachingSettingsImpl.scala
@@ -19,7 +19,7 @@ private[http] final case class CachingSettingsImpl(lfuCacheSettings: LfuCacheSet
 
 /** INTERNAL API */
 @InternalApi
-private[http] object CachingSettingsImpl extends SettingsCompanionImpl[CachingSettingsImpl]("akka.http.caching") {
+private[http] object CachingSettingsImpl extends SettingsCompanionImpl[CachingSettingsImpl]("pekko.http.caching") {
   def fromSubConfig(root: Config, c: Config): CachingSettingsImpl = {
     new CachingSettingsImpl(
       LfuCachingSettingsImpl.fromSubConfig(root, c.getConfig("lfu-cache")))

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/impl/settings/LfuCachingSettingsImpl.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/impl/settings/LfuCachingSettingsImpl.scala
@@ -27,7 +27,7 @@ private[http] final case class LfuCachingSettingsImpl(
 /** INTERNAL API */
 @InternalApi
 private[http] object LfuCachingSettingsImpl
-    extends SettingsCompanionImpl[LfuCachingSettingsImpl]("akka.http.caching.lfu-cache") {
+    extends SettingsCompanionImpl[LfuCachingSettingsImpl]("pekko.http.caching.lfu-cache") {
   def fromSubConfig(root: Config, inner: Config): LfuCachingSettingsImpl = {
     val c = inner.withFallback(root.getConfig(prefix))
     new LfuCachingSettingsImpl(

--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/TlsSessionInfo.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/TlsSessionInfo.java
@@ -11,7 +11,7 @@ import javax.net.ssl.SSLSession;
  * the message carrying this header was received with.
  *
  * This header will only be added if it enabled in the configuration by setting
- * <code>akka.http.[client|server].parsing.tls-session-info-header = on</code>.
+ * <code>pekko.http.[client|server].parsing.tls-session-info-header = on</code>.
  */
 public abstract class TlsSessionInfo extends CustomHeader {
     /**

--- a/http-core/src/main/resources/reference.conf
+++ b/http-core/src/main/resources/reference.conf
@@ -9,7 +9,7 @@
 # Loaded from generated conf file.
 include "pekko-http-version"
 
-akka.http {
+pekko.http {
 
   server {
     # The default value of the `Server` header to produce if no
@@ -174,7 +174,7 @@ akka.http {
 
     # Modify to tweak parsing settings on the server-side only.
     parsing {
-      # no overrides by default, see `akka.http.parsing` for default values
+      # no overrides by default, see `pekko.http.parsing` for default values
 
       # Server-specific parsing settings:
 
@@ -207,7 +207,7 @@ akka.http {
     # on implementation details and networking conditions and should be treated as
     # arbitrary).
     #
-    # For logging on the client side, see akka.http.client.log-unencrypted-network-bytes.
+    # For logging on the client side, see pekko.http.client.log-unencrypted-network-bytes.
     #
     # `off` : no log messages are produced
     # Int   : determines how many bytes should be logged per data chunk
@@ -321,7 +321,7 @@ akka.http {
       periodic-keep-alive-mode = ping
 
       # Interval for sending periodic keep-alives
-      # The frame sent will be the one configured in akka.http.server.websocket.periodic-keep-alive-mode
+      # The frame sent will be the one configured in pekko.http.server.websocket.periodic-keep-alive-mode
       # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
       # The value `infinite` means that *no* keep-alive heartbeat will be sent, as: "the allowed idle time is infinite"
       periodic-keep-alive-max-idle = infinite
@@ -374,7 +374,7 @@ akka.http {
 
     # Modify to tweak parsing settings on the client-side only.
     parsing {
-      # no overrides by default, see `akka.http.parsing` for default values
+      # no overrides by default, see `pekko.http.parsing` for default values
 
       # Default maximum content length which should not be exceeded by incoming response entities.
       # Can be changed at runtime (to a higher or lower value) via the `HttpEntity::withSizeLimit` method.
@@ -398,7 +398,7 @@ akka.http {
     # on implementation details and networking conditions and should be treated as
     # arbitrary).
     #
-    # For logging on the server side, see akka.http.server.log-unencrypted-network-bytes.
+    # For logging on the server side, see pekko.http.server.log-unencrypted-network-bytes.
     #
     # `off` : no log messages are produced
     # Int   : determines how many bytes should be logged per data chunk
@@ -476,12 +476,12 @@ akka.http {
       max-persistent-attempts = 0
 
       # Starting backoff before reconnecting when a persistent HTTP/2 client connection fails
-      # see `akka.http.host-connection-pool.base-connection-backoff` for details on the backoff mechanism.
-      base-connection-backoff = ${akka.http.host-connection-pool.base-connection-backoff}
+      # see `pekko.http.host-connection-pool.base-connection-backoff` for details on the backoff mechanism.
+      base-connection-backoff = ${pekko.http.host-connection-pool.base-connection-backoff}
 
       # Max backoff between reconnect attempts when a persistent HTTP/2 client connection fails
-      # see `akka.http.host-connection-pool.max-connection-backoff` for details on the backoff mechanism.
-      max-connection-backoff = ${akka.http.host-connection-pool.max-connection-backoff}
+      # see `pekko.http.host-connection-pool.max-connection-backoff` for details on the backoff mechanism.
+      max-connection-backoff = ${pekko.http.host-connection-pool.max-connection-backoff}
 
       # When gracefully closing the HTTP/2 client, await at most `completion-timeout` for in-flight
       # requests to complete.
@@ -503,7 +503,7 @@ akka.http {
       periodic-keep-alive-mode = ping
 
       # Interval for sending periodic keep-alives
-      # The frame sent will be the one configured in akka.http.server.websocket.periodic-keep-alive-mode
+      # The frame sent will be the one configured in pekko.http.server.websocket.periodic-keep-alive-mode
       # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
       periodic-keep-alive-max-idle = infinite
 
@@ -595,7 +595,7 @@ akka.http {
     idle-timeout = 30 s
 
     # HTTP connections are commonly used for multiple requests, that is, they are kept alive between requests. The
-    # `akka.http.host-connection-pool.keep-alive-timeout` setting configures how long a pool keeps a connection alive between
+    # `pekko.http.host-connection-pool.keep-alive-timeout` setting configures how long a pool keeps a connection alive between
     # requests before it closes the connection (and eventually reestablishes it).
     #
     # A common scenario where this setting is useful is to prevent a race-condition inherent in HTTP: in most cases, a server
@@ -620,7 +620,7 @@ akka.http {
     # Modify this section to tweak client settings only for host connection pools APIs like `Http().superPool` or
     # `Http().singleRequest`.
     client = {
-      # no overrides by default, see `akka.http.client` for default values
+      # no overrides by default, see `pekko.http.client` for default values
     }
 
     #per-host-overrides
@@ -667,7 +667,7 @@ akka.http {
   #
   # IMPORTANT:
   # Please note that this sections settings can be overridden by the corresponding settings in:
-  # `akka.http.server.parsing`, `akka.http.client.parsing` or `akka.http.host-connection-pool.client.parsing`.
+  # `pekko.http.server.parsing`, `pekko.http.client.parsing` or `pekko.http.host-connection-pool.client.parsing`.
   parsing {
     # The limits for the various parts of the HTTP message parser.
     max-uri-length             = 2k
@@ -732,7 +732,7 @@ akka.http {
     # If set to `off`, only essential headers will be parsed into their model classes. All other ones will be provided
     # as instances of `RawHeader`. Currently, `Connection`, `Host`, and `Expect` headers will still be provided in their
     # typed model. The full list of headers still provided as modeled instances can be found in the source code of
-    # `akka.http.impl.engine.parsing.HttpHeaderParser.alwaysParsedHeaders`. Note that (regardless of this setting)
+    # `org.apache.pekko.http.impl.engine.parsing.HttpHeaderParser.alwaysParsedHeaders`. Note that (regardless of this setting)
     # some headers like `Content-Type` are treated specially and will never be provided in the list of headers.
     modeled-header-parsing = on
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
@@ -34,7 +34,7 @@ private[pekko] object HttpConnectionIdleTimeoutBidi {
     val ex = new HttpIdleTimeoutException(
       "HTTP idle-timeout encountered" + connectionToString + ", " +
       "no bytes passed in the last " + idleTimeout + ". " +
-      "This is configurable by akka.http.[server|client].idle-timeout.", idleTimeout)
+      "This is configurable by pekko.http.[server|client].idle-timeout.", idleTimeout)
 
     val mapError = Flow[ByteString].mapError { case t: TimeoutException => ex }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
@@ -122,7 +122,7 @@ private[http] object PoolInterface {
     }
 
     override protected def onTimer(timerKey: Any): Unit = {
-      debug(s"Pool shutting down because akka.http.host-connection-pool.idle-timeout triggered after $idleTimeout.")
+      debug(s"Pool shutting down because pekko.http.host-connection-pool.idle-timeout triggered after $idleTimeout.")
       requestShutdown(ShutdownReason.IdleTimeout)
     }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/TelemetrySpi.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/TelemetrySpi.scala
@@ -25,7 +25,7 @@ import java.net.InetSocketAddress
  */
 @InternalApi
 private[http] object TelemetrySpi {
-  private val ConfigKey = "akka.http.http2-telemetry-class"
+  private val ConfigKey = "pekko.http.http2-telemetry-class"
   def create(system: ActorSystem): TelemetrySpi = {
     if (!system.settings.config.hasPath(ConfigKey)) NoOpTelemetry
     else {

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpRequestParser.scala
@@ -111,7 +111,7 @@ private[http] final class HttpRequestParser(
               BadRequest,
               ErrorInfo("Unsupported HTTP method",
                 s"HTTP method too long (started with '${sb.toString}')$remoteAddressStr. " +
-                "Increase `akka.http.server.parsing.max-method-length` to support HTTP methods with more characters."))
+                "Increase `pekko.http.server.parsing.max-method-length` to support HTTP methods with more characters."))
 
         @tailrec def parseMethod(meth: HttpMethod, ix: Int = 1): Int =
           if (ix == meth.value.length)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
@@ -536,7 +536,7 @@ private[http] object HttpServerBluePrint {
                       s"Aggregated data length of request entity exceeds the configured limit of $limit bytes"
                   }
                   val info =
-                    ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                    ErrorInfo(summary, "Consider increasing the value of pekko.http.server.parsing.max-content-length")
                   finishWithIllegalRequestError(StatusCodes.PayloadTooLarge, info)
 
                 case IllegalUriException(errorInfo) =>

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ClientConnectionSettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ClientConnectionSettingsImpl.scala
@@ -52,7 +52,7 @@ private[pekko] final case class ClientConnectionSettingsImpl(
 /** INTERNAL API */
 @InternalApi
 private[pekko] object ClientConnectionSettingsImpl
-    extends SettingsCompanionImpl[ClientConnectionSettingsImpl]("akka.http.client") {
+    extends SettingsCompanionImpl[ClientConnectionSettingsImpl]("pekko.http.client") {
   def fromSubConfig(root: Config, inner: Config): ClientConnectionSettingsImpl = {
     val c = inner.withFallback(root.getConfig(prefix))
     new ClientConnectionSettingsImpl(

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -90,7 +90,7 @@ private[pekko] final case class ConnectionPoolSettingsImpl(
 /** INTERNAL API */
 @InternalApi
 private[pekko] object ConnectionPoolSettingsImpl
-    extends SettingsCompanionImpl[ConnectionPoolSettingsImpl]("akka.http.host-connection-pool") {
+    extends SettingsCompanionImpl[ConnectionPoolSettingsImpl]("pekko.http.host-connection-pool") {
 
   def fromSubConfig(root: Config, c: Config): ConnectionPoolSettingsImpl = {
     new ConnectionPoolSettingsImpl(

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/HttpsProxySettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/HttpsProxySettingsImpl.scala
@@ -20,7 +20,7 @@ private[http] final case class HttpsProxySettingsImpl(
   override def productPrefix = "HttpsProxySettings"
 }
 
-object HttpsProxySettingsImpl extends SettingsCompanionImpl[HttpsProxySettingsImpl]("akka.http.client.proxy.https") {
+object HttpsProxySettingsImpl extends SettingsCompanionImpl[HttpsProxySettingsImpl]("pekko.http.client.proxy.https") {
   override def fromSubConfig(root: Config, c: Config): HttpsProxySettingsImpl = {
     new HttpsProxySettingsImpl(
       c.getString("host"),

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ParserSettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ParserSettingsImpl.scala
@@ -77,7 +77,7 @@ private[pekko] final case class ParserSettingsImpl(
   override def productPrefix = "ParserSettings"
 }
 
-object ParserSettingsImpl extends SettingsCompanionImpl[ParserSettingsImpl]("akka.http.parsing") {
+object ParserSettingsImpl extends SettingsCompanionImpl[ParserSettingsImpl]("pekko.http.parsing") {
 
   private[this] val noCustomMethods: String => Option[HttpMethod] = ConstantFun.scalaAnyToNone
   private[this] val noCustomStatusCodes: Int => Option[StatusCode] = ConstantFun.scalaAnyToNone
@@ -85,7 +85,7 @@ object ParserSettingsImpl extends SettingsCompanionImpl[ParserSettingsImpl]("akk
     ConstantFun.scalaAnyTwoToNone
 
   def forServer(root: Config): ParserSettings =
-    fromSubConfig(root, root.getConfig("akka.http.server.parsing"))
+    fromSubConfig(root, root.getConfig("pekko.http.server.parsing"))
 
   def fromSubConfig(root: Config, inner: Config): ParserSettingsImpl = {
     val c = inner.withFallback(root.getConfig(prefix))

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/PreviewServerSettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/PreviewServerSettingsImpl.scala
@@ -16,7 +16,7 @@ private[http] final case class PreviewServerSettingsImpl(
   override def productPrefix: String = "PreviewServerSettings"
 }
 
-object PreviewServerSettingsImpl extends SettingsCompanionImpl[PreviewServerSettingsImpl]("akka.http.server.preview") {
+object PreviewServerSettingsImpl extends SettingsCompanionImpl[PreviewServerSettingsImpl]("pekko.http.server.preview") {
   def fromSubConfig(root: Config, c: Config) = PreviewServerSettingsImpl(
     c.getBoolean("enable-http2"))
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ServerSettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ServerSettingsImpl.scala
@@ -72,7 +72,7 @@ private[pekko] final case class ServerSettingsImpl(
 
 /** INTERNAL API */
 @InternalApi
-private[http] object ServerSettingsImpl extends SettingsCompanionImpl[ServerSettingsImpl]("akka.http.server") {
+private[http] object ServerSettingsImpl extends SettingsCompanionImpl[ServerSettingsImpl]("pekko.http.server") {
   implicit def timeoutsShortcut(s: js.ServerSettings): js.ServerSettings.Timeouts = s.getTimeouts
 
   final case class Timeouts(

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/WebSocketSettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/WebSocketSettingsImpl.scala
@@ -45,12 +45,12 @@ private[pekko] object WebSocketSettingsImpl { // on purpose not extending Settin
     settings.asInstanceOf[WebSocketSettingsImpl].periodicKeepAliveData eq NoPeriodicKeepAliveData
 
   def serverFromRoot(root: Config): WebSocketSettingsImpl =
-    server(root.getConfig("akka.http.server.websocket"))
+    server(root.getConfig("pekko.http.server.websocket"))
   def server(config: Config): WebSocketSettingsImpl =
     fromConfig(config)
 
   def clientFromRoot(root: Config): WebSocketSettingsImpl =
-    client(root.getConfig("akka.http.client.websocket"))
+    client(root.getConfig("pekko.http.client.websocket"))
   def client(config: Config): WebSocketSettingsImpl =
     fromConfig(config)
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/SettingsCompanionImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/SettingsCompanionImpl.scala
@@ -59,6 +59,6 @@ private[http] object SettingsCompanionImpl {
     val localHostName =
       try new InetSocketAddress(InetAddress.getLocalHost, 80).getHostString
       catch { case NonFatal(_) => "" }
-    ConfigFactory.parseMap(Map("akka.http.hostname" -> localHostName).asJava)
+    ConfigFactory.parseMap(Map("pekko.http.hostname" -> localHostName).asJava)
   }
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ClientTransport.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ClientTransport.scala
@@ -55,7 +55,7 @@ object ClientTransport {
    * Returns a [[ClientTransport]] that runs all connection through the given HTTP(S) proxy using the
    * HTTP CONNECT method.
    *
-   * Pulls the host/port pair from the application.conf: akka.client.proxy.https.{host, port}
+   * Pulls the host/port pair from the application.conf: pekko.client.proxy.https.{host, port}
    */
   def httpsProxy(implicit system: ActorSystem): ClientTransport =
     scaladsl.ClientTransport.httpsProxy().asJava
@@ -77,7 +77,7 @@ object ClientTransport {
    * Returns a [[ClientTransport]] that runs all connection through the given HTTP(S) proxy using the
    * HTTP CONNECT method. This method also takes [[HttpCredentials]] in order to pass along to the proxy.
    *
-   * Pulls the host/port pair from the application.conf: akka.client.proxy.https.{host, port}
+   * Pulls the host/port pair from the application.conf: pekko.client.proxy.https.{host, port}
    */
   def httpsProxy(proxyCredentials: HttpCredentials, system: ActorSystem): ClientTransport =
     scaladsl.ClientTransport.httpsProxy(proxyCredentials.asScala)(system).asJava

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -67,7 +67,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
   /**
    * Constructs a server layer stage using the given [[pekko.http.javadsl.settings.ServerSettings]]. The returned [[pekko.stream.javadsl.BidiFlow]] isn't reusable and
    * can only be materialized once. The `remoteAddress`, if provided, will be added as a header to each [[HttpRequest]]
-   * this layer produces if the `akka.http.server.remote-address-header` configuration option is enabled.
+   * this layer produces if the `pekko.http.server.remote-address-header` configuration option is enabled.
    */
   def serverLayer(
       settings: ServerSettings,
@@ -78,7 +78,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
   /**
    * Constructs a server layer stage using the given [[ServerSettings]]. The returned [[pekko.stream.javadsl.BidiFlow]] isn't reusable and
    * can only be materialized once. The remoteAddress, if provided, will be added as a header to each [[HttpRequest]]
-   * this layer produces if the `akka.http.server.remote-address-header` configuration option is enabled.
+   * this layer produces if the `pekko.http.server.remote-address-header` configuration option is enabled.
    */
   def serverLayer(
       settings: ServerSettings,
@@ -183,7 +183,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * [[pekko.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
@@ -209,7 +209,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * [[pekko.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
@@ -237,7 +237,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * function for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
@@ -261,7 +261,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * function for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
@@ -289,7 +289,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * function for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
@@ -313,7 +313,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * function for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
@@ -533,7 +533,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * object of type `T` from the application which is emitted together with the corresponding response.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def cachedHostConnectionPool[T](
       to: ConnectHttp,
@@ -673,7 +673,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
 
   /**
    * Constructs a WebSocket [[pekko.stream.javadsl.BidiFlow]] using the configured default [[ClientConnectionSettings]],
-   * configured using the `akka.http.client` config section.
+   * configured using the `pekko.http.client` config section.
    *
    * The layer is not reusable and must only be materialized once.
    */
@@ -685,7 +685,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
 
   /**
    * Constructs a WebSocket [[pekko.stream.javadsl.BidiFlow]] using the configured default [[ClientConnectionSettings]],
-   * configured using the `akka.http.client` config section.
+   * configured using the `pekko.http.client` config section.
    *
    * The layer is not reusable and must only be materialized once.
    */

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
@@ -65,7 +65,7 @@ trait ServerBuilder {
    * [[pekko.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * Supports HTTP/2 on the same port if http2 support is enabled.
@@ -79,7 +79,7 @@ trait ServerBuilder {
    * Most importantly, you can pass a Route to this method because Route implements HandlerProvider.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * Supports HTTP/2 on the same port if http2 support is enabled.
@@ -91,7 +91,7 @@ trait ServerBuilder {
    * [[pekko.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * Supports HTTP/2 on the same port if http2 support is enabled.
@@ -103,7 +103,7 @@ trait ServerBuilder {
    * [[pekko.stream.scaladsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    */
   def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): CompletionStage[ServerBinding]

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ClientTransport.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ClientTransport.scala
@@ -42,7 +42,7 @@ object ClientTransport {
   private case object TCPTransport extends ClientTransport {
     def connectTo(host: String, port: Int, settings: ClientConnectionSettings)(
         implicit system: ActorSystem): Flow[ByteString, ByteString, Future[OutgoingConnection]] =
-      // The InetSocketAddress representing the remote address must be created unresolved because akka.io.TcpOutgoingConnection will
+      // The InetSocketAddress representing the remote address must be created unresolved because org.apache.pekko.io.TcpOutgoingConnection will
       // not attempt DNS resolution if the InetSocketAddress is already resolved. That behavior is problematic when it comes to
       // connection pools since it means that new connections opened by the pool in the future can end up using a stale IP address.
       // By passing an unresolved InetSocketAddress instead, we ensure that DNS resolution is performed for every new connection.
@@ -73,7 +73,7 @@ object ClientTransport {
    * Returns a [[ClientTransport]] that runs all connection through the given HTTP(S) proxy using the
    * HTTP CONNECT method.
    *
-   * Pulls the host/port pair from the application.conf: akka.client.proxy.https.{host, port}
+   * Pulls the host/port pair from the application.conf: pekko.client.proxy.https.{host, port}
    */
   def httpsProxy()(implicit system: ActorSystem): ClientTransport = {
     val settings = HttpsProxySettings(system.settings.config)
@@ -96,7 +96,7 @@ object ClientTransport {
    * Returns a [[ClientTransport]] that runs all connection through the given HTTP(S) proxy using the
    * HTTP CONNECT method. This method also takes [[HttpCredentials]] in order to pass along to the proxy.
    *
-   * Pulls the host/port pair from the application.conf: akka.client.proxy.https.{host, port}
+   * Pulls the host/port pair from the application.conf: pekko.client.proxy.https.{host, port}
    */
   def httpsProxy(proxyCredentials: HttpCredentials)(implicit system: ActorSystem): ClientTransport = {
     val settings = HttpsProxySettings(system.settings.config)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
@@ -175,7 +175,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * which is 80 for HTTP and 443 for HTTPS.
    *
    * To configure additional settings for a server started using this method,
-   * use the `akka.http.server` config section or pass in a [[pekko.http.scaladsl.settings.ServerSettings]] explicitly.
+   * use the `pekko.http.server` config section or pass in a [[pekko.http.scaladsl.settings.ServerSettings]] explicitly.
    */
   @deprecated(
     "Use Http().newServerAt(...)...connectionSource() to create a source that can be materialized to a binding.",
@@ -222,11 +222,11 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * [[pekko.stream.scaladsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * To configure additional settings for a server started using this method,
-   * use the `akka.http.server` config section or pass in a [[pekko.http.scaladsl.settings.ServerSettings]] explicitly.
+   * use the `pekko.http.server` config section or pass in a [[pekko.http.scaladsl.settings.ServerSettings]] explicitly.
    */
   @deprecated("Use Http().newServerAt(...)...bindFlow() to create server bindings.", since = "10.2.0")
   @nowarn("msg=deprecated")
@@ -304,11 +304,11 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * [[pekko.stream.scaladsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * To configure additional settings for a server started using this method,
-   * use the `akka.http.server` config section or pass in a [[pekko.http.scaladsl.settings.ServerSettings]] explicitly.
+   * use the `pekko.http.server` config section or pass in a [[pekko.http.scaladsl.settings.ServerSettings]] explicitly.
    */
   @deprecated("Use Http().newServerAt(...)...bindSync() to create server bindings.", since = "10.2.0")
   @nowarn("msg=deprecated")
@@ -326,16 +326,16 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * [[pekko.stream.scaladsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * To configure additional settings for a server started using this method,
-   * use the `akka.http.server` config section or pass in a [[pekko.http.scaladsl.settings.ServerSettings]] explicitly.
+   * use the `pekko.http.server` config section or pass in a [[pekko.http.scaladsl.settings.ServerSettings]] explicitly.
    *
    * Parameter `parallelism` specifies how many requests are attempted to be handled concurrently per connection. In HTTP/1
    * this makes only sense if HTTP pipelining is enabled (which is not recommended). The default value of `0` means that
-   * the value is taken from the `akka.http.server.pipelining-limit` setting from the configuration. In HTTP/2,
-   * the default value is taken from `akka.http.server.http2.max-concurrent-streams`.
+   * the value is taken from the `pekko.http.server.pipelining-limit` setting from the configuration. In HTTP/2,
+   * the default value is taken from `pekko.http.server.http2.max-concurrent-streams`.
    *
    * Any other value for `parallelism` overrides the setting.
    */
@@ -382,7 +382,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
   /**
    * Constructs a [[pekko.http.scaladsl.Http.ServerLayer]] stage using the given [[pekko.http.scaladsl.settings.ServerSettings]]. The returned [[pekko.stream.scaladsl.BidiFlow]] isn't reusable and
    * can only be materialized once. The `remoteAddress`, if provided, will be added as a header to each [[pekko.http.scaladsl.model.HttpRequest]]
-   * this layer produces if the `akka.http.server.remote-address-header` configuration option is enabled.
+   * this layer produces if the `pekko.http.server.remote-address-header` configuration option is enabled.
    */
   def serverLayer(
       settings: ServerSettings = ServerSettings(system),
@@ -415,7 +415,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * Every materialization of the produced flow will attempt to establish a new outgoing connection.
    *
    * To configure additional settings for requests made using this method,
-   * use the `akka.http.client` config section or pass in a [[pekko.http.scaladsl.settings.ClientConnectionSettings]] explicitly.
+   * use the `pekko.http.client` config section or pass in a [[pekko.http.scaladsl.settings.ClientConnectionSettings]] explicitly.
    *
    * Prefer [[connectionTo]] over this method.
    */
@@ -433,7 +433,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * for encryption on the connection.
    *
    * To configure additional settings for requests made using this method,
-   * use the `akka.http.client` config section or pass in a [[pekko.http.scaladsl.settings.ClientConnectionSettings]] explicitly.
+   * use the `pekko.http.client` config section or pass in a [[pekko.http.scaladsl.settings.ClientConnectionSettings]] explicitly.
    *
    * Prefer [[connectionTo]] over this method.
    */
@@ -451,7 +451,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * implementation
    *
    * To configure additional settings for requests made using this method,
-   * use the `akka.http.client` config section or pass in a [[pekko.http.scaladsl.settings.ClientConnectionSettings]] explicitly.
+   * use the `pekko.http.client` config section or pass in a [[pekko.http.scaladsl.settings.ClientConnectionSettings]] explicitly.
    *
    * Prefer [[connectionTo]] over this method.
    */
@@ -493,7 +493,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
 
   /**
    * Constructs a [[pekko.http.scaladsl.Http.ClientLayer]] stage using the configured default [[pekko.http.scaladsl.settings.ClientConnectionSettings]],
-   * configured using the `akka.http.client` config section.
+   * configured using the `pekko.http.client` config section.
    */
   def clientLayer(hostHeader: Host): ClientLayer =
     clientLayer(hostHeader, ClientConnectionSettings(system))
@@ -525,7 +525,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * object of type `T` from the application which is emitted together with the corresponding response.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def newHostConnectionPool[T](host: String, port: Int = 80,
       settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
@@ -542,7 +542,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * for encryption on the connections.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def newHostConnectionPoolHttps[T](host: String, port: Int = 443,
       connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
@@ -583,7 +583,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * object of type `T` from the application which is emitted together with the corresponding response.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def cachedHostConnectionPool[T](host: String, port: Int = 80,
       settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
@@ -600,7 +600,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * for encryption on the connections.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def cachedHostConnectionPoolHttps[T](host: String, port: Int = 443,
       connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
@@ -650,7 +650,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * object of type `T` from the application which is emitted together with the corresponding response.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def superPool[T](
       connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
@@ -681,7 +681,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
 
   /**
    * Constructs a [[pekko.http.scaladsl.Http.WebSocketClientLayer]] stage using the configured default [[pekko.http.scaladsl.settings.ClientConnectionSettings]],
-   * configured using the `akka.http.client` config section.
+   * configured using the `pekko.http.client` config section.
    *
    * The layer is not reusable and must only be materialized once.
    */
@@ -1127,7 +1127,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
   def lookup() = Http
 
   def createExtension(system: ExtendedActorSystem): HttpExt =
-    new HttpExt(system.settings.config.getConfig("akka.http"))(system)
+    new HttpExt(system.settings.config.getConfig("pekko.http"))(system)
 
   @nowarn("msg=use remote-address-attribute instead")
   @InternalApi

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ServerBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ServerBuilder.scala
@@ -60,7 +60,7 @@ trait ServerBuilder {
    * [[pekko.stream.scaladsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * Supports HTTP/2 on the same port if http2 support is enabled.
@@ -72,7 +72,7 @@ trait ServerBuilder {
    * [[pekko.stream.scaladsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    *
    * Supports HTTP/2 on the same port if http2 support is enabled.
@@ -84,7 +84,7 @@ trait ServerBuilder {
    * [[pekko.stream.scaladsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
-   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    */
   def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): Future[ServerBinding]

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ErrorInfo.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ErrorInfo.scala
@@ -119,8 +119,8 @@ object EntityStreamException {
 
 /**
  * This exception is thrown when the size of the HTTP Entity exceeds the configured limit.
- * It is possible to configure the limit using configuration options `akka.http.parsing.max-content-length`
- * or specifically for the server or client side by setting `akka.http.[server|client].parsing.max-content-length`.
+ * It is possible to configure the limit using configuration options `pekko.http.parsing.max-content-length`
+ * or specifically for the server or client side by setting `pekko.http.[server|client].parsing.max-content-length`.
  *
  * The limit can also be configured in code, by calling [[HttpEntity#withSizeLimit]]
  * on the entity before materializing its `dataBytes` stream.
@@ -131,8 +131,8 @@ final case class EntityStreamSizeException(limit: Long, actualSize: Option[Long]
 
   override def toString = {
     s"EntityStreamSizeException: incoming entity size (${actualSize.getOrElse("while streaming")}) exceeded size limit ($limit bytes)! " +
-    "This may have been a parser limit (set via `akka.http.[server|client].parsing.max-content-length`), " +
-    "a decoder limit (set via `akka.http.routing.decode-max-size`), " +
+    "This may have been a parser limit (set via `pekko.http.[server|client].parsing.max-content-length`), " +
+    "a decoder limit (set via `pekko.http.routing.decode-max-size`), " +
     "or a custom limit set with `withSizeLimit`."
   }
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
@@ -72,14 +72,14 @@ sealed trait HttpEntity extends jm.HttpEntity {
    * Collects all possible parts and returns a potentially future Strict entity for easier processing.
    * The Future is failed with an TimeoutException if the stream isn't completed after the given timeout,
    * or with a EntityStreamException when the end of the entity is not reached within the maximum number of bytes
-   * as configured in `akka.http.parsing.max-to-strict-bytes`. Not that this method does not support different
+   * as configured in `pekko.http.parsing.max-to-strict-bytes`. Not that this method does not support different
    * defaults for client- and server use: if you want that, use the `toStrict` method and pass in an explicit
    * maximum number of bytes.
    */
   def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[HttpEntity.Strict] = {
     import pekko.http.impl.util._
     val config = fm.asInstanceOf[ActorMaterializer].system.settings.config
-    toStrict(timeout, config.getPossiblyInfiniteBytes("akka.http.parsing.max-to-strict-bytes"))
+    toStrict(timeout, config.getPossiblyInfiniteBytes("pekko.http.parsing.max-to-strict-bytes"))
   }
 
   /**

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
@@ -482,7 +482,7 @@ object HttpRequest {
       def fail(detail: String) =
         throw IllegalUriException(
           s"Cannot establish effective URI of request to `$uri`, request has a relative URI and $detail",
-          "consider setting `akka.http.server.default-host-header`")
+          "consider setting `pekko.http.server.default-host-header`")
       val Host(hostHeaderHost, hostHeaderPort) = hostHeader match {
         case OptionVal.None => if (defaultHostHeader.isEmpty) fail("is missing a `Host` header") else defaultHostHeader
         case OptionVal.Some(x) if x.isEmpty =>

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
@@ -1055,7 +1055,7 @@ final case class `Timeout-Access`(timeoutAccess: pekko.http.scaladsl.TimeoutAcce
  * This header will only be added if it enabled in the configuration by setting
  *
  * ```
- * akka.http.[client|server].parsing.tls-session-info-header = on
+ * pekko.http.[client|server].parsing.tls-session-info-header = on
  * ```
  */
 object `Tls-Session-Info` extends ModeledCompanion[`Tls-Session-Info`]

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/sse/ServerSentEvent.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/sse/ServerSentEvent.scala
@@ -68,7 +68,7 @@ object ServerSentEvent {
 
 /**
  * Representation of a server-sent event. By default akka-http uses events with an empty data field as a heartbeat that is
- * ignored on reception. Set `akka.http.sse.emit-empty-events` can be used to change that default behavior.
+ * ignored on reception. Set `pekko.http.sse.emit-empty-events` can be used to change that default behavior.
  *
  * @param data data, may span multiple lines
  * @param eventType optional type, must not contain \n or \r

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -105,9 +105,9 @@ object ConnectionPoolSettings extends SettingsCompanion[ConnectionPoolSettings] 
     import scala.collection.JavaConverters._
 
     val hostOverrides =
-      config.getConfigList("akka.http.host-connection-pool.per-host-override").asScala.toList.map { cfg =>
+      config.getConfigList("pekko.http.host-connection-pool.per-host-override").asScala.toList.map { cfg =>
         ConnectionPoolSettingsImpl.hostRegex(cfg.getString("host-pattern")) ->
-        ConnectionPoolSettingsImpl(cfg.atPath("akka.http.host-connection-pool").withFallback(config))
+        ConnectionPoolSettingsImpl(cfg.atPath("pekko.http.host-connection-pool").withFallback(config))
       }
 
     ConnectionPoolSettingsImpl(config).copy(hostOverrides = hostOverrides)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/Http2ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/Http2ServerSettings.scala
@@ -131,7 +131,7 @@ object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
   }
 
   private[http] object Http2ServerSettingsImpl
-      extends pekko.http.impl.util.SettingsCompanionImpl[Http2ServerSettingsImpl]("akka.http.server.http2") {
+      extends pekko.http.impl.util.SettingsCompanionImpl[Http2ServerSettingsImpl]("pekko.http.server.http2") {
     def fromSubConfig(root: Config, c: Config): Http2ServerSettingsImpl = Http2ServerSettingsImpl(
       maxConcurrentStreams = c.getInt("max-concurrent-streams"),
       requestEntityChunkSize = c.getIntBytes("request-entity-chunk-size"),
@@ -238,7 +238,7 @@ object Http2ClientSettings extends SettingsCompanion[Http2ClientSettings] {
   }
 
   private[http] object Http2ClientSettingsImpl
-      extends pekko.http.impl.util.SettingsCompanionImpl[Http2ClientSettingsImpl]("akka.http.client.http2") {
+      extends pekko.http.impl.util.SettingsCompanionImpl[Http2ClientSettingsImpl]("pekko.http.client.http2") {
     def fromSubConfig(root: Config, c: Config): Http2ClientSettingsImpl = Http2ClientSettingsImpl(
       maxConcurrentStreams = c.getInt("max-concurrent-streams"),
       requestEntityChunkSize = c.getIntBytes("request-entity-chunk-size"),

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ParserSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ParserSettings.scala
@@ -236,5 +236,5 @@ object ParserSettings extends SettingsCompanion[ParserSettings] {
     ParserSettingsImpl.forServer(system.classicSystem.settings.config)
   def forClient(implicit system: ClassicActorSystemProvider): ParserSettings =
     ParserSettingsImpl.fromSubConfig(system.classicSystem.settings.config,
-      system.classicSystem.settings.config.getConfig("akka.http.client.parsing"))
+      system.classicSystem.settings.config.getConfig("pekko.http.client.parsing"))
 }

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -48,8 +48,8 @@ class HostConnectionPoolSpec extends PekkoSpecWithMaterializer(
        serialize-messages = off
        default-dispatcher.throughput = 100
      }
-     akka.http.client.log-unencrypted-network-bytes = 200
-     akka.http.server.log-unencrypted-network-bytes = 200
+     pekko.http.client.log-unencrypted-network-bytes = 200
+     pekko.http.server.log-unencrypted-network-bytes = 200
   """) with Eventually {
   lazy val singleElementBufferMaterializer = materializer
   val defaultSettings =

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HttpConfigurationSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HttpConfigurationSpec.scala
@@ -41,8 +41,8 @@ class HttpConfigurationSpec extends PekkoSpec {
       }
     }
 
-    "override value from `akka.http.parsing` by setting `akka.http.client.parsing`" in {
-      configuredSystem("""akka.http.client.parsing.illegal-header-warnings = off""") { sys =>
+    "override value from `pekko.http.parsing` by setting `pekko.http.client.parsing`" in {
+      configuredSystem("""pekko.http.client.parsing.illegal-header-warnings = off""") { sys =>
         val client = ClientConnectionSettings(sys)
         client.parserSettings.illegalHeaderWarnings should ===(Off)
 
@@ -54,8 +54,8 @@ class HttpConfigurationSpec extends PekkoSpec {
       }
     }
 
-    "override `akka.http.parsing` by setting `akka.http.host-connection-pool.client.parsing` setting" in {
-      configuredSystem("""akka.http.host-connection-pool.client.parsing.illegal-header-warnings = off""") { sys =>
+    "override `pekko.http.parsing` by setting `pekko.http.host-connection-pool.client.parsing` setting" in {
+      configuredSystem("""pekko.http.host-connection-pool.client.parsing.illegal-header-warnings = off""") { sys =>
         val client = ClientConnectionSettings(sys)
         client.parserSettings.illegalHeaderWarnings should ===(On)
 
@@ -67,8 +67,8 @@ class HttpConfigurationSpec extends PekkoSpec {
       }
     }
 
-    "set `akka.http.host-connection-pool.client.idle-timeout` only" in {
-      configuredSystem("""akka.http.host-connection-pool.client.idle-timeout = 1337s""") { sys =>
+    "set `pekko.http.host-connection-pool.client.idle-timeout` only" in {
+      configuredSystem("""pekko.http.host-connection-pool.client.idle-timeout = 1337s""") { sys =>
         import scala.concurrent.duration._
 
         val client = ClientConnectionSettings(sys)
@@ -78,11 +78,11 @@ class HttpConfigurationSpec extends PekkoSpec {
         pool.connectionSettings.idleTimeout should ===(1337.seconds)
 
         val server = ServerSettings(sys)
-        server.idleTimeout should ===(60.seconds) // no change, default akka.http.server.idle-timeout
+        server.idleTimeout should ===(60.seconds) // no change, default pekko.http.server.idle-timeout
       }
     }
-    "set `akka.http.server.idle-timeout` only" in {
-      configuredSystem("""akka.http.server.idle-timeout = 1337s""") { sys =>
+    "set `pekko.http.server.idle-timeout` only" in {
+      configuredSystem("""pekko.http.server.idle-timeout = 1337s""") { sys =>
         import scala.concurrent.duration._
 
         val client = ClientConnectionSettings(sys)
@@ -96,8 +96,8 @@ class HttpConfigurationSpec extends PekkoSpec {
       }
     }
 
-    "change parser settings for all by setting `akka.http.parsing`" in {
-      configuredSystem("""akka.http.parsing.illegal-header-warnings = off""") { sys =>
+    "change parser settings for all by setting `pekko.http.parsing`" in {
+      configuredSystem("""pekko.http.parsing.illegal-header-warnings = off""") { sys =>
         val client = ClientConnectionSettings(sys)
         client.parserSettings.illegalHeaderWarnings should ===(Off)
 
@@ -109,9 +109,9 @@ class HttpConfigurationSpec extends PekkoSpec {
       }
     }
 
-    "change parser settings for all by setting `akka.http.parsing`, unless client/server override it" in {
+    "change parser settings for all by setting `pekko.http.parsing`, unless client/server override it" in {
       configuredSystem("""
-        akka.http {
+        pekko.http {
           parsing.illegal-header-warnings = off
           server.parsing.illegal-header-warnings = on
           client.parsing.illegal-header-warnings = on // also affects host-connection-pool.client
@@ -127,9 +127,9 @@ class HttpConfigurationSpec extends PekkoSpec {
       }
     }
 
-    "change parser settings for all by setting `akka.http.parsing`, unless all override it" in {
+    "change parser settings for all by setting `pekko.http.parsing`, unless all override it" in {
       configuredSystem("""
-        akka.http {
+        pekko.http {
           parsing.illegal-header-warnings = off
           server.parsing.illegal-header-warnings = on
           client.parsing.illegal-header-warnings = on
@@ -146,11 +146,11 @@ class HttpConfigurationSpec extends PekkoSpec {
       }
     }
 
-    "set `akka.http.host-connection-pool.min-connections` only" in {
+    "set `pekko.http.host-connection-pool.min-connections` only" in {
       configuredSystem(
         """
-          akka.http.host-connection-pool.min-connections = 42
-          akka.http.host-connection-pool.max-connections = 43
+          pekko.http.host-connection-pool.min-connections = 42
+          pekko.http.host-connection-pool.max-connections = 43
         """.stripMargin) { sys =>
         val pool = ConnectionPoolSettings(sys)
         pool.getMinConnections should ===(42)
@@ -164,17 +164,17 @@ class HttpConfigurationSpec extends PekkoSpec {
 
       configuredSystem(
         """
-          akka.http.host-connection-pool.min-connections = 101
-          akka.http.host-connection-pool.max-connections = 1
+          pekko.http.host-connection-pool.min-connections = 101
+          pekko.http.host-connection-pool.max-connections = 1
         """.stripMargin) { sys =>
         intercept[IllegalArgumentException] { ConnectionPoolSettings(sys) }
       }
     }
 
-    "set `akka.http.client.proxy.https.host` only in" in {
+    "set `pekko.http.client.proxy.https.host` only in" in {
       configuredSystem(
         """
-          akka.http.client.proxy.https.host = ""
+          pekko.http.client.proxy.https.host = ""
         """) { sys =>
         assertThrows[IllegalArgumentException] {
           HttpsProxySettings(sys)
@@ -182,10 +182,10 @@ class HttpConfigurationSpec extends PekkoSpec {
       }
     }
 
-    "set `akka.http.client.proxy.https.port` only in" in {
+    "set `pekko.http.client.proxy.https.port` only in" in {
       configuredSystem(
         """
-          akka.http.client.proxy.https.port = 8080
+          pekko.http.client.proxy.https.port = 8080
         """) { sys =>
         assertThrows[IllegalArgumentException] {
           HttpsProxySettings(sys)
@@ -193,11 +193,11 @@ class HttpConfigurationSpec extends PekkoSpec {
       }
     }
 
-    "set `akka.http.client.proxy.https.port` and `akka.http.client.proxy.https.host` in" in {
+    "set `pekko.http.client.proxy.https.port` and `pekko.http.client.proxy.https.host` in" in {
       configuredSystem(
         """
-          akka.http.client.proxy.https.host = localhost
-          akka.http.client.proxy.https.port = 8080
+          pekko.http.client.proxy.https.host = localhost
+          pekko.http.client.proxy.https.port = 8080
         """.stripMargin) { sys =>
         val settings = HttpsProxySettings(sys)
         settings.host should ===("localhost")

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -401,7 +401,7 @@ class LowLevelOutgoingConnectionSpec extends PekkoSpecWithMaterializer with Insi
 
       val ignoreConfig =
         """
-          akka.http.parsing.illegal-response-header-value-processing-mode = ignore
+          pekko.http.parsing.illegal-response-header-value-processing-mode = ignore
         """
       "ignore illegal response header value if setting the config to ignore" in new TestSetup(config = ignoreConfig) {
         sendStandardRequest()
@@ -419,7 +419,7 @@ class LowLevelOutgoingConnectionSpec extends PekkoSpecWithMaterializer with Insi
 
       val ignoreNameConfig =
         """
-          akka.http.parsing.illegal-response-header-name-processing-mode = ignore
+          pekko.http.parsing.illegal-response-header-name-processing-mode = ignore
         """
       "ignore illegal response header name if setting the config to ignore" in new TestSetup(
         config = ignoreNameConfig) {
@@ -438,7 +438,7 @@ class LowLevelOutgoingConnectionSpec extends PekkoSpecWithMaterializer with Insi
 
       val warnConfig =
         """
-          akka.http.parsing.illegal-response-header-value-processing-mode = warn
+          pekko.http.parsing.illegal-response-header-value-processing-mode = warn
         """
       "ignore illegal response header value and log a warning message if setting the config to warn" in new TestSetup(
         config = warnConfig) {
@@ -458,7 +458,7 @@ class LowLevelOutgoingConnectionSpec extends PekkoSpecWithMaterializer with Insi
 
     val warnNameConfig =
       """
-          akka.http.parsing.illegal-response-header-name-processing-mode = warn
+          pekko.http.parsing.illegal-response-header-name-processing-mode = warn
         """
     "ignore illegal response header name and log a warning message if setting the config to warn" in new TestSetup(
       config = warnNameConfig) {

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/NewConnectionPoolSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/NewConnectionPoolSpec.scala
@@ -48,7 +48,7 @@ class NewConnectionPoolSpec extends PekkoSpecWithMaterializer("""
     pekko.io.tcp.trace-logging = off
     pekko.test.single-expect-default = 5000 # timeout for checks, adjust as necessary, set here to 5s
     pekko.scheduler.tick-duration = 1ms     # to make race conditions in Pool idle-timeout more likely
-    akka.http.client.log-unencrypted-network-bytes = 200
+    pekko.http.client.log-unencrypted-network-bytes = 200
                                           """) { testSuite =>
 
   implicit class WithPoolStatus(val poolId: PoolId) {

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/TlsEndpointVerificationSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/TlsEndpointVerificationSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.time.{ Seconds, Span }
 import scala.concurrent.Future
 
 class TlsEndpointVerificationSpec extends PekkoSpecWithMaterializer("""
-    akka.http.parsing.ssl-session-attribute = on
+    pekko.http.parsing.ssl-session-attribute = on
   """) {
   /*
    * Useful when debugging against "what if we hit a real website"

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -26,9 +26,9 @@ import pekko.testkit.EventFilter
 
 abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends PekkoSpecWithMaterializer(
       """
-    akka.http.parsing.max-header-name-length = 60
-    akka.http.parsing.max-header-value-length = 1000
-    akka.http.parsing.header-cache.Host = 300
+    pekko.http.parsing.max-header-name-length = 60
+    pekko.http.parsing.max-header-value-length = 1000
+    pekko.http.parsing.header-cache.Host = 300
   """) {
   s"The HttpHeaderParser (mode: $mode)" should {
     "insert the 1st value" in new TestSetup(testSetupMode = TestSetupMode.Unprimed) {

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParserTestBed.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParserTestBed.scala
@@ -14,9 +14,9 @@ object HttpHeaderParserTestBed extends App {
   val testConf: Config = ConfigFactory.parseString("""
     pekko.event-handlers = ["org.apache.pekko.testkit.TestEventListener"]
     pekko.loglevel = ERROR
-    akka.http.parsing.max-header-name-length = 20
-    akka.http.parsing.max-header-value-length = 21
-    akka.http.parsing.header-cache.Host = 300""")
+    pekko.http.parsing.max-header-name-length = 20
+    pekko.http.parsing.max-header-value-length = 21
+    pekko.http.parsing.header-cache.Host = 300""")
   val system = ActorSystem("HttpHeaderParserTestBed", testConf)
 
   val parser = HttpHeaderParser.prime {

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
@@ -43,9 +43,9 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
   val testConf: Config = ConfigFactory.parseString("""
     pekko.event-handlers = ["org.apache.pekko.testkit.TestEventListener"]
     pekko.loglevel = WARNING
-    akka.http.parsing.max-header-value-length = 32
-    akka.http.parsing.max-uri-length = 40
-    akka.http.parsing.max-content-length = infinite""")
+    pekko.http.parsing.max-header-value-length = 32
+    pekko.http.parsing.max-uri-length = 40
+    pekko.http.parsing.max-content-length = infinite""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
 
@@ -567,7 +567,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
           BadRequest,
           ErrorInfo(
             "Unsupported HTTP method",
-            "HTTP method too long (started with 'ABCDEFGHIJKLMNOP'). Increase `akka.http.server.parsing.max-method-length` to support HTTP methods with more characters."))
+            "HTTP method too long (started with 'ABCDEFGHIJKLMNOP'). Increase `pekko.http.server.parsing.max-method-length` to support HTTP methods with more characters."))
       }
 
       "two Content-Length headers" in new Test {

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -33,7 +33,7 @@ import pekko.testkit._
 
 abstract class ResponseParserSpec(mode: String, newLine: String) extends PekkoSpecWithMaterializer(
       """
-     akka.http.parsing.max-response-reason-length = 21
+     pekko.http.parsing.max-response-reason-length = 21
   """) {
   import system.dispatcher
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerBug21008Spec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerBug21008Spec.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 
 class HttpServerBug21008Spec extends PekkoSpecWithMaterializer(
       """
-   akka.http.server.request-timeout = infinite
+   pekko.http.server.request-timeout = infinite
    pekko.test.filter-leeway=1s""") with Inside { spec =>
   "The HttpServer" should {
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerSpec.scala
@@ -47,8 +47,8 @@ object TestParsingErrorHandler extends ParsingErrorHandler {
 class HttpServerSpec extends PekkoSpec(
       """pekko.loggers = ["org.apache.pekko.http.impl.util.SilenceAllTestEventListener"]
      pekko.loglevel = DEBUG
-     akka.http.server.log-unencrypted-network-bytes = 100
-     akka.http.server.request-timeout = infinite
+     pekko.http.server.log-unencrypted-network-bytes = 100
+     pekko.http.server.request-timeout = infinite
   """) with Inside with WithLogCapturing { spec =>
   implicit val materializer = ActorMaterializer()
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerWithExplicitSchedulerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerWithExplicitSchedulerSpec.scala
@@ -17,8 +17,8 @@ import scala.concurrent.duration._
 /** Tests similar to HttpServerSpec that need ExplicitlyTriggeredScheduler */
 class HttpServerWithExplicitSchedulerSpec extends PekkoSpecWithMaterializer(
       """
-     akka.http.server.log-unencrypted-network-bytes = 100
-     akka.http.server.request-timeout = infinite
+     pekko.http.server.log-unencrypted-network-bytes = 100
+     pekko.http.server.request-timeout = infinite
      pekko.scheduler.implementation = "org.apache.pekko.testkit.ExplicitlyTriggeredScheduler"
   """) with Inside { spec =>
   "The server implementation" should {

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/MessageSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/MessageSpec.scala
@@ -28,8 +28,8 @@ import scala.concurrent.Await
 
 class MessageSpec extends PekkoSpecWithMaterializer(
       """
-     akka.http.server.websocket.log-frames = on
-     akka.http.client.websocket.log-frames = on
+     pekko.http.server.websocket.log-frames = on
+     pekko.http.client.websocket.log-frames = on
   """) with Eventually {
 
   import WSTestUtils._

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketClientSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketClientSpec.scala
@@ -24,7 +24,7 @@ import pekko.util.ByteString
 import pekko.testkit._
 import pekko.http.impl.util._
 
-class WebSocketClientSpec extends PekkoSpecWithMaterializer("akka.http.client.websocket.log-frames = on") {
+class WebSocketClientSpec extends PekkoSpecWithMaterializer("pekko.http.client.websocket.log-frames = on") {
   "The client-side WebSocket implementation should" should {
     "establish a websocket connection when the user requests it" in new EstablishedConnectionSetup with ClientEchoes
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketServerSpec.scala
@@ -15,7 +15,7 @@ import pekko.http.impl.util.PekkoSpecWithMaterializer
 
 import scala.concurrent.duration._
 
-class WebSocketServerSpec extends PekkoSpecWithMaterializer("akka.http.server.websocket.log-frames = on") { spec =>
+class WebSocketServerSpec extends PekkoSpecWithMaterializer("pekko.http.server.websocket.log-frames = on") { spec =>
 
   "The server-side WebSocket integration should" should {
     "establish a websocket connection when the user requests it" should {

--- a/http-core/src/test/scala/org/apache/pekko/http/javadsl/HttpExtensionApiSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/javadsl/HttpExtensionApiSpec.scala
@@ -25,9 +25,9 @@ import scala.util.Try
 
 class HttpExtensionApiSpec extends PekkoSpecWithMaterializer(
       """
-    akka.http.server.log-unencrypted-network-bytes = 100
-    akka.http.client.log-unencrypted-network-bytes = 100
-    akka.http.server.request-timeout = infinite
+    pekko.http.server.log-unencrypted-network-bytes = 100
+    pekko.http.client.log-unencrypted-network-bytes = 100
+    pekko.http.server.request-timeout = infinite
     pekko.io.tcp.trace-logging = true
   """) {
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
@@ -51,10 +51,10 @@ class ClientServerHttp2EnabledSpec extends ClientServerSpecBase(http2 = true)
 
 abstract class ClientServerSpecBase(http2: Boolean) extends PekkoSpecWithMaterializer(
       s"""
-     akka.http.server.preview.enable-http2 = $http2
-     akka.http.server.request-timeout = infinite
-     akka.http.server.log-unencrypted-network-bytes = 200
-     akka.http.client.log-unencrypted-network-bytes = 200
+     pekko.http.server.preview.enable-http2 = $http2
+     pekko.http.server.request-timeout = infinite
+     pekko.http.server.log-unencrypted-network-bytes = 200
+     pekko.http.client.log-unencrypted-network-bytes = 200
   """) with ScalaFutures {
   import system.dispatcher
 
@@ -872,7 +872,7 @@ Host: example.com
 
     "properly complete a simple request/response cycle when `modeled-header-parsing = off`" in Utils.assertAllStagesStopped {
       new TestSetup {
-        override def configOverrides = "akka.http.parsing.modeled-header-parsing = off"
+        override def configOverrides = "pekko.http.parsing.modeled-header-parsing = off"
 
         val (clientOut, clientIn) = openNewClientConnection()
         val (serverIn, serverOut) = acceptConnection()
@@ -906,8 +906,8 @@ Host: example.com
     "properly complete a simple request/response cycle when `max-content-length` is set to 0" in Utils.assertAllStagesStopped {
       new TestSetup {
         override def configOverrides = """
-            akka.http.client.parsing.max-content-length = 0
-            akka.http.server.parsing.max-content-length = 0
+            pekko.http.client.parsing.max-content-length = 0
+            pekko.http.server.parsing.max-content-length = 0
         """
 
         val (clientOut, clientIn) = openNewClientConnection()

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientSpec.scala
@@ -24,7 +24,7 @@ class ClientSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     pekko.stdout-loglevel = ERROR
     windows-connection-abort-workaround-enabled = auto
     pekko.log-dead-letters = OFF
-    akka.http.server.request-timeout = infinite""")
+    pekko.http.server.request-timeout = infinite""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   implicit val materializer = ActorMaterializer()
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future, Promise }
 
 class ClientTransportWithCustomResolverSpec
-    extends PekkoSpecWithMaterializer("akka.http.server.request-timeout = infinite") with OptionValues {
+    extends PekkoSpecWithMaterializer("pekko.http.server.request-timeout = infinite") with OptionValues {
   "A custom resolver" should {
 
     "change to the desired destination" in {

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/GracefulTerminationSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/GracefulTerminationSpec.scala
@@ -31,9 +31,9 @@ import scala.util.{ Failure, Success, Try }
 class GracefulTerminationSpec
     extends PekkoSpecWithMaterializer("""
     windows-connection-abort-workaround-enabled = auto
-    akka.http.server.request-timeout = infinite
-    akka.http.server.log-unencrypted-network-bytes = 200
-    akka.http.client.log-unencrypted-network-bytes = 200
+    pekko.http.server.request-timeout = infinite
+    pekko.http.server.log-unencrypted-network-bytes = 200
+    pekko.http.client.log-unencrypted-network-bytes = 200
                                                    """)
     with Tolerance with Eventually {
   implicit lazy val dispatcher = system.dispatcher
@@ -252,7 +252,7 @@ class GracefulTerminationSpec
 
         override def serverSettings: ServerSettings =
           ServerSettings(
-            """akka.http.server {
+            """pekko.http.server {
                  termination-deadline-exceeded-response.status = 418 # I'm a teapot
                }""")
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/TightRequestTimeoutSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/TightRequestTimeoutSpec.scala
@@ -25,7 +25,7 @@ class TightRequestTimeoutSpec extends AnyWordSpec with Matchers with BeforeAndAf
     pekko.stdout-loglevel = ERROR
     windows-connection-abort-workaround-enabled = auto
     pekko.log-dead-letters = OFF
-    akka.http.server.request-timeout = 10ms""")
+    pekko.http.server.request-timeout = 10ms""")
 
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   implicit val materializer = ActorMaterializer()

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/HttpMessageSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/HttpMessageSpec.scala
@@ -29,7 +29,7 @@ class HttpMessageSpec extends AnyWordSpec with Matchers {
 
     (thrown should have).message(
       s"Cannot establish effective URI of request to `/relative`, request has a relative URI and $details: " +
-      "consider setting `akka.http.server.default-host-header`")
+      "consider setting `pekko.http.server.default-host-header`")
   }
 
   "HttpRequest" should {

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -14,21 +14,21 @@ import com.typesafe.config.ConfigFactory
 
 class ConnectionPoolSettingsSpec extends PekkoSpec {
   "ConnectionPoolSettings" should {
-    "use akka.http.client settings by default" in {
+    "use pekko.http.client settings by default" in {
       val settings = config(
         """
-          akka.http.client.user-agent-header = "serva/0.0"
+          pekko.http.client.user-agent-header = "serva/0.0"
         """)
 
       settings.connectionSettings.userAgentHeader shouldEqual Some(
         `User-Agent`.parseFromValueString("serva/0.0").right.get)
     }
-    "allow overriding client settings with akka.http.host-connection-pool.client" in {
+    "allow overriding client settings with pekko.http.host-connection-pool.client" in {
       val settings = config(
         """
-          akka.http.client.request-header-size-hint = 1024
-          akka.http.client.user-agent-header = "serva/0.0"
-          akka.http.host-connection-pool.client.user-agent-header = "serva/5.7"
+          pekko.http.client.request-header-size-hint = 1024
+          pekko.http.client.user-agent-header = "serva/0.0"
+          pekko.http.host-connection-pool.client.user-agent-header = "serva/5.7"
         """)
 
       settings.connectionSettings.userAgentHeader shouldEqual Some(
@@ -36,16 +36,16 @@ class ConnectionPoolSettingsSpec extends PekkoSpec {
       settings.connectionSettings.requestHeaderSizeHint shouldEqual 1024 // still fall back
     }
     "allow max-open-requests = 1" in {
-      config("akka.http.host-connection-pool.max-open-requests = 1").maxOpenRequests should be(1)
+      config("pekko.http.host-connection-pool.max-open-requests = 1").maxOpenRequests should be(1)
     }
     "allow max-open-requests = 42" in {
-      config("akka.http.host-connection-pool.max-open-requests = 42").maxOpenRequests should be(42)
+      config("pekko.http.host-connection-pool.max-open-requests = 42").maxOpenRequests should be(42)
     }
     "allow per host overrides" in {
 
       val settingsString =
         """
-          |akka.http.host-connection-pool {
+          |pekko.http.host-connection-pool {
           |  max-connections = 7
           |
           |  per-host-override : [
@@ -93,7 +93,7 @@ class ConnectionPoolSettingsSpec extends PekkoSpec {
     "allow overriding values from code" in {
       val settingsString =
         """
-          |akka.http.host-connection-pool {
+          |pekko.http.host-connection-pool {
           |  max-connections = 7
           |
           |  per-host-override = [
@@ -119,7 +119,7 @@ class ConnectionPoolSettingsSpec extends PekkoSpec {
     "choose the first matching override when there are multiple" in {
       val settingsString =
         """
-          |akka.http.host-connection-pool {
+          |pekko.http.host-connection-pool {
           |  min-connections = 2
           |  max-connections = 7
           |

--- a/http-testkit/src/main/resources/reference.conf
+++ b/http-testkit/src/main/resources/reference.conf
@@ -1,1 +1,1 @@
-akka.http.testkit.marshalling.timeout = 1 s
+pekko.http.testkit.marshalling.timeout = 1 s

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/MarshallingTestUtils.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/MarshallingTestUtils.scala
@@ -21,7 +21,7 @@ trait MarshallingTestUtils {
 
   def testConfig: Config
 
-  def marshallingTimeout = testConfig.getFiniteDuration("akka.http.testkit.marshalling.timeout")
+  def marshallingTimeout = testConfig.getFiniteDuration("pekko.http.testkit.marshalling.timeout")
 
   def marshal[T: ToEntityMarshaller](value: T)(implicit ec: ExecutionContext, mat: Materializer): HttpEntity.Strict =
     Await.result(Marshal(value).to[HttpEntity].flatMap(_.toStrict(marshallingTimeout)), 2 * marshallingTimeout)

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTest.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTest.scala
@@ -167,7 +167,7 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
         def apply(request: HttpRequest, route: Route): Out = {
           if (request.method == HttpMethods.HEAD && ServerSettings(system).transparentHeadRequests)
             failTest(
-              "`akka.http.server.transparent-head-requests = on` not supported in RouteTest using `~>`. Use `~!>` instead " +
+              "`pekko.http.server.transparent-head-requests = on` not supported in RouteTest using `~>`. Use `~!>` instead " +
               "for a full-stack test, e.g. `req ~!> route ~> check {...}`")
 
           implicit val executionContext: ExecutionContext = system.classicSystem.dispatcher

--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRouteTest with ScalaFutures {
-  override def testConfigSource: String = "akka.http.server.transparent-head-requests = on" // see test below
+  override def testConfigSource: String = "pekko.http.server.transparent-head-requests = on" // see test below
 
   "The ScalatestRouteTest should support" - {
 
@@ -159,7 +159,7 @@ class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRou
 
       val ex = the[Exception] thrownBy (runTest())
       ex.getMessage shouldEqual
-      "`akka.http.server.transparent-head-requests = on` not supported in RouteTest using `~>`. " +
+      "`pekko.http.server.transparent-head-requests = on` not supported in RouteTest using `~>`. " +
       "Use `~!>` instead for a full-stack test, e.g. `req ~!> route ~> check {...}`"
     }
   }

--- a/http-tests/src/multi-jvm/scala/org/apache/pekko/remote/testkit/MultiNodeConfig.scala
+++ b/http-tests/src/multi-jvm/scala/org/apache/pekko/remote/testkit/MultiNodeConfig.scala
@@ -108,8 +108,8 @@ abstract class MultiNodeConfig {
     val transportConfig =
       if (_testTransport) ConfigFactory.parseString(
         """
-           akka.remote.netty.tcp.applied-adapters = [trttl, gremlin]
-           akka.remote.artery.advanced.test-mode = on
+           pekko.remote.netty.tcp.applied-adapters = [trttl, gremlin]
+           pekko.remote.artery.advanced.test-mode = on
         """)
       else ConfigFactory.empty
 
@@ -466,7 +466,7 @@ abstract class MultiNodeSpec(val myself: RoleName, _system: ActorSystem, _roles:
    */
   protected def startNewSystem(): ActorSystem = {
     val config =
-      ConfigFactory.parseString(s"akka.remote.netty.tcp{port=${myAddress.port.get}\nhostname=${myAddress.host.get}}")
+      ConfigFactory.parseString(s"pekko.remote.netty.tcp{port=${myAddress.port.get}\nhostname=${myAddress.host.get}}")
         .withFallback(system.settings.config)
     val sys = ActorSystem(system.name, config)
     injectDeployments(sys, myself)

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/directives/RouteDirectivesTest.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/directives/RouteDirectivesTest.java
@@ -91,8 +91,8 @@ public class RouteDirectivesTest extends JUnitRouteTest {
       .run(HttpRequest.create("/limit-5").withEntity("1234567890"))
       .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE)
       .assertEntity("EntityStreamSizeException: incoming entity size (10) exceeded size limit (5 bytes)! " +
-              "This may have been a parser limit (set via `akka.http.[server|client].parsing.max-content-length`), " +
-	      "a decoder limit (set via `akka.http.routing.decode-max-size`), " +
+              "This may have been a parser limit (set via `pekko.http.[server|client].parsing.max-content-length`), " +
+	      "a decoder limit (set via `pekko.http.routing.decode-max-size`), " +
               "or a custom limit set with `withSizeLimit`.");
   }
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/ConnectionTestApp.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/ConnectionTestApp.scala
@@ -21,7 +21,7 @@ object ConnectionTestApp {
     pekko.loglevel = debug
     pekko.log-dead-letters = off
 
-    akka.http {
+    pekko.http {
       client {
         idle-timeout = 10s
       }

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -33,10 +33,11 @@ abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String
       # disable logs (very noisy tests - 100 expected errors)
       loglevel = DEBUG
       loggers = ["org.apache.pekko.http.impl.util.SilenceAllTestEventListener"]
-    }
-    akka.http.host-connection-pool.pool-implementation = $poolImplementation
-    akka.http.host-connection-pool.base-connection-backoff = 0 ms
-    """).withFallback(ConfigFactory.load())
+
+      http.host-connection-pool.pool-implementation = $poolImplementation
+
+      http.host-connection-pool.base-connection-backoff = 0 ms
+    }""").withFallback(ConfigFactory.load())
   implicit val system = ActorSystem("DontLeakActorsOnFailingConnectionSpecs-" + poolImplementation, config)
   implicit val materializer = ActorMaterializer()
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/SizeLimitSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/SizeLimitSpec.scala
@@ -39,8 +39,8 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
     pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
     pekko.loglevel = ERROR
     pekko.stdout-loglevel = ERROR
-    akka.http.server.parsing.max-content-length = $maxContentLength
-    akka.http.routing.decode-max-size = $decodeMaxSize
+    pekko.http.server.parsing.max-content-length = $maxContentLength
+    pekko.http.routing.decode-max-size = $decodeMaxSize
     """)
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
@@ -65,7 +65,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
         .futureValue.status shouldEqual StatusCodes.OK
     }
 
-    "not accept entities bigger than configured with akka.http.parsing.max-content-length" in {
+    "not accept entities bigger than configured with pekko.http.parsing.max-content-length" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength + 1)))
         .futureValue.status shouldEqual StatusCodes.PayloadTooLarge
     }
@@ -225,7 +225,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
 
     val binding = Http().newServerAt("localhost", port = 0).bind(route).futureValue
 
-    "accept entities bigger than configured with akka.http.parsing.max-content-length" in {
+    "accept entities bigger than configured with pekko.http.parsing.max-content-length" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/withoutSizeLimit", entityOfSize(maxContentLength + 1)))
         .futureValue.status shouldEqual StatusCodes.OK
     }

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -32,7 +32,7 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
   require(testRoot.exists(), s"testRoot was not found at ${testRoot.getAbsolutePath}")
 
   override def testConfigSource = super.testConfigSource ++ """
-    akka.http.routing.range-coalescing-threshold = 1
+    pekko.http.routing.range-coalescing-threshold = 1
   """
 
   def writeAllText(text: String, file: File): Unit =

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -128,8 +128,8 @@ class MiscDirectivesSpec extends RoutingSpec {
         responseAs[String] shouldEqual "The request content was malformed:\n" +
         "EntityStreamSizeException: incoming entity size (134) " +
         "exceeded size limit (64 bytes)! " +
-        "This may have been a parser limit (set via `akka.http.[server|client].parsing.max-content-length`), " +
-        "a decoder limit (set via `akka.http.routing.decode-max-size`), " +
+        "This may have been a parser limit (set via `pekko.http.[server|client].parsing.max-content-length`), " +
+        "a decoder limit (set via `pekko.http.routing.decode-max-size`), " +
         "or a custom limit set with `withSizeLimit`."
       }
     }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -5,7 +5,7 @@
 # This is the reference config file that contains all the default settings.
 # Make your edits/overrides in your application.conf.
 
-akka.http {
+pekko.http {
   routing {
     # Enables/disables the returning of more detailed error messages to the
     # client in the error response

--- a/http/src/main/scala/org/apache/pekko/http/impl/settings/RoutingSettingsImpl.scala
+++ b/http/src/main/scala/org/apache/pekko/http/impl/settings/RoutingSettingsImpl.scala
@@ -21,14 +21,14 @@ private[http] final case class RoutingSettingsImpl(
     decodeMaxSize: Long) extends pekko.http.scaladsl.settings.RoutingSettings {
 
   @deprecated(
-    "binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
+    "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
   override def fileIODispatcher: String = ""
 
   override def productPrefix = "RoutingSettings"
 }
 
-object RoutingSettingsImpl extends SettingsCompanionImpl[RoutingSettingsImpl]("akka.http.routing") {
+object RoutingSettingsImpl extends SettingsCompanionImpl[RoutingSettingsImpl]("pekko.http.routing") {
   def fromSubConfig(root: Config, c: Config) = new RoutingSettingsImpl(
     c.getBoolean("verbose-error-messages"),
     c.getBoolean("file-get-conditional"),

--- a/http/src/main/scala/org/apache/pekko/http/impl/settings/ServerSentEventSettingsImpl.scala
+++ b/http/src/main/scala/org/apache/pekko/http/impl/settings/ServerSentEventSettingsImpl.scala
@@ -21,7 +21,7 @@ private[http] final case class ServerSentEventSettingsImpl(
 
 }
 
-object ServerSentEventSettingsImpl extends SettingsCompanionImpl[ServerSentEventSettingsImpl]("akka.http.sse") {
+object ServerSentEventSettingsImpl extends SettingsCompanionImpl[ServerSentEventSettingsImpl]("pekko.http.sse") {
   def fromSubConfig(root: Config, c: Config) = ServerSentEventSettingsImpl(
     c.getInt("max-event-size"),
     c.getInt("max-line-size"),

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
@@ -324,7 +324,7 @@ abstract class BasicDirectives {
    * WARNING: This will read the entire request entity into memory and effectively disable streaming.
    *
    * To help protect against excessive memory use, the request will be aborted if the request is larger
-   * than allowed by the `akka.http.parsing.max-to-strict-bytes` configuration setting.
+   * than allowed by the `pekko.http.parsing.max-to-strict-bytes` configuration setting.
    *
    * Converts the HttpEntity from the [[pekko.http.javadsl.server.RequestContext]] into an
    * [[pekko.http.javadsl.model.HttpEntity.Strict]] and extracts it, or fails the route if unable to drain the
@@ -340,7 +340,7 @@ abstract class BasicDirectives {
    * WARNING: This will read the entire request entity into memory and effectively disable streaming.
    *
    * To help protect against excessive memory use, the request will be aborted if the request is larger
-   * than allowed by the `akka.http.parsing.max-to-strict-bytes` configuration setting.
+   * than allowed by the `pekko.http.parsing.max-to-strict-bytes` configuration setting.
    *
    * Converts the HttpEntity from the [[pekko.http.javadsl.server.RequestContext]] into an
    * [[pekko.http.javadsl.model.HttpEntity.Strict]] and extracts it, or fails the route if unable to drain the
@@ -357,7 +357,7 @@ abstract class BasicDirectives {
    * WARNING: This will read the entire request entity into memory and effectively disable streaming.
    *
    * To help protect against excessive memory use, the request will be aborted if the request is larger
-   * than allowed by the `akka.http.parsing.max-to-strict-bytes` configuration setting.
+   * than allowed by the `pekko.http.parsing.max-to-strict-bytes` configuration setting.
    *
    * Extracts the [[pekko.http.javadsl.server.RequestContext]] itself with the strict HTTP entity,
    * or fails the route if unable to drain the entire request body within the timeout.
@@ -372,7 +372,7 @@ abstract class BasicDirectives {
    * WARNING: This will read the entire request entity into memory and effectively disable streaming.
    *
    * To help protect against excessive memory use, the request will be aborted if the request is larger
-   * than allowed by the `akka.http.parsing.max-to-strict-bytes` configuration setting.
+   * than allowed by the `pekko.http.parsing.max-to-strict-bytes` configuration setting.
    *
    * Extracts the [[pekko.http.javadsl.server.RequestContext]] itself with the strict HTTP entity,
    * or fails the route if unable to drain the entire request body within the timeout.

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/MiscDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/MiscDirectives.scala
@@ -64,7 +64,7 @@ abstract class MiscDirectives extends MethodDirectives {
 
   /**
    * Fails the stream with [[pekko.http.scaladsl.model.EntityStreamSizeException]] if its request entity size exceeds
-   * given limit. Limit given as parameter overrides limit configured with ``akka.http.parsing.max-content-length``.
+   * given limit. Limit given as parameter overrides limit configured with ``pekko.http.parsing.max-content-length``.
    *
    * Beware that request entity size check is executed when entity is consumed.
    */
@@ -73,7 +73,7 @@ abstract class MiscDirectives extends MethodDirectives {
   }
 
   /**
-   * Disables the size limit (configured by `akka.http.parsing.max-content-length` by default) checking on the incoming
+   * Disables the size limit (configured by `pekko.http.parsing.max-content-length` by default) checking on the incoming
    * [[pekko.http.javadsl.model.HttpRequest]] entity.
    * Can be useful when handling arbitrarily large data uploads in specific parts of your routes.
    *

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
@@ -22,7 +22,7 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
   def getRangeCoalescingThreshold: Long
   def getDecodeMaxBytesPerChunk: Int
   @deprecated(
-    "binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
+    "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
   @Deprecated
   def getFileIODispatcher: String
@@ -40,7 +40,7 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
     self.copy(decodeMaxBytesPerChunk = decodeMaxBytesPerChunk)
   def withDecodeMaxSize(decodeMaxSize: Long): RoutingSettings = self.copy(decodeMaxSize = decodeMaxSize)
   @deprecated(
-    "binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
+    "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
   @Deprecated
   def withFileIODispatcher(fileIODispatcher: String): RoutingSettings = self

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectives.scala
@@ -339,7 +339,7 @@ trait BasicDirectives {
    * WARNING: This will read the entire request entity into memory and effectively disable streaming.
    *
    * To help protect against excessive memory use, the request will be aborted if the request is larger
-   * than allowed by the `akka.http.parsing.max-to-strict-bytes` configuration setting.
+   * than allowed by the `pekko.http.parsing.max-to-strict-bytes` configuration setting.
    *
    * Converts the HttpEntity from the [[pekko.http.scaladsl.server.RequestContext]] into an
    * [[pekko.http.scaladsl.model.HttpEntity.Strict]] and extracts it, or fails the route if unable to drain the
@@ -355,7 +355,7 @@ trait BasicDirectives {
    * WARNING: This will read the entire request entity into memory and effectively disable streaming.
    *
    * To help protect against excessive memory use, the request will be aborted if the request is larger
-   * than allowed by the `akka.http.parsing.max-to-strict-bytes` configuration setting.
+   * than allowed by the `pekko.http.parsing.max-to-strict-bytes` configuration setting.
    *
    * Converts the HttpEntity from the [[pekko.http.scaladsl.server.RequestContext]] into an
    * [[pekko.http.scaladsl.model.HttpEntity.Strict]] and extracts it, or fails the route if unable to drain the
@@ -371,7 +371,7 @@ trait BasicDirectives {
    * WARNING: This will read the entire request entity into memory and effectively disable streaming.
    *
    * To help protect against excessive memory use, the request will be aborted if the request is larger
-   * than allowed by the `akka.http.parsing.max-to-strict-bytes` configuration setting.
+   * than allowed by the `pekko.http.parsing.max-to-strict-bytes` configuration setting.
    *
    * Extracts the [[pekko.http.scaladsl.server.RequestContext]] itself with the strict HTTP entity,
    * or fails the route if unable to drain the entire request body within the timeout.
@@ -388,7 +388,7 @@ trait BasicDirectives {
    * WARNING: This will read the entire request entity into memory and effectively disable streaming.
    *
    * To help protect against excessive memory use, the request will be aborted if the request is larger
-   * than allowed by the `akka.http.parsing.max-to-strict-bytes` configuration setting.
+   * than allowed by the `pekko.http.parsing.max-to-strict-bytes` configuration setting.
    *
    * Extracts the [[pekko.http.scaladsl.server.RequestContext]] itself with the strict HTTP entity,
    * or fails the route if unable to drain the entire request body within the timeout.

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -37,7 +37,7 @@ trait FramedEntityStreamingDirectives extends MarshallingDirectives {
    * Cancelling extracted [[pekko.stream.scaladsl.Source]] closes the connection abruptly (same as cancelling the `entity.dataBytes`).
    *
    * See also [[MiscDirectives.withoutSizeLimit]] as you may want to allow streaming infinite streams of data in this route.
-   * By default the uploaded data is limited by the `akka.http.parsing.max-content-length`.
+   * By default the uploaded data is limited by the `pekko.http.parsing.max-content-length`.
    */
   final def asSourceOf[T](
       implicit um: FromByteStringUnmarshaller[T], support: EntityStreamingSupport): RequestToSourceUnmarshaller[T] =
@@ -56,7 +56,7 @@ trait FramedEntityStreamingDirectives extends MarshallingDirectives {
    * Cancelling extracted [[pekko.stream.scaladsl.Source]] closes the connection abruptly (same as cancelling the `entity.dataBytes`).
    *
    * See also [[MiscDirectives.withoutSizeLimit]] as you may want to allow streaming infinite streams of data in this route.
-   * By default the uploaded data is limited by the `akka.http.parsing.max-content-length`.
+   * By default the uploaded data is limited by the `pekko.http.parsing.max-content-length`.
    */
   final def asSourceOf[T](support: EntityStreamingSupport)(
       implicit um: FromByteStringUnmarshaller[T]): RequestToSourceUnmarshaller[T] =

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectives.scala
@@ -78,7 +78,7 @@ trait MiscDirectives {
 
   /**
    * Fails the stream with [[pekko.http.scaladsl.model.EntityStreamSizeException]] if its request entity size exceeds
-   * given limit. Limit given as parameter overrides limit configured with `akka.http.parsing.max-content-length`.
+   * given limit. Limit given as parameter overrides limit configured with `pekko.http.parsing.max-content-length`.
    *
    * Beware that request entity size check is executed when entity is consumed.
    *
@@ -88,7 +88,7 @@ trait MiscDirectives {
     mapRequestContext(_.mapRequest(_.mapEntity(_.withSizeLimit(maxBytes))))
 
   /**
-   * Disables the size limit (configured by `akka.http.parsing.max-content-length` by default) checking on the incoming
+   * Disables the size limit (configured by `pekko.http.parsing.max-content-length` by default) checking on the incoming
    * [[HttpRequest]] entity.
    * Can be useful when handling arbitrarily large data uploads in specific parts of your routes.
    *

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettings.scala
@@ -23,7 +23,7 @@ abstract class RoutingSettings private[pekko] () extends pekko.http.javadsl.sett
   def decodeMaxBytesPerChunk: Int
   def decodeMaxSize: Long
   @deprecated(
-    "binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
+    "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
   def fileIODispatcher: String
 
@@ -36,7 +36,7 @@ abstract class RoutingSettings private[pekko] () extends pekko.http.javadsl.sett
   def getDecodeMaxBytesPerChunk: Int = decodeMaxBytesPerChunk
   def getDecodeMaxSize: Long = decodeMaxSize
   @deprecated(
-    "binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
+    "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
   @Deprecated
   def getFileIODispatcher: String = fileIODispatcher
@@ -54,7 +54,7 @@ abstract class RoutingSettings private[pekko] () extends pekko.http.javadsl.sett
     self.copy(decodeMaxBytesPerChunk = decodeMaxBytesPerChunk)
   override def withDecodeMaxSize(decodeMaxSize: Long): RoutingSettings = self.copy(decodeMaxSize = decodeMaxSize)
   @deprecated(
-    "binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
+    "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
   @Deprecated
   override def withFileIODispatcher(fileIODispatcher: String): RoutingSettings = self

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamUnmarshalling.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamUnmarshalling.scala
@@ -23,8 +23,8 @@ import pekko.stream.scaladsl.{ Keep, Source }
  * unmarshalled to a source of [[ServerSentEvent]]s.
  *
  * The maximum size for parsing server-sent events is 8KiB. The maximum size for parsing lines of a server-sent event
- * is 4KiB. If you need to customize any of these, set the `akka.http.sse.max-event-size` and
- * `akka.http.sse.max-line-size` properties respectively.
+ * is 4KiB. If you need to customize any of these, set the `pekko.http.sse.max-event-size` and
+ * `pekko.http.sse.max-line-size` properties respectively.
  */
 @ApiMayChange
 object EventStreamUnmarshalling extends EventStreamUnmarshalling
@@ -34,8 +34,8 @@ object EventStreamUnmarshalling extends EventStreamUnmarshalling
  * [[ServerSentEvent]]s.
  *
  * The maximum size for parsing server-sent events is 8KiB by default and can be customized by configuring
- * `akka.http.sse.max-event-size`. The maximum size for parsing lines of a server-sent event is 4KiB by
- * default and can be customized by configuring `akka.http.sse.max-line-size`.
+ * `pekko.http.sse.max-event-size`. The maximum size for parsing lines of a server-sent event is 4KiB by
+ * default and can be customized by configuring `pekko.http.sse.max-line-size`.
  */
 @ApiMayChange
 trait EventStreamUnmarshalling {
@@ -44,7 +44,7 @@ trait EventStreamUnmarshalling {
    * The maximum size for parsing lines of a server-sent event; 4KiB by default.
    */
   @deprecated(
-    "Set this property in configuration as `akka.http.sse.max-line-size` before calling fromEventsStream(implicit ActorSystem)",
+    "Set this property in configuration as `pekko.http.sse.max-line-size` before calling fromEventsStream(implicit ActorSystem)",
     "Akka HTTP 10.1.8")
   protected def maxLineSize: Int = 4096
 
@@ -52,7 +52,7 @@ trait EventStreamUnmarshalling {
    * The maximum size for parsing server-sent events; 8KiB by default.
    */
   @deprecated(
-    "Set this property in configuration as `akka.http.sse.max-event-size` before calling fromEventsStream(implicit ActorSystem)",
+    "Set this property in configuration as `pekko.http.sse.max-event-size` before calling fromEventsStream(implicit ActorSystem)",
     "Akka HTTP 10.1.8")
   protected def maxEventSize: Int = 8192
 

--- a/http2-tests/src/test/java/org/apache/pekko/http/javadsl/Http2JavaServerTest.java
+++ b/http2-tests/src/test/java/org/apache/pekko/http/javadsl/Http2JavaServerTest.java
@@ -25,7 +25,7 @@ public class Http2JavaServerTest {
       "pekko.actor.serialize-messages = off\n" +
       "#pekko.actor.default-dispatcher.throughput = 1000\n" +
       "pekko.actor.default-dispatcher.fork-join-executor.parallelism-max=8\n" +
-      "akka.http.server.preview.enable-http2 = on\n"
+      "pekko.http.server.preview.enable-http2 = on\n"
     );
     ActorSystem system = ActorSystem.create("ServerTest", testConf);
 

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -25,15 +25,15 @@ class H2SpecIntegrationSpec extends PekkoSpec(
      pekko {
        loglevel = DEBUG
        loggers = ["org.apache.pekko.http.impl.util.SilenceAllTestEventListener"]
+       http.server.log-unencrypted-network-bytes = 100
+       http.server.preview.enable-http2 = on
+       http.server.http2.log-frames = on
 
        actor.serialize-creators = off
        actor.serialize-messages = off
 
        stream.materializer.debug.fuzzing-mode = off
      }
-     akka.http.server.log-unencrypted-network-bytes = 100
-     akka.http.server.preview.enable-http2 = on
-     akka.http.server.http2.log-frames = on
   """) with Directives with ScalaFutures with WithLogCapturing {
 
   implicit val ec: ExecutionContext = system.dispatcher

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2cUpgradeSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2cUpgradeSpec.scala
@@ -18,8 +18,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class H2cUpgradeSpec extends PekkoSpecWithMaterializer("""
-    akka.http.server.preview.enable-http2 = on
-    akka.http.server.http2.log-frames = on
+    pekko.http.server.preview.enable-http2 = on
+    pekko.http.server.http2.log-frames = on
   """) {
 
   override implicit val patience = PatienceConfig(5.seconds, 5.seconds)

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientServerSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientServerSpec.scala
@@ -40,12 +40,12 @@ import scala.concurrent.duration._
 import scala.concurrent.{ Future, Promise }
 
 class Http2ClientServerSpec extends PekkoSpecWithMaterializer(
-      """akka.http.server.remote-address-header = on
-     akka.http.server.http2.log-frames = on
-     akka.http.server.log-unencrypted-network-bytes = 100
-     akka.http.server.preview.enable-http2 = on
-     akka.http.client.http2.log-frames = on
-     akka.http.client.log-unencrypted-network-bytes = 100
+      """pekko.http.server.remote-address-header = on
+     pekko.http.server.http2.log-frames = on
+     pekko.http.server.log-unencrypted-network-bytes = 100
+     pekko.http.server.preview.enable-http2 = on
+     pekko.http.client.http2.log-frames = on
+     pekko.http.client.log-unencrypted-network-bytes = 100
      pekko.actor.serialize-messages = false
   """) with ScalaFutures {
   override protected def failOnSevereMessages: Boolean = true

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
@@ -63,9 +63,9 @@ import scala.concurrent.duration._
  * * validate the produced application-level responses
  */
 class Http2ClientSpec extends PekkoSpecWithMaterializer("""
-    akka.http.client.remote-address-header = on
-    akka.http.client.http2.log-frames = on
-    akka.http.client.http2.completion-timeout = 500ms
+    pekko.http.client.remote-address-header = on
+    pekko.http.client.http2.log-frames = on
+    pekko.http.client.http2.completion-timeout = 500ms
   """)
     with WithInPendingUntilFixed with Eventually {
 
@@ -916,7 +916,7 @@ class Http2ClientSpec extends PekkoSpecWithMaterializer("""
         user.requestOut.sendComplete()
 
         // The streams is on hold until stream '3' finishes...
-        // 400 millis is slightly less than the value of "akka.http.client.http2.completion-timeout"
+        // 400 millis is slightly less than the value of "pekko.http.client.http2.completion-timeout"
         user.responseIn.expectNoMessage(400.millis)
 
         // Eventually, completion happens after a timeout

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2PersistentClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2PersistentClientSpec.scala
@@ -50,14 +50,14 @@ class Http2PersistentClientPlaintextSpec extends Http2PersistentClientSpec(false
 abstract class Http2PersistentClientSpec(tls: Boolean) extends PekkoSpecWithMaterializer(
       // FIXME: would rather use remote-address-attribute, but that doesn't work with HTTP/2
       // see https://github.com/apache/incubator-pekko-http/issues/3707
-      """akka.http.server.remote-address-attribute = on
-     akka.http.server.preview.enable-http2 = on
-     akka.http.client.http2.log-frames = on
-     akka.http.client.http2.max-persistent-attempts = 5
-     akka.http.client.log-unencrypted-network-bytes = 100
+      """pekko.http.server.remote-address-attribute = on
+     pekko.http.server.preview.enable-http2 = on
+     pekko.http.client.http2.log-frames = on
+     pekko.http.client.http2.max-persistent-attempts = 5
+     pekko.http.client.log-unencrypted-network-bytes = 100
      pekko.actor.serialize-messages = false
-     akka.http.server.http2.completion-timeout=100ms
-     akka.http.client.http2.completion-timeout=100ms
+     pekko.http.server.http2.completion-timeout=100ms
+     pekko.http.client.http2.completion-timeout=100ms
   """) with ScalaFutures {
   override def failOnSevereMessages: Boolean = true
   private val notSevere = Set("ChannelReadable", "WriteAck")

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDemuxSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDemuxSpec.scala
@@ -19,8 +19,8 @@ import scala.collection.immutable.Seq
  * low-level tests testing Http2ServerDemux in isolation
  */
 class Http2ServerDemuxSpec extends PekkoSpecWithMaterializer("""
-    akka.http.server.remote-address-header = on
-    akka.http.server.http2.log-frames = on
+    pekko.http.server.remote-address-header = on
+    pekko.http.server.http2.log-frames = on
     pekko.stream.materializer.debug.fuzzing-mode = on
   """) {
   "Http2ServerDemux" should {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
@@ -55,8 +55,8 @@ import scala.concurrent.Promise
  * * validate the produced response frames
  */
 class Http2ServerSpec extends PekkoSpecWithMaterializer("""
-    akka.http.server.remote-address-header = on
-    akka.http.server.http2.log-frames = on
+    pekko.http.server.remote-address-header = on
+    pekko.http.server.http2.log-frames = on
   """)
     with WithInPendingUntilFixed with Eventually {
   override def failOnSevereMessages: Boolean = true

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/TelemetrySpiSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/TelemetrySpiSpec.scala
@@ -56,9 +56,9 @@ class TelemetrySpiCypherSpec extends TelemetrySpiSpec(true)
 
 abstract class TelemetrySpiSpec(useTls: Boolean) extends PekkoSpecWithMaterializer(
       """
-     akka.http.server.preview.enable-http2 = on
+     pekko.http.server.preview.enable-http2 = on
      pekko.actor.serialize-messages = false
-     akka.http.http2-telemetry-class = "org.apache.pekko.http.impl.engine.http2.TestTelemetryImpl"
+     pekko.http.http2-telemetry-class = "org.apache.pekko.http.impl.engine.http2.TestTelemetryImpl"
   """) with ScalaFutures with BeforeAndAfterAll {
 
   case class RequestId(id: String) extends RequestResponseAssociation
@@ -239,7 +239,7 @@ abstract class TelemetrySpiSpec(useTls: Boolean) extends PekkoSpecWithMaterializ
       val system = ActorSystem(s"${getClass.getSimpleName}-noImplFound",
         ConfigFactory.parseString(
           s"""
-            akka.http.http2-telemetry-class = no.such.Clazz
+            pekko.http.http2-telemetry-class = no.such.Clazz
           """))
       try {
         TelemetrySpi.create(system) should ===(NoOpTelemetry)

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
@@ -18,8 +18,8 @@ import pekko.util.ByteString
 import scala.concurrent.Future
 
 class WithPriorKnowledgeSpec extends PekkoSpecWithMaterializer("""
-    akka.http.server.preview.enable-http2 = on
-    akka.http.server.http2.log-frames = on
+    pekko.http.server.preview.enable-http2 = on
+    pekko.http.server.http2.log-frames = on
   """) {
 
   "An HTTP server with PriorKnowledge" should {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/scaladsl/Http2ServerTest.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/scaladsl/Http2ServerTest.scala
@@ -34,7 +34,7 @@ object Http2ServerTest extends App {
     pekko.actor.serialize-messages = off
     #pekko.actor.default-dispatcher.throughput = 1000
     pekko.actor.default-dispatcher.fork-join-executor.parallelism-max=8
-    akka.http.server.preview.enable-http2 = true
+    pekko.http.server.preview.enable-http2 = true
                                                    """)
   implicit val system = ActorSystem("ServerTest", testConf)
   implicit val ec: ExecutionContext = system.dispatcher


### PR DESCRIPTION
The PR changes the `akka` typesafe config prefix to `pekko`. It also recombines the configs in `H2SpecIntegrationSpec` and `DontLeakActorsOnFailingConnectionSpecs` which had to be split out in https://github.com/apache/incubator-pekko-http/pull/34 in order not to break `main`. Paradox docs have also been updated.

Note that this PR does update the `akka` prefix for system properties/environment variables that are used in tests (that should be done in a separate PR).

Resolves: https://github.com/apache/incubator-pekko-http/issues/25