### PR TITLE
run full validation when github workflows change

### DIFF
--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -111,7 +111,7 @@ object ValidatePullRequest extends AutoPlugin {
   val additionalTasks = settingKey[Seq[TaskKey[_]]]("Additional tasks for pull request validation")
 
   // The set of (top-level) files or directories to watch for build changes.
-  val BuildFilesAndDirectories = Set("project", "build.sbt", ".github/workflows")
+  val BuildFilesAndDirectories = Set("project", "build.sbt", ".github")
 
   def changedDirectoryIsDependency(changedDirs: Set[String], name: String,
       graphsToTest: Seq[(Configuration, ModuleGraph)])(log: Logger): Boolean = {


### PR DESCRIPTION
To make sure that changes to the validation task really run all tests.