### PR TITLE
Undo removal of doc ForkJoinPool mention

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -405,6 +405,8 @@ lazy val docs = project("docs")
       "jackson.xml.version" -> Dependencies.jacksonXmlVersion,
       "scalafix.version" -> _root_.scalafix.sbt.BuildInfo.scalafixVersion, // grab from scalafix plugin directly
       "extref.pekko-docs.base_url" -> s"https://pekko.apache.org/docs/pekko/current/%s",
+      "javadoc.java.base_url" -> "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/",
+      "javadoc.java.link_style" -> "direct",
       "javadoc.org.apache.pekko.base_url" -> s"https://pekko.apache.org/japi/pekko/${PekkoDependency.docs.link}",
       "javadoc.org.apache.pekko.link_style" -> "direct",
       "scaladoc.org.apache.pekko.base_url" -> s"https://pekko.apache.org/api/pekko/${PekkoDependency.docs.link}",

--- a/docs/src/main/paradox/handling-blocking-operations-in-pekko-http-routes.md
+++ b/docs/src/main/paradox/handling-blocking-operations-in-pekko-http-routes.md
@@ -66,6 +66,7 @@ For example, the above screenshot shows an Apache Pekko FJP dispatchers threads,
 named "`default-akka.default-dispatcher2,3,4`" going into the blocking state, after having been idle. 
 It can be observed that the number of new threads increases, "`default-akka.actor.default-dispatcher 18,19,20,...`" 
 however they go to sleep state immediately, thus wasting the resources.
+@java[The same happens to the global @javadoc[ForkJoinPool](java.util.concurrent.ForkJoinPool) when using Java Futures.]
 
 The number of such new threads depends on the default dispatcher configuration,
 but it will likely not exceed 50. Since many POST requests are being processed, the entire


### PR DESCRIPTION
Resolves:  https://github.com/apache/incubator-pekko-http/issues/42

I believe the original use of `@apidoc` was an oversight that just happened to work due to shadowing of package names, judging from what the text is saying I am quite sure its meant to be referring to `java.util.concurrent.ForkJoinPool` in which case direct linking to an external javadoc using `@javadoc` is what should be used.

I checked locally and the docs are render'ing as expected and I can confirm the link works (its `ForkJoinPool` is linking to https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ForkJoinPool.html)