### PR TITLE
Freeze Pekko Snapshot

### DIFF
--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -59,7 +59,8 @@ object PekkoDependency {
   val minimumExpectedPekko26Version = "1.0.0"
   val docs = pekkoDependency(defaultVersion = minimumExpectedPekko26Version)
 
-  lazy val mainSnapshot = Artifact(determineLatestSnapshot("0.0.0"), true)
+  // TODO: Revert to Artifact(determineLatestSnapshot(...), true) when Pekko has its first release
+  lazy val mainSnapshot = Artifact("0.0.0+26623-85c2a469-SNAPSHOT", true)
 
   val pekkoVersion: String = default match {
     case Artifact(version, _) => version


### PR DESCRIPTION
Rather than using a static version for a snapshot, Pekko Http currently has code that tries to determine the latest snapshot version automatically by querying the snapshot repo (see https://github.com/apache/incubator-pekko-http/blob/main/project/PekkoDependency.scala#L100-L126). While this approach is a qol improvement when you are trying to work with Pekko http locally against some latest pekko snapshot, not having pekko-http release with a frozen version of a pekko snapshot is causing issues due to Pekko behaviour of not mixing different pekko core artifacts (which it inherited from Akka), i.e.

```
[error] Caused by: java.lang.IllegalStateException: You are using version 0.0.0+26623-85c2a469-SNAPSHOT of Apache Pekko, but it appears you (perhaps indirectly) also depend on older versions of related artifacts. You can solve this by adding an explicit dependency on version 0.0.0+26623-85c2a469-SNAPSHOT of the [pekko-persistence] artifacts to your project. Here's a complete collection of detected artifacts: (0.0.0+26599-83545a33-SNAPSHOT, [pekko-persistence]), (0.0.0+26623-85c2a469-SNAPSHOT, [pekko-actor, pekko-actor-testkit-typed, pekko-actor-typed, pekko-cluster, pekko-cluster-sharding, pekko-cluster-sharding-typed, pekko-cluster-tools, pekko-cluster-typed, pekko-coordination, pekko-distributed-data, pekko-persistence-query, pekko-persistence-typed, pekko-pki, pekko-protobuf-v3, pekko-remote, pekko-serialization-jackson, pekko-slf4j, pekko-stream, pekko-stream-testkit, pekko-stream-typed, pekko-testkit]). See also: https://pekko.apache.org/docs/pekko/current/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed
```
from https://github.com/apache/incubator-pekko-projection/actions/runs/4518596146/jobs/7958565828?pr=19.

This PR freezes the snapshot version of pekko core that pekko http resolves so that its possible to guarantee that the exact same version of pekko core is currently used within our ecosystem.