### PR TITLE
Update sbt-apache-sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,6 @@ import com.lightbend.paradox.apidoc.ApidocPlugin.autoImport.apidocRootPackage
 
 sourceDistName := "incubator-pekko-http"
 inThisBuild(Def.settings(
-  organization := "org.apache.pekko",
   apiURL := {
     val apiVersion = if (isSnapshot.value) "current" else version.value
     Some(url(s"https://pekko.apache.org/api/pekko-http/$apiVersion/"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,7 +33,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.4")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.5")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 addSbtPlugin("net.virtual-void" % "sbt-hackers-digest" % "0.1.2")
 


### PR DESCRIPTION
Updates to the latest version of sbt-apache-sonatype. Note that the `organization` value is no longer required, sbt-apache-sonatype handles this for you now.