### PR TITLE
update to Scala 2.13.10

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala
@@ -125,7 +125,7 @@ class JsonStreamingExamplesSpec extends RoutingSpec with CompileOnlySpec {
       Marshalling.WithFixedContentType(ContentTypes.`text/csv(UTF-8)`,
         () => {
           val txt = t.txt.replaceAll(",", ".")
-          val uid = t.uid
+          val uid = t.uid.toString
           ByteString(List(uid, txt).mkString(","))
         })
     }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -25,18 +25,16 @@ object Common extends AutoPlugin {
     scalacOptions ++= Seq(
       "-deprecation",
       "-encoding", "UTF-8", // yes, this is 2 args
-      "-target:jvm-1.8",
       "-unchecked",
       "-Xlint",
       "-Ywarn-dead-code",
       // Silence deprecation notices for changes introduced in Scala 2.12
       // Can be removed when we drop support for Scala 2.12:
       "-Wconf:msg=object JavaConverters in package collection is deprecated:s",
-      "-Wconf:msg=is deprecated \\(since 2\\.13\\.:s"),
-    // '-release' parameter is restricted to 'Compile, compile' scope because
-    // otherwise `sbt pekko-http-xml/compile:doc` fails with it on Scala 2.12.9
-    Compile / compile / scalacOptions ++=
-      onlyAfterScala212(onlyAfterJdk8("-release", "8")).value,
+      "-Wconf:msg=is deprecated \\(since 2\\.13\\.:s") ++
+    (if (isJdk8) Seq.empty
+     else if (scalaBinaryVersion.value == "2.12") Seq("-target:jvm-1.8")
+     else Seq("-release", "8")),
     javacOptions ++=
       Seq("-encoding", "UTF-8") ++ onlyOnJdk8("-source", "1.8") ++ onlyAfterJdk8("--release", "8"),
     // restrict to 'compile' scope because otherwise it is also passed to

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   val scalafixVersion = _root_.scalafix.sbt.BuildInfo.scalafixVersion // grab from plugin
 
   val scala212Version = "2.12.15"
-  val scala213Version = "2.13.8"
+  val scala213Version = "2.13.10"
   val allScalaVersions = Seq(scala213Version, scala212Version)
 
   val Versions = Seq(


### PR DESCRIPTION
Recent Scala 2.13 versions deprecated the -target option which then fails the docs module compilation which has warnings as errors.

(Extracted from #81 because it was more complicated than expected)