### PR TITLE
make sure that no pekko version specified to build against is same as "default"

### DIFF
--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -45,9 +45,8 @@ object PekkoDependency {
             // (typically for the docs that require 2.6)
             if (defaultVersion.startsWith("1.0")) Artifact(determineLatestSnapshot("0.0.0"), true)
             else Artifact(defaultVersion)
-          case Some("default") => Artifact(defaultVersion)
-          case Some(other)     => Artifact(other, true)
-          case None            =>
+          case Some(other)            => Artifact(other, true)
+          case Some("default") | None =>
             // TODO: Revert to Artifact(defaultVersion) when release of Pekko is made
             mainSnapshot
         }

--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -48,7 +48,7 @@ object PekkoDependency {
           case Some("default") | None =>
             // TODO: Revert to Artifact(defaultVersion) when release of Pekko is made
             mainSnapshot
-          case Some(other)            => Artifact(other, true)
+          case Some(other) => Artifact(other, true)
         }
     }
   }

--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -45,10 +45,10 @@ object PekkoDependency {
             // (typically for the docs that require 2.6)
             if (defaultVersion.startsWith("1.0")) Artifact(determineLatestSnapshot("0.0.0"), true)
             else Artifact(defaultVersion)
-          case Some(other)            => Artifact(other, true)
           case Some("default") | None =>
             // TODO: Revert to Artifact(defaultVersion) when release of Pekko is made
             mainSnapshot
+          case Some(other)            => Artifact(other, true)
         }
     }
   }


### PR DESCRIPTION
That fixes the nightly tests which only accidentally worked before and when fixing the akka->pekko prefix in f47c735e20d62fa58ce81e43cb4f5d82a1c9272b broke because "default" started to refer to pekko 1.0.0 which is not yet released.