### PR TITLE
Add Apache to POM licenses field by updating sbt-apache-sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ inThisBuild(Def.settings(
   },
   scmInfo := Some(
     ScmInfo(url("https://github.com/apache/incubator-pekko-http"), "git@github.com:apache/incubator-pekko-http.git")),
-  licenses := Seq("Apache-2.0" -> url("https://opensource.org/licenses/Apache-2.0")),
   description := "Apache Pekko Http: Modern, fast, asynchronous, streaming-first HTTP server and client.",
   testOptions ++= Seq(
     Tests.Argument(TestFrameworks.JUnit, "-q", "-v"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -34,7 +34,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.1")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.4")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 
 // used in ValidatePullRequest to check github PR comments whether to build all subprojects


### PR DESCRIPTION
self explanatory, confirmed it works locally i.e.

```
pekko-http > licenses
[info] http-caching / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-jackson / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-marshallers-java / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-spray-json / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-xml / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-marshallers-scala / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] bill-of-materials / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-bench-jmh / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-core / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-tests / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] parsing / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-scalafix-rules / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http2-tests / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] http-testkit / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] docs / licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
[info] licenses
[info]  List((Apache-2.0,https://www.apache.org/licenses/LICENSE-2.0.html))
```
