### PR TITLE
use sbt-hackers-digest

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -36,6 +36,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
+addSbtPlugin("net.virtual-void" % "sbt-hackers-digest" % "0.1.2")
 
 // used in ValidatePullRequest to check github PR comments whether to build all subprojects
 libraryDependencies += "org.kohsuke" % "github-api" % "1.306"


### PR DESCRIPTION
This is a new plugin I'm working on. It will annotate compilation errors, warnings, and test failures on
the relevant files in Github Actions.

I added a test failure to show the result here.