### PR TITLE
add scala-collection-compat to license/notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -211,6 +211,6 @@ Copyright 2014 Twitter, Inc.
 ---------------
 
 pekko-http-core contains code from scala-collection-compat in the `org.apache.pekko.http.ccompat` package
-which has written by the Scala-Lang team under an Apache 2.0 license.
+distributed under the Apache 2.0 license.
 Copyright (c) 2002-2023 EPFL
 Copyright (c) 2011-2023 Lightbend, Inc.

--- a/LICENSE
+++ b/LICENSE
@@ -207,3 +207,10 @@ pekko-http-core contains the sources of Twitter HPACK runtime support,
 moved into the source package `org.apache.pekko.http.shaded.com.twitter.hpack`
 so as to avoid version conflicts. This code is under an Apache 2.0 license.
 Copyright 2014 Twitter, Inc.
+
+---------------
+
+pekko-http-core contains code from scala-collection-compat in the `org.apache.pekko.http.ccompat` package
+which has written by the Scala-Lang team under an Apache 2.0 license.
+Copyright (c) 2002-2023 EPFL
+Copyright (c) 2011-2023 Lightbend, Inc.

--- a/NOTICE
+++ b/NOTICE
@@ -12,8 +12,7 @@ Apache License, Version 2.0 License.
 
 ---------------
 
-pekko-http-core contains code from scala-collection-compat which has changes made by the Scala-Lang team
-under an Apache 2.0 license.
+pekko-http-core contains code from scala-collection-compat distributed under the Apache 2.0 license.
 
 scala-collection-compat
 Copyright (c) 2002-2023 EPFL

--- a/legal/PekkoNotice.txt
+++ b/legal/PekkoNotice.txt
@@ -9,16 +9,3 @@ Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
 
 Apache Pekko-HTTP is derived from Akka-HTTP 10.2.x, the last version that was distributed under the
 Apache License, Version 2.0 License.
-
----------------
-
-pekko-http-core contains code from scala-collection-compat which has changes made by the Scala-Lang team
-under an Apache 2.0 license.
-
-scala-collection-compat
-Copyright (c) 2002-2023 EPFL
-Copyright (c) 2011-2023 Lightbend, Inc.
-
-Scala includes software developed at
-LAMP/EPFL (https://lamp.epfl.ch/) and
-Lightbend, Inc. (https://www.lightbend.com/).

--- a/project/AddMetaInfLicenseFiles.scala
+++ b/project/AddMetaInfLicenseFiles.scala
@@ -23,13 +23,15 @@ object AddMetaInfLicenseFiles extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     apacheSonatypeLicenseFile := baseDir.value / "legal" / "StandardLicense.txt",
+    apacheSonatypeNoticeFile := baseDir.value / "legal" / "PekkoNotice.txt",
     apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))
 
   /**
    * Settings specific for Pekko http-core subproject which require a different license file.
    */
   lazy val httpCoreSettings = Seq(
-    apacheSonatypeLicenseFile := baseDir.value / "LICENSE")
+    apacheSonatypeLicenseFile := baseDir.value / "LICENSE",
+    apacheSonatypeNoticeFile := baseDir.value / "NOTICE")
 
   override def trigger = allRequirements
 


### PR DESCRIPTION
* relates to #101 
* among our jars, only pekko-http-core needs additional text in license/notice
* all other jars built from this repo, will get the basic Apache license and the basic Pekko notice
