### PR TITLE
Apply compat changes from latest Pekko

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/server/directives/FileUploadDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FileUploadDirectivesExamplesTest.java
@@ -39,8 +39,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import static scala.compat.java8.JFunction.func;
-
 //#storeUploadedFile
 import static org.apache.pekko.http.javadsl.server.Directives.complete;
 import static org.apache.pekko.http.javadsl.server.Directives.storeUploadedFile;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.pekko.http.javadsl.server.PathMatchers.*;
-import static scala.compat.java8.JFunction.func;
 
 //#onComplete
 import static org.apache.pekko.http.javadsl.server.Directives.complete;
@@ -60,14 +59,13 @@ public class FutureDirectivesExamplesTest extends JUnitRouteTest {
     @Test
     public void testOnComplete() {
         //#onComplete
-        // import static scala.compat.java8.JFunction.func;
         // import static org.apache.pekko.http.javadsl.server.PathMatchers.*;
 
         final Route route = path(segment("divide").slash(integerSegment()).slash(integerSegment()),
                 (a, b) -> onComplete(
                         () -> CompletableFuture.supplyAsync(() -> a / b),
                         maybeResult -> maybeResult
-                                .map(func(result -> complete("The result was " + result)))
+                                .map(result -> complete("The result was " + result))
                                 .recover(new PFBuilder<Throwable, Route>()
                                         .matchAny(ex -> complete(StatusCodes.InternalServerError(),
                                                 "An error occurred: " + ex.getMessage())
@@ -154,7 +152,7 @@ public class FutureDirectivesExamplesTest extends JUnitRouteTest {
                 (a, b) -> onCompleteWithBreaker(breaker,
                         () -> CompletableFuture.supplyAsync(() -> a / b),
                         maybeResult -> maybeResult
-                                .map(func(result -> complete("The result was " + result)))
+                                .map(result -> complete("The result was " + result))
                                 .recover(new PFBuilder<Throwable, Route>()
                                         .matchAny(ex -> complete(StatusCodes.InternalServerError(),
                                                 "An error occurred: " + ex.toString())

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
@@ -29,8 +29,8 @@ import pekko.http.caching.scaladsl.Cache
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.caching.CacheJavaMapping.Implicits._
 
-import scala.compat.java8.FutureConverters._
-import scala.compat.java8.FunctionConverters._
+import pekko.util.FutureConverters._
+import pekko.util.FunctionConverters._
 
 @ApiMayChange
 object LfuCache {
@@ -102,20 +102,20 @@ object LfuCache {
   }
 
   def toJavaMappingFunction[K, V](genValue: () => Future[V]): BiFunction[K, Executor, CompletableFuture[V]] =
-    asJavaBiFunction[K, Executor, CompletableFuture[V]]((k, e) => genValue().toJava.toCompletableFuture)
+    ((_: K, _: Executor) => genValue().asJava.toCompletableFuture: CompletableFuture[V]).asJava
 
   def toJavaMappingFunction[K, V](loadValue: K => Future[V]): BiFunction[K, Executor, CompletableFuture[V]] =
-    asJavaBiFunction[K, Executor, CompletableFuture[V]]((k, e) => loadValue(k).toJava.toCompletableFuture)
+    ((k: K, _: Executor) => loadValue(k).asJava.toCompletableFuture: CompletableFuture[V]).asJava
 }
 
 /** INTERNAL API */
 @InternalApi
 private[caching] class LfuCache[K, V](val store: AsyncCache[K, V]) extends Cache[K, V] {
 
-  def get(key: K): Option[Future[V]] = Option(store.getIfPresent(key)).map(_.toScala)
+  def get(key: K): Option[Future[V]] = Option(store.getIfPresent(key)).map(_.asScala)
 
   def apply(key: K, genValue: () => Future[V]): Future[V] =
-    store.get(key, toJavaMappingFunction[K, V](genValue)).toScala
+    store.get(key, toJavaMappingFunction[K, V](genValue)).asScala
 
   /**
    * Multiple call to put method for the same key may result in a race condition,
@@ -126,17 +126,17 @@ private[caching] class LfuCache[K, V](val store: AsyncCache[K, V]) extends Cache
 
     previouslyCacheValue match {
       case None =>
-        store.put(key, toJava(mayBeValue).toCompletableFuture)
+        store.put(key, mayBeValue.asJava.toCompletableFuture)
         mayBeValue
       case _ => mayBeValue.map { value =>
-          store.put(key, toJava(Future.successful(value)).toCompletableFuture)
+          store.put(key, Future.successful(value).asJava.toCompletableFuture)
           value
         }
     }
   }
 
   def getOrLoad(key: K, loadValue: K => Future[V]): Future[V] =
-    store.get(key, toJavaMappingFunction[K, V](loadValue)).toScala
+    store.get(key, toJavaMappingFunction[K, V](loadValue)).asScala
 
   def remove(key: K): Unit = store.synchronous().invalidate(key)
 

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/Cache.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/Cache.scala
@@ -19,10 +19,10 @@ import java.util.concurrent.{ CompletableFuture, CompletionStage }
 import org.apache.pekko
 import pekko.annotation.{ ApiMayChange, DoNotInherit }
 import pekko.japi.{ Creator, Procedure }
+import pekko.util.FutureConverters._
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.compat.java8.FutureConverters.{ toJava => futureToJava, toScala => futureToScala }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 
 /**
@@ -66,7 +66,7 @@ abstract class Cache[K, V] extends pekko.http.caching.javadsl.Cache[K, V] {
    */
   def get(key: K): Option[Future[V]]
   override def getOptional(key: K): Optional[CompletionStage[V]] =
-    Optional.ofNullable(get(key).map(f => futureToJava(f)).orNull)
+    Optional.ofNullable(get(key).map(f => f.asJava).orNull)
 
   /**
    * Cache the given future if not cached previously.
@@ -96,21 +96,21 @@ abstract class Cache[K, V] extends pekko.http.caching.javadsl.Cache[K, V] {
   override def getKeys: java.util.Set[K] = keys.asJava
 
   final override def getFuture(key: K, genValue: Creator[CompletionStage[V]]): CompletionStage[V] =
-    futureToJava(apply(key, () => futureToScala(genValue.create())))
+    apply(key, () => genValue.create().asScala).asJava
 
   final override def getOrFulfil(key: K, f: Procedure[CompletableFuture[V]]): CompletionStage[V] =
-    futureToJava(apply(key,
+    apply(key,
       promise => {
         val completableFuture = new CompletableFuture[V]
         f(completableFuture)
-        promise.completeWith(futureToScala(completableFuture))
-      }))
+        promise.completeWith(completableFuture.asScala)
+      }).asJava
 
   /**
    * Returns either the cached CompletionStage for the given key or the given value as a CompletionStage
    */
   override def getOrCreateStrict(key: K, block: Creator[V]): CompletionStage[V] =
-    futureToJava(get(key, () => block.create()))
+    get(key, () => block.create()).asJava
 
   /**
    * Returns the upper bound for the number of currently cached entries.

--- a/http-core/src/main/java/org/apache/pekko/http/impl/util/Util.java
+++ b/http-core/src/main/java/org/apache/pekko/http/impl/util/Util.java
@@ -13,16 +13,18 @@
 
 package org.apache.pekko.http.impl.util;
 
-import scala.compat.java8.OptionConverters;
 import scala.None$;
 import scala.collection.immutable.Map$;
 import scala.collection.immutable.Seq;
 import org.apache.pekko.stream.scaladsl.Source;
 import org.apache.pekko.http.ccompat.MapHelpers;
+import org.apache.pekko.util.OptionConverters;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 /**
  * Contains internal helper methods.
@@ -50,6 +52,26 @@ public abstract class Util {
     @SuppressWarnings("unchecked") // contains an upcast
     public static <T, U extends T> scala.Option<U> convertOptionalToScala(Optional<T> o) {
         return OptionConverters.toScala((Optional<U>) o);
+    }
+
+    // This is needed to be used in Java source code that calls Scala code which expects scala.Long
+    // since an implicit cast from java.lang.Long to scala.Long is not available in Java source
+    public static scala.Option<Object> convertOptionalToScala(OptionalLong o) {
+        if (o.isPresent()) {
+            return new scala.Some(o.getAsLong());
+        } else {
+            return scala.Option.empty();
+        }
+    }
+
+    // This is needed to be used in Java source code that calls Scala code which expects scala.Int
+    // since an implicit cast from java.lang.Int to scala.Int is not available in Java source
+    public static scala.Option<Object> convertOptionalToScala(OptionalInt o) {
+        if (o.isPresent()) {
+            return new scala.Some(o.getAsInt());
+        } else {
+            return scala.Option.empty();
+        }
     }
 
     public static final scala.collection.immutable.Map<String, String> emptyMap =

--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/ContentRange.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/ContentRange.java
@@ -17,7 +17,7 @@ import org.apache.pekko.http.scaladsl.model.ContentRange$;
 
 import java.util.Optional;
 import java.util.OptionalLong;
-import scala.compat.java8.OptionConverters;
+import org.apache.pekko.http.impl.util.Util;
 
 public abstract class ContentRange {
     public abstract boolean isByteContentRange();
@@ -39,7 +39,7 @@ public abstract class ContentRange {
     }
     @SuppressWarnings("unchecked")
     public static ContentRange create(long first, long last, OptionalLong instanceLength) {
-        return ContentRange$.MODULE$.apply(first, last, OptionConverters.toScala(instanceLength));
+        return ContentRange$.MODULE$.apply(first, last, Util.convertOptionalToScala(instanceLength));
     }
     public static ContentRange createUnsatisfiable(long length) {
         return new org.apache.pekko.http.scaladsl.model.ContentRange.Unsatisfiable(length);

--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/RemoteAddress.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/RemoteAddress.java
@@ -18,7 +18,7 @@ import java.net.InetSocketAddress;
 import java.util.Optional;
 
 import org.apache.pekko.http.javadsl.model.headers.HttpEncodingRanges;
-import scala.compat.java8.OptionConverters;
+import org.apache.pekko.util.OptionConverters;
 
 public abstract class RemoteAddress {
     public abstract boolean isUnknown();

--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/CacheDirectives.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/CacheDirectives.java
@@ -13,10 +13,10 @@
 
 package org.apache.pekko.http.javadsl.model.headers;
 
-import scala.compat.java8.OptionConverters;
-
 import java.util.Optional;
 import java.util.OptionalLong;
+import org.apache.pekko.http.impl.util.Util;
+import org.apache.pekko.util.OptionConverters;
 
 public final class CacheDirectives {
     private CacheDirectives() {}
@@ -28,7 +28,7 @@ public final class CacheDirectives {
         return new org.apache.pekko.http.scaladsl.model.headers.CacheDirectives.max$minusstale(OptionConverters.toScala(Optional.empty()));
     }
     public static CacheDirective MAX_STALE(long deltaSeconds) {
-        return new org.apache.pekko.http.scaladsl.model.headers.CacheDirectives.max$minusstale(OptionConverters.toScala(OptionalLong.of(deltaSeconds)));
+        return new org.apache.pekko.http.scaladsl.model.headers.CacheDirectives.max$minusstale(new scala.Some(deltaSeconds));
     }
     public static CacheDirective MIN_FRESH(long deltaSeconds) {
         return new org.apache.pekko.http.scaladsl.model.headers.CacheDirectives.min$minusfresh(deltaSeconds);

--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/HttpCookie.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/HttpCookie.java
@@ -16,7 +16,7 @@ package org.apache.pekko.http.javadsl.model.headers;
 import org.apache.pekko.annotation.DoNotInherit;
 import org.apache.pekko.http.javadsl.model.DateTime;
 import org.apache.pekko.http.impl.util.Util;
-import scala.compat.java8.OptionConverters;
+import org.apache.pekko.util.OptionConverters;
 
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -71,7 +71,7 @@ public abstract class HttpCookie {
         return new org.apache.pekko.http.scaladsl.model.headers.HttpCookie(
                 name, value,
                 Util.<DateTime, org.apache.pekko.http.scaladsl.model.DateTime>convertOptionalToScala(expires),
-                OptionConverters.toScala(maxAge),
+                Util.convertOptionalToScala(maxAge),
                 OptionConverters.toScala(domain),
                 OptionConverters.toScala(path),
                 secure,
@@ -94,7 +94,7 @@ public abstract class HttpCookie {
         return new org.apache.pekko.http.scaladsl.model.headers.HttpCookie(
                 name, value,
                 Util.<DateTime, org.apache.pekko.http.scaladsl.model.DateTime>convertOptionalToScala(expires),
-                OptionConverters.toScala(maxAge),
+                Util.convertOptionalToScala(maxAge),
                 OptionConverters.toScala(domain),
                 OptionConverters.toScala(path),
                 secure,

--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/sse/ServerSentEvent.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/sse/ServerSentEvent.java
@@ -18,8 +18,10 @@ package org.apache.pekko.http.javadsl.model.sse;
 
 import java.util.Optional;
 import java.util.OptionalInt;
+
+import org.apache.pekko.util.OptionConverters;
 import scala.Option;
-import static scala.compat.java8.OptionConverters.toScala;
+import org.apache.pekko.http.impl.util.Util;
 
 /**
  * Representation of a server-sent event. According to the specification, an empty data field
@@ -27,9 +29,9 @@ import static scala.compat.java8.OptionConverters.toScala;
  */
 public abstract class ServerSentEvent {
 
-    private static final Option<String> stringNone =  toScala(Optional.empty());
+    private static final Option<String> stringNone =  Util.scalaNone();
 
-    private static final Option<Object> intNone = toScala(OptionalInt.empty());
+    private static final Option<Object> intNone = Util.scalaNone();
 
 
     /**
@@ -92,7 +94,7 @@ public abstract class ServerSentEvent {
                                          Optional<String> id,
                                          OptionalInt retry) {
         return org.apache.pekko.http.scaladsl.model.sse.ServerSentEvent.apply(
-                data, toScala(type), toScala(id), toScala(retry)
+                data, OptionConverters.toScala(type), OptionConverters.toScala(id), Util.convertOptionalToScala(retry)
         );
     }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/OutgoingConnectionBuilderImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/OutgoingConnectionBuilderImpl.scala
@@ -156,9 +156,9 @@ private[pekko] object OutgoingConnectionBuilderImpl {
 
     private def javaFlow(flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]])
         : JFlow[javadsl.model.HttpRequest, javadsl.model.HttpResponse, CompletionStage[javadsl.OutgoingConnection]] = {
-      import scala.compat.java8.FutureConverters.toJava
+      import pekko.util.FutureConverters._
       javaFlowKeepMatVal(flow.mapMaterializedValue(f =>
-        toJava(f.map(oc => new javadsl.OutgoingConnection(oc))(ExecutionContexts.parasitic))))
+        f.map(oc => new javadsl.OutgoingConnection(oc))(ExecutionContexts.parasitic).asJava))
     }
 
     private def javaFlowKeepMatVal[M](

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/JavaMapping.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/JavaMapping.scala
@@ -23,7 +23,6 @@ import pekko.japi.Pair
 import pekko.stream.{ javadsl, scaladsl, FlowShape, Graph }
 
 import scala.collection.immutable
-import scala.compat.java8.{ FutureConverters, OptionConverters }
 import scala.reflect.ClassTag
 import pekko.NotUsed
 import pekko.annotation.InternalApi
@@ -37,6 +36,8 @@ import pekko.http.javadsl.{
 }
 import pekko.http.{ javadsl => jdsl, scaladsl => sdsl }
 import pekko.http.scaladsl.{ model => sm }
+import pekko.util.FutureConverters._
+import pekko.util.OptionConverters._
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
@@ -135,8 +136,8 @@ private[http] object JavaMapping {
     }
   implicit def option[_J, _S](implicit mapping: JavaMapping[_J, _S]): JavaMapping[Optional[_J], Option[_S]] =
     new JavaMapping[Optional[_J], Option[_S]] {
-      def toScala(javaObject: Optional[_J]): Option[_S] = OptionConverters.toScala(javaObject).map(mapping.toScala)
-      def toJava(scalaObject: Option[_S]): Optional[_J] = OptionConverters.toJava(scalaObject.map(mapping.toJava))
+      def toScala(javaObject: Optional[_J]): Option[_S] = javaObject.toScala.map(mapping.toScala)
+      def toJava(scalaObject: Option[_S]): Optional[_J] = scalaObject.map(mapping.toJava).toJava
     }
 
   implicit def flowMapping[JIn, SIn, JOut, SOut, JM, SM](implicit inMapping: JavaMapping[JIn, SIn],
@@ -191,9 +192,9 @@ private[http] object JavaMapping {
       implicit mapping: JavaMapping[_J, _S], ec: ExecutionContext): JavaMapping[CompletionStage[_J], Future[_S]] =
     new JavaMapping[CompletionStage[_J], Future[_S]] {
       def toJava(scalaObject: Future[_S]): CompletionStage[_J] =
-        FutureConverters.toJava(scalaObject.map(mapping.toJava))
+        scalaObject.map(mapping.toJava).asJava
       def toScala(javaObject: CompletionStage[_J]): Future[_S] =
-        FutureConverters.toScala(javaObject).map(mapping.toScala)
+        javaObject.asScala.map(mapping.toScala)
     }
 
   implicit object StringIdentity extends Identity[String]

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ClientTransport.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ClientTransport.scala
@@ -97,8 +97,8 @@ object ClientTransport {
    *               to an [[InetSocketAddress]]
    */
   def withCustomResolver(lookup: BiFunction[String, Int, CompletionStage[InetSocketAddress]]): ClientTransport = {
-    import scala.compat.java8.FutureConverters._
-    scaladsl.ClientTransport.withCustomResolver((host, port) => lookup.apply(host, port).toScala).asJava
+    import pekko.util.FutureConverters._
+    scaladsl.ClientTransport.withCustomResolver((host, port) => lookup.apply(host, port).asScala).asJava
   }
 
   def fromScala(scalaTransport: scaladsl.ClientTransport): ClientTransport =

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectHttp.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectHttp.scala
@@ -16,11 +16,10 @@ package org.apache.pekko.http.javadsl
 import java.util.Locale
 import java.util.Optional
 
-import scala.compat.java8.OptionConverters._
-
 import org.apache.pekko
 import pekko.annotation.{ DoNotInherit, InternalApi }
 import pekko.http.javadsl.model.Uri
+import pekko.util.OptionConverters._
 
 @DoNotInherit
 abstract class ConnectHttp {
@@ -31,11 +30,11 @@ abstract class ConnectHttp {
   def connectionContext: Optional[HttpsConnectionContext]
 
   final def effectiveHttpsConnectionContext(fallbackContext: HttpsConnectionContext): HttpsConnectionContext =
-    connectionContext.asScala
+    connectionContext.toScala
       .getOrElse(fallbackContext)
 
   final def effectiveConnectionContext(fallbackContext: ConnectionContext): ConnectionContext =
-    connectionContext.asScala // Optional doesn't deal well with covariance
+    connectionContext.toScala // Optional doesn't deal well with covariance
       .getOrElse(fallbackContext)
 
   override def toString = s"ConnectHttp($host,$port,$isHttps,$connectionContext)"

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectionContext.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectionContext.scala
@@ -20,10 +20,9 @@ import pekko.annotation.{ ApiMayChange, DoNotInherit }
 import pekko.http.scaladsl
 import pekko.japi.Util
 import pekko.stream.TLSClientAuth
+import pekko.util.OptionConverters._
 import com.typesafe.sslconfig.pekko.PekkoSSLConfig
 import javax.net.ssl.{ SSLContext, SSLEngine, SSLParameters }
-
-import scala.compat.java8.OptionConverters
 
 object ConnectionContext {
   // #https-server-context-creation
@@ -80,11 +79,11 @@ object ConnectionContext {
     // #https-context-creation
     scaladsl.ConnectionContext.https(
       sslContext,
-      OptionConverters.toScala(sslConfig),
-      OptionConverters.toScala(enabledCipherSuites).map(Util.immutableSeq(_)),
-      OptionConverters.toScala(enabledProtocols).map(Util.immutableSeq(_)),
-      OptionConverters.toScala(clientAuth),
-      OptionConverters.toScala(sslParameters))
+      sslConfig.toScala,
+      enabledCipherSuites.toScala.map(Util.immutableSeq(_)),
+      enabledProtocols.toScala.map(Util.immutableSeq(_)),
+      clientAuth.toScala,
+      sslParameters.toScala)
 
   /** Used to serve HTTPS traffic. */
   @Deprecated @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
@@ -98,10 +97,10 @@ object ConnectionContext {
     scaladsl.ConnectionContext.https(
       sslContext,
       None,
-      OptionConverters.toScala(enabledCipherSuites).map(Util.immutableSeq(_)),
-      OptionConverters.toScala(enabledProtocols).map(Util.immutableSeq(_)),
-      OptionConverters.toScala(clientAuth),
-      OptionConverters.toScala(sslParameters))
+      enabledCipherSuites.toScala.map(Util.immutableSeq(_)),
+      enabledProtocols.toScala.map(Util.immutableSeq(_)),
+      clientAuth.toScala,
+      sslParameters.toScala)
 
   /** Used to serve HTTP traffic. */
   def noEncryption(): HttpConnectionContext =

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -18,8 +18,6 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
-import scala.compat.java8.FutureConverters._
-import scala.compat.java8.OptionConverters._
 import scala.util.Try
 import com.typesafe.sslconfig.pekko.PekkoSSLConfig
 import org.apache.pekko
@@ -39,6 +37,7 @@ import pekko.stream.TLSProtocol._
 import pekko.stream.Materializer
 import pekko.stream.javadsl.{ BidiFlow, Flow, Source }
 import pekko.stream.scaladsl.Keep
+import pekko.util.FutureConverters._
 
 object Http extends ExtensionId[Http] with ExtensionIdProvider {
   override def get(system: ActorSystem): Http = super.get(system)
@@ -126,7 +125,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
     new Source(delegate.bind(connect.host, connect.port, connectionContext)
       .map(new IncomingConnection(_))
-      .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava))
+      .mapMaterializedValue(_.map(new ServerBinding(_))(ec).asJava))
   }
 
   /**
@@ -155,7 +154,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     new Source(delegate.bind(connect.host, connect.port, settings = settings.asScala,
       connectionContext = connectionContext)
       .map(new IncomingConnection(_))
-      .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava))
+      .mapMaterializedValue(_.map(new ServerBinding(_))(ec).asJava))
   }
 
   /**
@@ -184,7 +183,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
     new Source(delegate.bind(connect.host, connect.port, connectionContext, settings.asScala, log)
       .map(new IncomingConnection(_))
-      .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava))
+      .mapMaterializedValue(_.map(new ServerBinding(_))(ec).asJava))
   }
 
   /**
@@ -210,7 +209,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     delegate.bindAndHandle(
       handler.asInstanceOf[Flow[sm.HttpRequest, sm.HttpResponse, _]].asScala,
       connect.host, connect.port, connectionContext)(materializer)
-      .map(new ServerBinding(_))(ec).toJava
+      .map(new ServerBinding(_))(ec).asJava
   }
 
   /**
@@ -238,7 +237,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     delegate.bindAndHandle(
       handler.asInstanceOf[Flow[sm.HttpRequest, sm.HttpResponse, _]].asScala,
       connect.host, connect.port, connectionContext, settings.asScala, log)(materializer)
-      .map(new ServerBinding(_))(ec).toJava
+      .map(new ServerBinding(_))(ec).asJava
   }
 
   /**
@@ -262,7 +261,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
       materializer: Materializer): CompletionStage[ServerBinding] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
     delegate.bindAndHandleSync(handler.apply(_).asScala, connect.host, connect.port, connectionContext)(materializer)
-      .map(new ServerBinding(_))(ec).toJava
+      .map(new ServerBinding(_))(ec).asJava
   }
 
   /**
@@ -290,7 +289,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     delegate.bindAndHandleSync(
       handler.apply(_).asScala,
       connect.host, connect.port, connectionContext, settings.asScala, log)(materializer)
-      .map(new ServerBinding(_))(ec).toJava
+      .map(new ServerBinding(_))(ec).asJava
   }
 
   /**
@@ -313,8 +312,8 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
       connect: ConnectHttp,
       materializer: Materializer): CompletionStage[ServerBinding] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
-    delegate.bindAndHandleAsync(handler.apply(_).toScala, connect.host, connect.port, connectionContext)(materializer)
-      .map(new ServerBinding(_))(ec).toJava
+    delegate.bindAndHandleAsync(handler.apply(_).asScala, connect.host, connect.port, connectionContext)(materializer)
+      .map(new ServerBinding(_))(ec).asJava
   }
 
   /**
@@ -340,9 +339,9 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
       materializer: Materializer): CompletionStage[ServerBinding] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
     delegate.bindAndHandleAsync(
-      handler.apply(_).toScala,
+      handler.apply(_).asScala,
       connect.host, connect.port, connectionContext, settings.asScala, parallelism, log)(materializer)
-      .map(new ServerBinding(_))(ec).toJava
+      .map(new ServerBinding(_))(ec).asJava
   }
 
   /**
@@ -641,7 +640,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * the future will be completed with an error.
    */
   def singleRequest(request: HttpRequest): CompletionStage[HttpResponse] =
-    delegate.singleRequest(request.asScala).toJava
+    delegate.singleRequest(request.asScala).asJava
 
   /**
    * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's
@@ -653,7 +652,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * the future will be completed with an error.
    */
   def singleRequest(request: HttpRequest, connectionContext: HttpsConnectionContext): CompletionStage[HttpResponse] =
-    delegate.singleRequest(request.asScala, connectionContext.asScala).toJava
+    delegate.singleRequest(request.asScala, connectionContext.asScala).asJava
 
   /**
    * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's
@@ -669,7 +668,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
       connectionContext: HttpsConnectionContext,
       settings: ConnectionPoolSettings,
       log: LoggingAdapter): CompletionStage[HttpResponse] =
-    delegate.singleRequest(request.asScala, connectionContext.asScala, settings.asScala, log).toJava
+    delegate.singleRequest(request.asScala, connectionContext.asScala, settings.asScala, log).asJava
 
   /**
    * Constructs a WebSocket [[pekko.stream.javadsl.BidiFlow]].
@@ -796,7 +795,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * If existing pool client flows are re-used or new ones materialized concurrently with or after this
    * method call the respective connection pools will be restarted and not contribute to the returned future.
    */
-  def shutdownAllConnectionPools(): CompletionStage[Unit] = delegate.shutdownAllConnectionPools().toJava
+  def shutdownAllConnectionPools(): CompletionStage[Unit] = delegate.shutdownAllConnectionPools().asJava
 
   /**
    * Gets the current default server-side [[ConnectionContext]] – defaults to plain HTTP.
@@ -855,7 +854,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     Flow.fromGraph {
       pekko.stream.scaladsl.Flow[HttpRequest].map(_.asScala)
         .viaMat(scalaFlow)(Keep.right)
-        .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).toJava)
+        .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).asJava)
     }
 
   private def adaptServerLayer(serverLayer: scaladsl.Http.ServerLayer)
@@ -897,5 +896,5 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     }
   private def adaptWsUpgradeResponse(
       responseFuture: Future[scaladsl.model.ws.WebSocketUpgradeResponse]): CompletionStage[WebSocketUpgradeResponse] =
-    responseFuture.map(WebSocketUpgradeResponse.adapt)(system.dispatcher).toJava
+    responseFuture.map(WebSocketUpgradeResponse.adapt)(system.dispatcher).asJava
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/IncomingConnection.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/IncomingConnection.scala
@@ -21,9 +21,9 @@ import pekko.stream.Materializer
 import pekko.stream.javadsl.Flow
 import pekko.http.javadsl.model._
 import pekko.http.scaladsl.{ model => sm }
+import pekko.util.FutureConverters._
 import java.util.concurrent.CompletionStage
 import scala.concurrent.Future
-import scala.compat.java8.FutureConverters._
 
 /**
  * Represents one accepted incoming HTTP connection.
@@ -66,13 +66,13 @@ class IncomingConnection private[http] (delegate: pekko.http.scaladsl.Http.Incom
    */
   def handleWithAsyncHandler(
       handler: Function[HttpRequest, CompletionStage[HttpResponse]], materializer: Materializer): Unit =
-    delegate.handleWithAsyncHandler(handler.apply(_).toScala.asInstanceOf[Future[sm.HttpResponse]])(materializer)
+    delegate.handleWithAsyncHandler(handler.apply(_).asScala.asInstanceOf[Future[sm.HttpResponse]])(materializer)
 
   /**
    * Handles the connection with the given handler function.
    */
   def handleWithAsyncHandler(handler: Function[HttpRequest, CompletionStage[HttpResponse]], parallelism: Int,
       materializer: Materializer): Unit =
-    delegate.handleWithAsyncHandler(handler.apply(_).toScala.asInstanceOf[Future[sm.HttpResponse]], parallelism)(
+    delegate.handleWithAsyncHandler(handler.apply(_).asScala.asInstanceOf[Future[sm.HttpResponse]], parallelism)(
       materializer)
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
@@ -20,9 +20,9 @@ import org.apache.pekko
 import pekko.Done
 import pekko.annotation.DoNotInherit
 import pekko.dispatch.ExecutionContexts
+import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
 
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
 import pekko.actor.ClassicActorSystemProvider
 
@@ -43,7 +43,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
    * The produced [[java.util.concurrent.CompletionStage]] is fulfilled when the unbinding has been completed.
    */
   def unbind(): CompletionStage[Done] =
-    delegate.unbind().toJava
+    delegate.unbind().asJava
 
   /**
    * Triggers "graceful" termination request being handled on this connection.
@@ -90,7 +90,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
   def terminate(hardDeadline: java.time.Duration): CompletionStage[HttpTerminated] = {
     delegate.terminate(FiniteDuration.apply(hardDeadline.toMillis, TimeUnit.MILLISECONDS))
       .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.sameThreadExecutionContext)
-      .toJava
+      .asJava
   }
 
   /**
@@ -104,7 +104,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
   def whenTerminationSignalIssued: CompletionStage[java.time.Duration] =
     delegate.whenTerminationSignalIssued
       .map(deadline => deadline.time.asJava)(ExecutionContexts.sameThreadExecutionContext)
-      .toJava
+      .asJava
 
   /**
    * This completion stage completes when the termination process, as initiated by an [[terminate]] call has completed.
@@ -121,7 +121,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
   def whenTerminated: CompletionStage[HttpTerminated] =
     delegate.whenTerminated
       .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.sameThreadExecutionContext)
-      .toJava
+      .asJava
 
   /**
    * Adds this `ServerBinding` to the actor system's coordinated shutdown, so that [[unbind]] and [[terminate]] get

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/Message.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/Message.scala
@@ -21,9 +21,9 @@ import pekko.http.scaladsl.{ model => sm }
 import pekko.stream.Materializer
 import pekko.stream.javadsl.Source
 import pekko.util.ByteString
+import pekko.util.FutureConverters._
 
 import scala.concurrent.duration._
-import scala.compat.java8.FutureConverters._
 
 /**
  * Represents a WebSocket message. A message can either be a binary message or a text message.
@@ -100,7 +100,7 @@ object TextMessage {
 
       def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.TextMessage.Strict] = asScala
         .toStrict(timeoutMillis.millis)(materializer)
-        .toJava
+        .asJava
 
       def asScala: sm.ws.TextMessage = sm.ws.TextMessage.Strict(text)
     }
@@ -116,7 +116,7 @@ object TextMessage {
 
       def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.TextMessage.Strict] = asScala
         .toStrict(timeoutMillis.millis)(materializer)
-        .toJava
+        .asJava
 
       def asScala: sm.ws.TextMessage = sm.ws.TextMessage(textStream.asScala)
     }
@@ -165,7 +165,7 @@ object BinaryMessage {
       def toStrict(
           timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.BinaryMessage.Strict] = asScala
         .toStrict(timeoutMillis.millis)(materializer)
-        .toJava
+        .asJava
 
       def asScala: sm.ws.BinaryMessage = sm.ws.BinaryMessage.Strict(data)
     }
@@ -182,7 +182,7 @@ object BinaryMessage {
       def toStrict(
           timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.BinaryMessage.Strict] = asScala
         .toStrict(timeoutMillis.millis)(materializer)
-        .toJava
+        .asJava
 
       def asScala: sm.ws.BinaryMessage = sm.ws.BinaryMessage(dataStream.asScala)
     }

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ClientConnectionSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ClientConnectionSettings.scala
@@ -27,10 +27,9 @@ import pekko.http.javadsl.model.headers.UserAgent
 import pekko.io.Inet.SocketOption
 import com.typesafe.config.Config
 import pekko.http.impl.util.JavaMapping.Implicits._
+import pekko.util.OptionConverters._
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.OptionConverters
-import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 /**
@@ -44,15 +43,15 @@ abstract class ClientConnectionSettings private[pekko] () { self: ClientConnecti
   final def getParserSettings: ParserSettings = parserSettings
   final def getIdleTimeout: Duration = idleTimeout
   final def getSocketOptions: java.lang.Iterable[SocketOption] = socketOptions.asJava
-  final def getUserAgentHeader: Optional[UserAgent] = OptionConverters.toJava(userAgentHeader)
-  final def getLogUnencryptedNetworkBytes: Optional[Int] = OptionConverters.toJava(logUnencryptedNetworkBytes)
+  final def getUserAgentHeader: Optional[UserAgent] = (userAgentHeader: Option[UserAgent]).toJava
+  final def getLogUnencryptedNetworkBytes: Optional[Int] = (logUnencryptedNetworkBytes: Option[Int]).toJava
   final def getStreamCancellationDelay: FiniteDuration = streamCancellationDelay
   final def getRequestHeaderSizeHint: Int = requestHeaderSizeHint
   final def getWebsocketSettings: WebSocketSettings = websocketSettings
   final def getWebsocketRandomFactory: Supplier[Random] = new Supplier[Random] {
     override def get(): Random = websocketRandomFactory()
   }
-  final def getLocalAddress: Optional[InetSocketAddress] = OptionConverters.toJava(localAddress)
+  final def getLocalAddress: Optional[InetSocketAddress] = (localAddress: Option[InetSocketAddress]).toJava
 
   /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
   @ApiMayChange
@@ -68,9 +67,9 @@ abstract class ClientConnectionSettings private[pekko] () { self: ClientConnecti
   // Java API versions of mutators
 
   def withUserAgentHeader(newValue: Optional[UserAgent]): ClientConnectionSettings =
-    self.copy(userAgentHeader = newValue.asScala.map(_.asScala))
+    self.copy(userAgentHeader = (newValue.asScala: Option[UserAgent]).map(_.asScala))
   def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ClientConnectionSettings =
-    self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
+    self.copy(logUnencryptedNetworkBytes = newValue.toScala)
   def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ClientConnectionSettings =
     self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
       override def get(): Random = newValue.get()
@@ -82,7 +81,7 @@ abstract class ClientConnectionSettings private[pekko] () { self: ClientConnecti
   def withParserSettings(newValue: ParserSettings): ClientConnectionSettings =
     self.copy(parserSettings = newValue.asScala)
   def withLocalAddress(newValue: Optional[InetSocketAddress]): ClientConnectionSettings =
-    self.copy(localAddress = OptionConverters.toScala(newValue))
+    self.copy(localAddress = newValue.asScala)
 
   @ApiMayChange
   def withTransport(newValue: ClientTransport): ClientConnectionSettings = self.copy(transport = newValue.asScala)

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
@@ -24,11 +24,10 @@ import pekko.http.javadsl.model.headers.Host
 import pekko.http.javadsl.model.headers.Server
 import pekko.io.Inet.SocketOption
 import pekko.http.impl.util.JavaMapping.Implicits._
+import pekko.util.OptionConverters._
 import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.OptionConverters
-import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 /**
@@ -71,7 +70,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   // ---
 
   def withServerHeader(newValue: Optional[Server]): ServerSettings =
-    self.copy(serverHeader = newValue.asScala.map(_.asScala))
+    self.copy(serverHeader = newValue.asScala)
   def withPreviewServerSettings(newValue: PreviewServerSettings): ServerSettings =
     self.copy(previewServerSettings = newValue.asScala)
   def withTimeouts(newValue: ServerSettings.Timeouts): ServerSettings = self.copy(timeouts = newValue.asScala)
@@ -97,7 +96,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def withWebsocketSettings(newValue: WebSocketSettings): ServerSettings =
     self.copy(websocketSettings = newValue.asScala)
   def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ServerSettings =
-    self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
+    self.copy(logUnencryptedNetworkBytes = newValue.toScala)
   def withHttp2Settings(newValue: Http2ServerSettings): ServerSettings = self.copy(http2Settings = newValue.asScala)
   def withDefaultHttpPort(newValue: Int): ServerSettings = self.copy(defaultHttpPort = newValue)
   def withDefaultHttpsPort(newValue: Int): ServerSettings = self.copy(defaultHttpPort = newValue)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ConnectionContext.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ConnectionContext.scala
@@ -19,13 +19,13 @@ import org.apache.pekko
 import pekko.annotation.{ ApiMayChange, InternalApi }
 import pekko.stream.TLSClientAuth
 import pekko.stream.TLSProtocol._
+import pekko.util.OptionConverters._
 import scala.annotation.nowarn
 import com.typesafe.sslconfig.pekko.PekkoSSLConfig
 import javax.net.ssl._
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.compat.java8.OptionConverters._
 
 trait ConnectionContext extends pekko.http.javadsl.ConnectionContext {
   @deprecated("Internal method, left for binary compatibility", since = "Akka HTTP 10.2.0")
@@ -158,13 +158,13 @@ final class HttpsConnectionContext private[http] (
   override def getSslContext = sslContext
   @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
   override def getEnabledCipherSuites: Optional[JCollection[String]] =
-    enabledCipherSuites.map(_.asJavaCollection).asJava
+    enabledCipherSuites.map(_.asJavaCollection).toJava
   @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
-  override def getEnabledProtocols: Optional[JCollection[String]] = enabledProtocols.map(_.asJavaCollection).asJava
+  override def getEnabledProtocols: Optional[JCollection[String]] = enabledProtocols.map(_.asJavaCollection).toJava
   @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
-  override def getClientAuth: Optional[TLSClientAuth] = clientAuth.asJava
+  override def getClientAuth: Optional[TLSClientAuth] = clientAuth.toJava
   @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
-  override def getSslParameters: Optional[SSLParameters] = sslParameters.asJava
+  override def getSslParameters: Optional[SSLParameters] = sslParameters.toJava
 }
 
 sealed class HttpConnectionContext extends pekko.http.javadsl.HttpConnectionContext with ConnectionContext {

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
@@ -43,6 +43,7 @@ import pekko.stream._
 import pekko.stream.TLSProtocol._
 import pekko.stream.scaladsl._
 import pekko.util.ByteString
+import pekko.util.FutureConverters._
 import pekko.util.ManifestInfo
 
 import scala.annotation.nowarn
@@ -54,7 +55,6 @@ import com.typesafe.sslconfig.ssl.ConfigSSLContextBuilder
 import scala.concurrent._
 import scala.util.{ Success, Try }
 import scala.util.control.NonFatal
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.duration._
 
@@ -1106,7 +1106,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
 
     private[http] def toJava = new pekko.http.javadsl.HostConnectionPool {
       override def setup = HostConnectionPool.this.setup
-      def shutdown(): CompletionStage[Done] = HostConnectionPool.this.shutdown().toJava
+      def shutdown(): CompletionStage[Done] = HostConnectionPool.this.shutdown().asJava
     }
 
     override def productArity: Int = 1

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ContentRange.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ContentRange.scala
@@ -17,7 +17,7 @@ import java.util.{ Optional, OptionalLong }
 import org.apache.pekko
 import pekko.http.impl.util.{ Rendering, ValueRenderable }
 import pekko.http.javadsl.{ model => jm }
-import scala.compat.java8.OptionConverters._
+import pekko.util.OptionConverters._
 
 sealed trait ContentRange extends jm.ContentRange with ValueRenderable {
   // default implementations to override
@@ -35,7 +35,7 @@ sealed trait ByteContentRange extends ContentRange {
   def isByteContentRange: Boolean = true
 
   /** Java API */
-  def getInstanceLength: OptionalLong = instanceLength.asPrimitive
+  def getInstanceLength: OptionalLong = instanceLength.toJavaPrimitive
 }
 
 // http://tools.ietf.org/html/rfc7233#section-4.2

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
@@ -34,15 +34,13 @@ import pekko.http.scaladsl.util.FastFuture
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.impl.util.{ JavaMapping, StreamUtils }
 import pekko.http.impl.util.JavaMapping.Implicits._
+import pekko.util.FutureConverters._
+import pekko.util.OptionConverters._
 
-import scala.compat.java8.OptionConverters._
-import scala.compat.java8.FutureConverters._
 import java.util.concurrent.CompletionStage
 
 import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.{ DoNotInherit, InternalApi }
-
-import scala.compat.java8.FutureConverters
 
 /**
  * Models the entity (aka "body" or "content") of an HTTP message.
@@ -194,7 +192,7 @@ sealed trait HttpEntity extends jm.HttpEntity {
     stream.javadsl.Source.fromGraph(dataBytes.asInstanceOf[Source[ByteString, AnyRef]])
 
   /** Java API */
-  override def getContentLengthOption: OptionalLong = contentLengthOption.asPrimitive
+  override def getContentLengthOption: OptionalLong = contentLengthOption.toJavaPrimitive
 
   // default implementations, should be overridden
   override def isCloseDelimited: Boolean = false
@@ -205,22 +203,22 @@ sealed trait HttpEntity extends jm.HttpEntity {
 
   /** Java API */
   override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.HttpEntity.Strict] =
-    toStrict(timeoutMillis.millis)(materializer).toJava
+    toStrict(timeoutMillis.millis)(materializer).asJava
 
   /** Java API */
   override def toStrict(
       timeoutMillis: Long, maxBytes: Long, materializer: Materializer): CompletionStage[jm.HttpEntity.Strict] =
-    toStrict(timeoutMillis.millis, maxBytes)(materializer).toJava
+    toStrict(timeoutMillis.millis, maxBytes)(materializer).asJava
 
   /** Java API */
   override def toStrict(
       timeoutMillis: Long, system: ClassicActorSystemProvider): CompletionStage[jm.HttpEntity.Strict] =
-    toStrict(timeoutMillis.millis)(SystemMaterializer(system).materializer).toJava
+    toStrict(timeoutMillis.millis)(SystemMaterializer(system).materializer).asJava
 
   /** Java API */
   override def toStrict(
       timeoutMillis: Long, maxBytes: Long, system: ClassicActorSystemProvider): CompletionStage[jm.HttpEntity.Strict] =
-    toStrict(timeoutMillis.millis, maxBytes)(SystemMaterializer(system).materializer).toJava
+    toStrict(timeoutMillis.millis, maxBytes)(SystemMaterializer(system).materializer).asJava
 
   /** Java API */
   override def withContentType(contentType: jm.ContentType): HttpEntity = {
@@ -730,7 +728,7 @@ object HttpEntity {
      * This future completes successfully once the underlying entity stream has been
      * successfully drained (and fails otherwise).
      */
-    def completionStage: CompletionStage[Done] = FutureConverters.toJava(f)
+    def completionStage: CompletionStage[Done] = f.asJava
   }
 
   /** Adds Scala DSL idiomatic methods to [[HttpEntity]], e.g. versions of methods with an implicit [[Materializer]]. */

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
@@ -22,7 +22,6 @@ import java.lang.{ Iterable => JIterable }
 import java.util.Optional
 import java.util.concurrent.{ CompletionStage, Executor }
 
-import scala.compat.java8.FutureConverters
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.collection.immutable
@@ -35,10 +34,10 @@ import pekko.http.ccompat.{ pre213, since213 }
 import pekko.http.impl.util._
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.scaladsl.util.FastFuture._
+import pekko.util.FutureConverters._
 import headers._
 
 import scala.annotation.tailrec
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration._
 
 /**
@@ -251,23 +250,23 @@ sealed trait HttpMessage extends jm.HttpMessage {
   /** Java API */
   def toStrict(timeoutMillis: Long, ec: Executor, materializer: Materializer): CompletionStage[Self] = {
     val ex = ExecutionContext.fromExecutor(ec)
-    toStrict(timeoutMillis.millis)(ex, materializer).toJava
+    toStrict(timeoutMillis.millis)(ex, materializer).asJava
   }
 
   /** Java API */
   def toStrict(timeoutMillis: Long, maxBytes: Long, ec: Executor, materializer: Materializer): CompletionStage[Self] = {
     val ex = ExecutionContext.fromExecutor(ec)
-    toStrict(timeoutMillis.millis, maxBytes)(ex, materializer).toJava
+    toStrict(timeoutMillis.millis, maxBytes)(ex, materializer).asJava
   }
 
   /** Java API */
   def toStrict(timeoutMillis: Long, system: ClassicActorSystemProvider): CompletionStage[Self] =
-    toStrict(timeoutMillis.millis)(system.classicSystem.dispatcher, SystemMaterializer(system).materializer).toJava
+    toStrict(timeoutMillis.millis)(system.classicSystem.dispatcher, SystemMaterializer(system).materializer).asJava
 
   /** Java API */
   def toStrict(timeoutMillis: Long, maxBytes: Long, system: ClassicActorSystemProvider): CompletionStage[Self] =
     toStrict(timeoutMillis.millis, maxBytes)(system.classicSystem.dispatcher,
-      SystemMaterializer(system).materializer).toJava
+      SystemMaterializer(system).materializer).asJava
 }
 
 object HttpMessage {
@@ -294,7 +293,7 @@ object HttpMessage {
      * This future completes successfully once the underlying entity stream has been
      * successfully drained (and fails otherwise).
      */
-    def completionStage: CompletionStage[Done] = FutureConverters.toJava(f)
+    def completionStage: CompletionStage[Done] = f.asJava
   }
   val AlreadyDiscardedEntity = new DiscardedEntity(Future.successful(Done))
 

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
@@ -36,8 +36,8 @@ import pekko.http.impl.engine.rendering.BodyPartRenderer
 import pekko.http.javadsl.{ model => jm }
 import FastFuture._
 import pekko.http.impl.util.JavaMapping.Implicits._
+import pekko.util.FutureConverters._
 
-import scala.compat.java8.FutureConverters._
 import java.util.concurrent.CompletionStage
 
 import pekko.annotation.InternalApi
@@ -99,7 +99,7 @@ sealed trait Multipart extends jm.Multipart {
 
   /** Java API */
   def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[_ <: jm.Multipart.Strict] =
-    toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).toJava
+    toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).asJava
 }
 
 object Multipart {
@@ -201,7 +201,7 @@ object Multipart {
 
     /** Java API */
     def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[_ <: jm.Multipart.BodyPart.Strict] =
-      toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).toJava
+      toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).asJava
   }
 
   object BodyPart {
@@ -244,7 +244,7 @@ object Multipart {
     /** Java API */
     override def toStrict(
         timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.General.Strict] =
-      super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[jm.Multipart.General.Strict]].toJava
+      super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[jm.Multipart.General.Strict]].asJava
   }
   object General {
     def apply(mediaType: MediaType.Multipart, parts: BodyPart.Strict*): Strict = Strict(mediaType, parts.toVector)
@@ -291,8 +291,8 @@ object Multipart {
       /** Java API */
       override def toStrict(
           timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.General.BodyPart.Strict] =
-        super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[
-          Future[jm.Multipart.General.BodyPart.Strict]].toJava
+        super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[
+          Future[jm.Multipart.General.BodyPart.Strict]].asJava
 
       private[BodyPart] def tryCreateFormDataBodyPart[T](
           f: (String, Map[String, String], immutable.Seq[HttpHeader]) => T): Try[T] = {
@@ -363,7 +363,7 @@ object Multipart {
     /** Java API */
     override def toStrict(
         timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.FormData.Strict] =
-      super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[jm.Multipart.FormData.Strict]].toJava
+      super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[jm.Multipart.FormData.Strict]].asJava
   }
   object FormData {
     def apply(parts: Multipart.FormData.BodyPart.Strict*): Multipart.FormData.Strict = Strict(parts.toVector)
@@ -498,8 +498,8 @@ object Multipart {
       /** Java API */
       override def toStrict(
           timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.FormData.BodyPart.Strict] =
-        super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[
-          Future[jm.Multipart.FormData.BodyPart.Strict]].toJava
+        super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[
+          Future[jm.Multipart.FormData.BodyPart.Strict]].asJava
     }
     object BodyPart {
       def apply(_name: String, _entity: BodyPartEntity,
@@ -585,7 +585,7 @@ object Multipart {
     /** Java API */
     override def toStrict(
         timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.ByteRanges.Strict] =
-      super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[jm.Multipart.ByteRanges.Strict]].toJava
+      super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[jm.Multipart.ByteRanges.Strict]].asJava
   }
   object ByteRanges {
     def apply(parts: Multipart.ByteRanges.BodyPart.Strict*): Strict = Strict(parts.toVector)
@@ -662,8 +662,8 @@ object Multipart {
       /** Java API */
       override def toStrict(
           timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.ByteRanges.BodyPart.Strict] =
-        super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[
-          jm.Multipart.ByteRanges.BodyPart.Strict]].toJava
+        super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[
+          jm.Multipart.ByteRanges.BodyPart.Strict]].asJava
     }
     object BodyPart {
       def apply(_contentRange: ContentRange, _entity: BodyPartEntity, _rangeUnit: RangeUnit = RangeUnits.Bytes,

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/HttpCookie.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/HttpCookie.scala
@@ -22,8 +22,7 @@ import pekko.http.scaladsl.model.DateTime
 import pekko.http.impl.util._
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.impl.util.JavaMapping.Implicits._
-
-import scala.compat.java8.OptionConverters._
+import pekko.util.OptionConverters._
 
 /**
  * for a full definition of the http cookie header fields, see
@@ -186,7 +185,7 @@ final class HttpCookie private[http] (
   override def httpOnly(): Boolean = this.httpOnly
 
   /** Java API */
-  def getSameSite: Optional[jm.headers.SameSite] = sameSite.map(_.asJava).asJava
+  def getSameSite: Optional[jm.headers.SameSite] = sameSite.map(_.asJava).toJava
 
   /** Java API */
   def getExtension: Optional[String] = extension.asJava
@@ -198,10 +197,10 @@ final class HttpCookie private[http] (
   def getDomain: Optional[String] = domain.asJava
 
   /** Java API */
-  def getMaxAge: OptionalLong = maxAge.asPrimitive
+  def getMaxAge: OptionalLong = maxAge.toJavaPrimitive
 
   /** Java API */
-  def getExpires: Optional[jm.DateTime] = expires.map(_.asJava).asJava
+  def getExpires: Optional[jm.DateTime] = expires.map(_.asJava).toJava
 
   def withName(name: String): HttpCookie = copy(name = name)
   def withValue(value: String): HttpCookie = copy(value = value)
@@ -225,7 +224,7 @@ final class HttpCookie private[http] (
   /** Java API */
   def withSameSite(sameSite: jm.headers.SameSite): HttpCookie = copy(sameSite = Option(sameSite.asScala()))
   def withSameSite(sameSite: Optional[jm.headers.SameSite]): HttpCookie =
-    copy(sameSite = sameSite.asScala.map(_.asScala()))
+    copy(sameSite = sameSite.toScala.map(_.asScala()))
 
   def withExtension(extension: String): HttpCookie = copy(extension = Some(extension))
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/sse/ServerSentEvent.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/sse/ServerSentEvent.scala
@@ -19,9 +19,9 @@ package sse
 import org.apache.pekko
 import pekko.http.javadsl.model
 import pekko.util.ByteString
+import pekko.util.OptionConverters._
 import java.nio.charset.StandardCharsets.UTF_8
 import scala.annotation.tailrec
-import scala.compat.java8.OptionConverters.RichOptionForJava8
 
 object ServerSentEvent {
 
@@ -133,9 +133,9 @@ final case class ServerSentEvent(
 
   override def getData = data
 
-  override def getEventType = eventType.asJava
+  override def getEventType = eventType.toJava
 
-  override def getId = id.asJava
+  override def getId = id.toJava
 
-  override def getRetry = retry.asPrimitive
+  override def getRetry = retry.toJavaPrimitive
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/Message.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/Message.scala
@@ -19,10 +19,10 @@ import org.apache.pekko
 import pekko.stream.{ javadsl, Materializer }
 import pekko.stream.scaladsl.Source
 import pekko.util.{ ByteString, ByteStringBuilder }
+import pekko.util.FutureConverters._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.compat.java8.FutureConverters._
 
 //#message-model
 /**
@@ -60,7 +60,7 @@ sealed trait TextMessage extends pekko.http.javadsl.model.ws.TextMessage with Me
   override def getStreamedText: javadsl.Source[String, _] = textStream.asJava
   override def asScala: TextMessage = this
   override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[TextMessage.Strict] =
-    toStrict(timeoutMillis.millis)(materializer).toJava
+    toStrict(timeoutMillis.millis)(materializer).asJava
 }
 //#message-model
 object TextMessage {
@@ -120,7 +120,7 @@ sealed trait BinaryMessage extends pekko.http.javadsl.model.ws.BinaryMessage wit
   override def getStreamedData: javadsl.Source[ByteString, _] = dataStream.asJava
   override def asScala: BinaryMessage = this
   override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[BinaryMessage.Strict] =
-    toStrict(timeoutMillis.millis)(materializer).toJava
+    toStrict(timeoutMillis.millis)(materializer).asJava
 }
 //#message-model
 object BinaryMessage {

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ParserSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ParserSettings.scala
@@ -25,10 +25,10 @@ import pekko.http.impl.util._
 import pekko.http.javadsl.model
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.{ settings => js }
+import pekko.util.OptionConverters._
 import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.OptionConverters
 
 /**
  * Public API but not intended for subclassing
@@ -88,15 +88,15 @@ abstract class ParserSettings private[pekko] () extends pekko.http.javadsl.setti
   override def getConflictingContentTypeHeaderProcessingMode = conflictingContentTypeHeaderProcessingMode
 
   override def getCustomMethods = new Function[String, Optional[pekko.http.javadsl.model.HttpMethod]] {
-    override def apply(t: String) = OptionConverters.toJava(customMethods(t))
+    override def apply(t: String) = (customMethods(t): Option[pekko.http.javadsl.model.HttpMethod]).toJava
   }
   override def getCustomStatusCodes = new Function[Int, Optional[pekko.http.javadsl.model.StatusCode]] {
-    override def apply(t: Int) = OptionConverters.toJava(customStatusCodes(t))
+    override def apply(t: Int) = (customStatusCodes(t): Option[pekko.http.javadsl.model.StatusCode]).toJava
   }
   override def getCustomMediaTypes =
     new pekko.japi.function.Function2[String, String, Optional[pekko.http.javadsl.model.MediaType]] {
       override def apply(mainType: String, subType: String): Optional[model.MediaType] =
-        OptionConverters.toJava(customMediaTypes(mainType, subType))
+        (customMediaTypes(mainType, subType): Option[pekko.http.javadsl.model.MediaType]).toJava
     }
   def getModeledHeaderParsing: Boolean = modeledHeaderParsing
 

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
@@ -27,11 +27,11 @@ import pekko.http.javadsl.{ settings => js }
 import pekko.http.scaladsl.model.HttpResponse
 import pekko.http.scaladsl.model.headers.{ Host, Server }
 import pekko.io.Inet.SocketOption
+import pekko.util.OptionConverters._
 import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.compat.java8.OptionConverters
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.language.implicitConversions
 
@@ -81,12 +81,12 @@ abstract class ServerSettings private[pekko] () extends pekko.http.javadsl.setti
   override def getResponseHeaderSizeHint = responseHeaderSizeHint
   override def getVerboseErrorMessages = verboseErrorMessages
   override def getSocketOptions = socketOptions.asJava
-  override def getServerHeader = OptionConverters.toJava(serverHeader.map(_.asJava))
+  override def getServerHeader = serverHeader.map(_.asJava).toJava
   override def getTimeouts = timeouts
   override def getRawRequestUriHeader = rawRequestUriHeader
   override def getRemoteAddressHeader = remoteAddressHeader
   override def getRemoteAddressAttribute: Boolean = remoteAddressAttribute
-  override def getLogUnencryptedNetworkBytes = OptionConverters.toJava(logUnencryptedNetworkBytes)
+  override def getLogUnencryptedNetworkBytes = logUnencryptedNetworkBytes.toJava
   @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.getRandomFactory instead",
     since = "Akka HTTP 10.2.0")
   override def getWebsocketRandomFactory = new Supplier[Random] {

--- a/http-core/src/test/scala/org/apache/pekko/http/javadsl/model/MultipartsSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/javadsl/model/MultipartsSpec.scala
@@ -25,8 +25,8 @@ import pekko.actor.ActorSystem
 import pekko.stream.SystemMaterializer
 import pekko.stream.javadsl.Source
 import pekko.testkit._
+import pekko.util.FutureConverters._
 
-import scala.compat.java8.FutureConverters
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -45,7 +45,7 @@ class MultipartsSpec extends AnyWordSpec with Matchers with Inside with BeforeAn
         Multiparts.createFormDataBodyPart("foo", HttpEntities.create("FOO")),
         Multiparts.createFormDataBodyPart("bar", HttpEntities.create("BAR")))
       val strictCS = streamed.toStrict(1000, materializer)
-      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second.dilated)
+      val strict = Await.result(strictCS.asScala, 1.second.dilated)
 
       strict shouldEqual org.apache.pekko.http.scaladsl.model.Multipart.FormData(
         Map("foo" -> org.apache.pekko.http.scaladsl.model.HttpEntity("FOO"),
@@ -56,7 +56,7 @@ class MultipartsSpec extends AnyWordSpec with Matchers with Inside with BeforeAn
         Multiparts.createFormDataBodyPart("foo", HttpEntities.create("FOO")),
         Multiparts.createFormDataBodyPart("bar", HttpEntities.create("BAR")))))
       val strictCS = streamed.toStrict(1000, materializer)
-      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second.dilated)
+      val strict = Await.result(strictCS.asScala, 1.second.dilated)
       strict shouldEqual org.apache.pekko.http.scaladsl.model.Multipart.FormData(
         Map("foo" -> org.apache.pekko.http.scaladsl.model.HttpEntity("FOO"),
           "bar" -> org.apache.pekko.http.scaladsl.model.HttpEntity("BAR")))
@@ -69,7 +69,7 @@ class MultipartsSpec extends AnyWordSpec with Matchers with Inside with BeforeAn
       fields.put("foo", HttpEntities.create("FOO"))
       val streamed = Multiparts.createFormDataFromFields(fields)
       val strictCS = streamed.toStrict(1000, materializer)
-      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second.dilated)
+      val strict = Await.result(strictCS.asScala, 1.second.dilated)
 
       strict shouldEqual org.apache.pekko.http.scaladsl.model.Multipart.FormData(
         Map("foo" -> org.apache.pekko.http.scaladsl.model.HttpEntity("FOO")))

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
-import static scala.compat.java8.FutureConverters.toJava;
+import static org.apache.pekko.util.FutureConverters.asJava;
 
 public class EventStreamUnmarshallingTest extends JUnitSuite {
 
@@ -52,7 +52,7 @@ public class EventStreamUnmarshallingTest extends JUnitSuite {
 
             Assert.assertEquals(events, unmarshalledEvents);
         } finally {
-            toJava(system.terminate()).toCompletableFuture().get(42, TimeUnit.SECONDS);
+            asJava(system.terminate()).toCompletableFuture().get(42, TimeUnit.SECONDS);
         }
     }
 }

--- a/http/src/main/java/org/apache/pekko/http/javadsl/coding/Coder.java
+++ b/http/src/main/java/org/apache/pekko/http/javadsl/coding/Coder.java
@@ -21,8 +21,8 @@ import org.apache.pekko.http.scaladsl.coding.Deflate$;
 import org.apache.pekko.http.scaladsl.coding.Gzip$;
 import org.apache.pekko.http.scaladsl.coding.NoCoding$;
 import org.apache.pekko.stream.Materializer;
+import org.apache.pekko.util.FutureConverters;
 import org.apache.pekko.util.ByteString;
-import scala.compat.java8.FutureConverters;
 
 /**
  * A coder is an implementation of the predefined encoders/decoders defined for HTTP.
@@ -65,7 +65,7 @@ public enum Coder {
     }
 
     public CompletionStage<ByteString> decode(ByteString input, Materializer mat) {
-        return FutureConverters.toJava(underlying.decode(input, mat));
+        return FutureConverters.asJava(underlying.decode(input, mat));
     }
     public org.apache.pekko.http.scaladsl.coding.Coder _underlyingScalaCoder() {
         return underlying;

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Rejections.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Rejections.scala
@@ -27,8 +27,8 @@ import pekko.annotation.DoNotInherit
 import pekko.http.scaladsl
 import pekko.japi.Util
 import pekko.pattern.CircuitBreakerOpenException
+import pekko.util.OptionConverters._
 
-import scala.compat.java8.OptionConverters._
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 
@@ -380,7 +380,7 @@ object Rejections {
     s.MalformedQueryParamRejection(parameterName, errorMsg)
   def malformedQueryParam(
       parameterName: String, errorMsg: String, cause: Optional[Throwable]): MalformedQueryParamRejection =
-    s.MalformedQueryParamRejection(parameterName, errorMsg, cause.asScala)
+    s.MalformedQueryParamRejection(parameterName, errorMsg, cause.toScala)
 
   def missingFormField(fieldName: String): MissingFormFieldRejection =
     s.MissingFormFieldRejection(fieldName)
@@ -389,7 +389,7 @@ object Rejections {
     s.MalformedFormFieldRejection(fieldName, errorMsg)
   def malformedFormField(
       fieldName: String, errorMsg: String, cause: Optional[Throwable]): s.MalformedFormFieldRejection =
-    s.MalformedFormFieldRejection(fieldName, errorMsg, cause.asScala)
+    s.MalformedFormFieldRejection(fieldName, errorMsg, cause.toScala)
 
   def missingHeader(headerName: String): MissingHeaderRejection =
     s.MissingHeaderRejection(headerName)
@@ -397,14 +397,14 @@ object Rejections {
   def malformedHeader(headerName: String, errorMsg: String): MalformedHeaderRejection =
     s.MalformedHeaderRejection(headerName, errorMsg)
   def malformedHeader(headerName: String, errorMsg: String, cause: Optional[Throwable]): s.MalformedHeaderRejection =
-    s.MalformedHeaderRejection(headerName, errorMsg, cause.asScala)
+    s.MalformedHeaderRejection(headerName, errorMsg, cause.toScala)
 
   def unsupportedRequestContentType(
       supported: java.lang.Iterable[MediaType],
       contentType: Optional[ContentType]): UnsupportedRequestContentTypeRejection =
     s.UnsupportedRequestContentTypeRejection(
       supported = supported.asScala.map(m => scaladsl.model.ContentTypeRange(m.asScala)).toSet,
-      contentType = contentType.asScala.map(_.asScala))
+      contentType = contentType.asScala)
 
   // for backwards compatibility
   def unsupportedRequestContentType(supported: java.lang.Iterable[MediaType]): UnsupportedRequestContentTypeRejection =
@@ -457,7 +457,7 @@ object Rejections {
   def validationRejection(message: String) =
     s.ValidationRejection(message)
   def validationRejection(message: String, cause: Optional[Throwable]) =
-    s.ValidationRejection(message, cause.asScala)
+    s.ValidationRejection(message, cause.toScala)
 
   def transformationRejection(f: java.util.function.Function[java.util.List[Rejection], java.util.List[Rejection]]) =
     s.TransformationRejection(rejections => f.apply(rejections.map(_.asJava).asJava).asScala.toVector.map(_.asScala)) // TODO this is maddness

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RequestContext.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RequestContext.scala
@@ -35,9 +35,9 @@ import pekko.http.scaladsl
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.scaladsl.marshalling.ToResponseMarshallable
 
-import scala.compat.java8.FutureConverters._
 import scala.annotation.varargs
 import pekko.http.scaladsl.model.Uri.Path
+import pekko.util.FutureConverters._
 
 class RequestContext private (val delegate: scaladsl.server.RequestContext) {
   import RequestContext._
@@ -60,18 +60,18 @@ class RequestContext private (val delegate: scaladsl.server.RequestContext) {
 
   def complete[T](value: T, marshaller: Marshaller[T, HttpResponse]): CompletionStage[RouteResult] = {
     delegate.complete(ToResponseMarshallable(value)(marshaller))
-      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).toJava
+      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).asJava
   }
 
   def completeWith(response: HttpResponse): CompletionStage[RouteResult] = {
     delegate.complete(response.asScala)
-      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).toJava
+      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).asJava
   }
 
   @varargs def reject(rejections: Rejection*): CompletionStage[RouteResult] = {
     val scalaRejections = rejections.map(_.asScala)
     delegate.reject(scalaRejections: _*)
-      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).toJava
+      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).asJava
   }
 
   def redirect(uri: Uri, redirectionType: StatusCode): CompletionStage[RouteResult] = {
@@ -80,7 +80,7 @@ class RequestContext private (val delegate: scaladsl.server.RequestContext) {
 
   def fail(error: Throwable): CompletionStage[RouteResult] =
     delegate.fail(error)
-      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).toJava
+      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).asJava
 
   def withRequest(req: HttpRequest): RequestContext = wrap(delegate.withRequest(req.asScala))
   def withExecutionContext(ec: ExecutionContextExecutor): RequestContext = wrap(delegate.withExecutionContext(ec))

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
@@ -99,7 +99,7 @@ private[http] object RoutingJavaMapping {
   //  val javaToScalaResponseEntity extends Inherited[javadsl.model.ResponseEntity, scaladsl.model.ResponseEntity]
 
   implicit final class ConvertCompletionStage[T](val stage: CompletionStage[T]) extends AnyVal {
-    import scala.compat.java8.FutureConverters._
-    def asScala = stage.toScala
+    import pekko.util.FutureConverters
+    def asScala = FutureConverters.asScala(stage)
   }
 }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/AttributeDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/AttributeDirectives.scala
@@ -19,8 +19,7 @@ import org.apache.pekko
 import pekko.http.javadsl.model.AttributeKey
 import pekko.http.javadsl.server.Route
 import pekko.http.scaladsl.server.directives.{ AttributeDirectives => D }
-
-import scala.compat.java8.OptionConverters._
+import pekko.util.OptionConverters._
 
 abstract class AttributeDirectives extends HeaderDirectives {
   import pekko.http.impl.util.JavaMapping._
@@ -40,7 +39,7 @@ abstract class AttributeDirectives extends HeaderDirectives {
    */
   def optionalAttribute[T](key: AttributeKey[T], inner: jf.Function[Optional[T], Route]) = RouteAdapter {
     D.optionalAttribute(toScala(key)) { value =>
-      inner.apply(value.asJava).delegate
+      inner.apply(value.toJava).delegate
     }
   }
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/CacheConditionDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/CacheConditionDirectives.scala
@@ -17,8 +17,6 @@ package directives
 import java.util.Optional
 import java.util.function.Supplier
 
-import scala.compat.java8.OptionConverters._
-
 import org.apache.pekko
 import pekko.http.javadsl.model.DateTime
 import pekko.http.javadsl.model.headers.EntityTag
@@ -85,7 +83,7 @@ abstract class CacheConditionDirectives extends BasicDirectives {
    */
   def conditional(eTag: Optional[EntityTag], lastModified: Optional[DateTime], inner: Supplier[Route]): Route =
     RouteAdapter {
-      D.conditional(eTag.asScala.map(_.asScala), lastModified.asScala.map(_.asScala)) { inner.get.delegate }
+      D.conditional(eTag.asScala, lastModified.asScala) { inner.get.delegate }
     }
 
 }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FormFieldDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FormFieldDirectives.scala
@@ -28,8 +28,7 @@ import pekko.http.javadsl.server.Route
 
 import pekko.http.scaladsl.server.{ Directives => D }
 import pekko.http.scaladsl.server.directives.ParameterDirectives._
-
-import scala.compat.java8.OptionConverters
+import pekko.util.OptionConverters._
 
 abstract class FormFieldDirectives extends FileUploadDirectives {
 
@@ -63,7 +62,7 @@ abstract class FormFieldDirectives extends FileUploadDirectives {
     import t.asScala
     RouteAdapter(
       D.formField(name.as[T].optional) { value =>
-        inner.apply(OptionConverters.toJava(value)).delegate
+        inner.apply(value.toJava).delegate
       })
   }
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
@@ -22,12 +22,12 @@ import org.apache.pekko
 import pekko.http.javadsl.marshalling.Marshaller
 import pekko.http.javadsl.model.RequestEntity
 
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
 import pekko.http.javadsl.server.Route
 import pekko.http.scaladsl.server.directives.{ CompleteOrRecoverWithMagnet, FutureDirectives => D }
 import pekko.pattern.CircuitBreaker
+import pekko.util.FutureConverters._
 
 abstract class FutureDirectives extends FormFieldDirectives {
 
@@ -38,7 +38,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def onComplete[T](f: Supplier[CompletionStage[T]], inner: JFunction[Try[T], Route]) = RouteAdapter {
-    D.onComplete(f.get.toScala.recover(unwrapCompletionException)) { value =>
+    D.onComplete(f.get.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -50,7 +50,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def onComplete[T](cs: CompletionStage[T], inner: JFunction[Try[T], Route]) = RouteAdapter {
-    D.onComplete(cs.toScala.recover(unwrapCompletionException)) { value =>
+    D.onComplete(cs.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -67,7 +67,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    */
   def onCompleteWithBreaker[T](breaker: CircuitBreaker, f: Supplier[CompletionStage[T]],
       inner: JFunction[Try[T], Route]) = RouteAdapter {
-    D.onCompleteWithBreaker(breaker)(f.get.toScala.recover(unwrapCompletionException)) { value =>
+    D.onCompleteWithBreaker(breaker)(f.get.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -81,7 +81,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def onSuccess[T](f: Supplier[CompletionStage[T]], inner: JFunction[T, Route]) = RouteAdapter {
-    D.onSuccess(f.get.toScala.recover(unwrapCompletionException)) { value =>
+    D.onSuccess(f.get.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -95,7 +95,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def onSuccess[T](cs: CompletionStage[T], inner: JFunction[T, Route]) = RouteAdapter {
-    D.onSuccess(cs.toScala.recover(unwrapCompletionException)) { value =>
+    D.onSuccess(cs.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -111,7 +111,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    */
   def completeOrRecoverWith[T](f: Supplier[CompletionStage[T]], marshaller: Marshaller[T, RequestEntity],
       inner: JFunction[Throwable, Route]): Route = RouteAdapter {
-    val magnet = CompleteOrRecoverWithMagnet(f.get.toScala)(Marshaller.asScalaEntityMarshaller(marshaller))
+    val magnet = CompleteOrRecoverWithMagnet(f.get.asScala)(Marshaller.asScalaEntityMarshaller(marshaller))
     D.completeOrRecoverWith(magnet) { ex => inner(ex).delegate }
   }
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
@@ -19,14 +19,13 @@ import java.util.{ function => jf }
 import org.apache.pekko
 import pekko.actor.ReflectiveDynamicAccess
 
-import scala.compat.java8.OptionConverters
-import scala.compat.java8.OptionConverters._
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.model.headers.{ HttpOriginRange, HttpOriginRanges }
 import pekko.http.javadsl.model.HttpHeader
 import pekko.http.javadsl.server.Route
 import pekko.http.scaladsl.model.headers.{ ModeledCustomHeader, ModeledCustomHeaderCompanion }
 import pekko.http.scaladsl.server.directives.{ HeaderDirectives => D, HeaderMagnet }
+import pekko.util.OptionConverters._
 
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
@@ -60,7 +59,7 @@ abstract class HeaderDirectives extends FutureDirectives {
    * with a [[pekko.http.javadsl.server.MalformedHeaderRejection]].
    */
   def headerValue[T](f: jf.Function[HttpHeader, Optional[T]], inner: jf.Function[T, Route]) = RouteAdapter {
-    D.headerValue(h => f.apply(h).asScala) { value =>
+    D.headerValue(h => f.apply(h).toScala) { value =>
       inner.apply(value).delegate
     }
   }
@@ -125,8 +124,8 @@ abstract class HeaderDirectives extends FutureDirectives {
    */
   def optionalHeaderValue[T](f: jf.Function[HttpHeader, Optional[T]], inner: jf.Function[Optional[T], Route]) =
     RouteAdapter {
-      D.optionalHeaderValue(h => f.apply(h).asScala) { value =>
-        inner.apply(value.asJava).delegate
+      D.optionalHeaderValue(h => f.apply(h).toScala) { value =>
+        inner.apply(value.toJava).delegate
       }
     }
 
@@ -138,7 +137,7 @@ abstract class HeaderDirectives extends FutureDirectives {
   def optionalHeaderValuePF[T](pf: PartialFunction[HttpHeader, T], inner: jf.Function[Optional[T], Route]) =
     RouteAdapter {
       D.optionalHeaderValuePF(pf) { value =>
-        inner.apply(value.asJava).delegate
+        inner.apply(value.toJava).delegate
       }
     }
 
@@ -161,7 +160,7 @@ abstract class HeaderDirectives extends FutureDirectives {
     // TODO needs instance of check if it's a modeled header and then magically locate companion
     D.optionalHeaderValueByType(HeaderMagnet.fromClassNormalJavaHeader(t).asInstanceOf[ScalaHeaderMagnet]) { value =>
       val valueT = value.asInstanceOf[Option[T]] // we know this is safe because T <: HttpHeader
-      inner.apply(OptionConverters.toJava[T](valueT)).delegate
+      inner.apply(valueT.toJava).delegate
     }
   }
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/ParameterDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/ParameterDirectives.scala
@@ -22,9 +22,9 @@ import pekko.http.javadsl.server.Route
 import pekko.http.javadsl.unmarshalling.Unmarshaller
 import pekko.http.scaladsl.server.directives.ParameterDirectives._
 import pekko.http.scaladsl.server.directives.{ ParameterDirectives => D }
+import pekko.util.OptionConverters._
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.OptionConverters._
 
 abstract class ParameterDirectives extends MiscDirectives {
 
@@ -37,7 +37,7 @@ abstract class ParameterDirectives extends MiscDirectives {
   def parameterOptional(
       name: String, inner: java.util.function.Function[Optional[String], Route]): Route = RouteAdapter(
     D.parameter(name.optional) { value =>
-      inner.apply(value.asJava).delegate
+      inner.apply(value.toJava).delegate
     })
 
   @CorrespondsTo("parameter")
@@ -69,7 +69,7 @@ abstract class ParameterDirectives extends MiscDirectives {
     import t.asScala
     RouteAdapter(
       D.parameter(name.as[T].optional) { value =>
-        inner.apply(value.asJava).delegate
+        inner.apply(value.toJava).delegate
       })
   }
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/SecurityDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/SecurityDirectives.scala
@@ -18,14 +18,14 @@ import java.util.concurrent.CompletionStage
 import java.util.function.{ Function => JFunction }
 import java.util.function.Supplier
 
-import scala.compat.java8.FutureConverters._
-import scala.compat.java8.OptionConverters._
 import org.apache.pekko
 import pekko.http.javadsl.model.headers.HttpChallenge
 import pekko.http.javadsl.model.headers.HttpCredentials
 import pekko.http.javadsl.server.{ RequestContext, Route }
 import pekko.http.scaladsl
 import pekko.http.scaladsl.server.{ Directives => D }
+import pekko.util.FutureConverters._
+import pekko.util.OptionConverters._
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 
@@ -65,7 +65,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
    */
   def extractCredentials(inner: JFunction[Optional[HttpCredentials], Route]): Route = RouteAdapter {
     D.extractCredentials { cred =>
-      inner.apply(cred.map(_.asJava).asJava).delegate // TODO attempt to not need map()
+      inner.apply(cred.map(_.asJava).toJava).delegate // TODO attempt to not need map()
     }
   }
 
@@ -78,7 +78,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
    */
   def authenticateBasic[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], Optional[T]],
       inner: JFunction[T, Route]): Route = RouteAdapter {
-    D.authenticateBasic(realm, c => authenticator.apply(toJava(c)).asScala) { t =>
+    D.authenticateBasic(realm, c => authenticator.apply(toJava(c)).toScala) { t =>
       inner.apply(t).delegate
     }
   }
@@ -116,7 +116,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
       case credentials =>
         val jCredentials = toJava(credentials)
         if (authenticator.isDefinedAt(jCredentials)) {
-          authenticator(jCredentials).toScala.map(Some(_))
+          authenticator(jCredentials).asScala.map(Some(_))
         } else {
           Future.successful(None)
         }
@@ -139,8 +139,8 @@ abstract class SecurityDirectives extends SchemeDirectives {
   @CorrespondsTo("authenticateBasic")
   def authenticateBasicOptional[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], Optional[T]],
       inner: JFunction[Optional[T], Route]): Route = RouteAdapter {
-    D.authenticateBasic(realm, c => authenticator.apply(toJava(c)).asScala).optional { t =>
-      inner.apply(t.asJava).delegate
+    D.authenticateBasic(realm, c => authenticator.apply(toJava(c)).toScala).optional { t =>
+      inner.apply(t.toJava).delegate
     }
   }
 
@@ -155,7 +155,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
       authenticator: JFunction[Optional[ProvidedCredentials], CompletionStage[Optional[T]]],
       inner: JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      D.authenticateBasicAsync(realm, c => authenticator.apply(toJava(c)).toScala.map(_.asScala)) { t =>
+      D.authenticateBasicAsync(realm, c => authenticator.apply(toJava(c)).asScala.map(_.toScala)) { t =>
         inner.apply(t).delegate
       }
     }
@@ -173,8 +173,8 @@ abstract class SecurityDirectives extends SchemeDirectives {
       authenticator: JFunction[Optional[ProvidedCredentials], CompletionStage[Optional[T]]],
       inner: JFunction[Optional[T], Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      D.authenticateBasicAsync(realm, c => authenticator.apply(toJava(c)).toScala.map(_.asScala)).optional { t =>
-        inner.apply(t.asJava).delegate
+      D.authenticateBasicAsync(realm, c => authenticator.apply(toJava(c)).asScala.map(_.toScala)).optional { t =>
+        inner.apply(t.toJava).delegate
       }
     }
   }
@@ -188,7 +188,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
    */
   def authenticateOAuth2[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], Optional[T]],
       inner: JFunction[T, Route]): Route = RouteAdapter {
-    D.authenticateOAuth2(realm, c => authenticator.apply(toJava(c)).asScala) { t =>
+    D.authenticateOAuth2(realm, c => authenticator.apply(toJava(c)).toScala) { t =>
       inner.apply(t).delegate
     }
   }
@@ -203,8 +203,8 @@ abstract class SecurityDirectives extends SchemeDirectives {
   @CorrespondsTo("authenticateOAuth2")
   def authenticateOAuth2Optional[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], Optional[T]],
       inner: JFunction[Optional[T], Route]): Route = RouteAdapter {
-    D.authenticateOAuth2(realm, c => authenticator.apply(toJava(c)).asScala).optional { t =>
-      inner.apply(t.asJava).delegate
+    D.authenticateOAuth2(realm, c => authenticator.apply(toJava(c)).toScala).optional { t =>
+      inner.apply(t.toJava).delegate
     }
   }
 
@@ -219,7 +219,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
       authenticator: JFunction[Optional[ProvidedCredentials], CompletionStage[Optional[T]]],
       inner: JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      D.authenticateOAuth2Async(realm, c => authenticator.apply(toJava(c)).toScala.map(_.asScala)) { t =>
+      D.authenticateOAuth2Async(realm, c => authenticator.apply(toJava(c)).asScala.map(_.toScala)) { t =>
         inner.apply(t).delegate
       }
     }
@@ -237,8 +237,8 @@ abstract class SecurityDirectives extends SchemeDirectives {
       authenticator: JFunction[Optional[ProvidedCredentials], CompletionStage[Optional[T]]],
       inner: JFunction[Optional[T], Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      D.authenticateOAuth2Async(realm, c => authenticator.apply(toJava(c)).toScala.map(_.asScala)).optional { t =>
-        inner.apply(t.asJava).delegate
+      D.authenticateOAuth2Async(realm, c => authenticator.apply(toJava(c)).asScala.map(_.toScala)).optional { t =>
+        inner.apply(t.toJava).delegate
       }
     }
   }
@@ -254,7 +254,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
       inner: JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
       val scalaAuthenticator = { cred: Option[scaladsl.model.headers.HttpCredentials] =>
-        authenticator.apply(cred.map(_.asJava).asJava).toScala.map(_.left.map(_.asScala))
+        authenticator.apply(cred.map(_.asJava).toJava).asScala.map(_.left.map(_.asScala))
       }
 
       D.authenticateOrRejectWithChallenge(scalaAuthenticator) { t =>
@@ -273,7 +273,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
       inner: JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
       val scalaAuthenticator = { cred: Option[scaladsl.model.headers.HttpCredentials] =>
-        authenticator.apply(cred.filter(c.isInstance).map(_.asJava).asJava.asInstanceOf[Optional[C]]).toScala.map(
+        authenticator.apply(cred.filter(c.isInstance).map(_.asJava).toJava.asInstanceOf[Optional[C]]).asScala.map(
           _.left.map(_.asScala)) // TODO make sure cast is safe
       }
 
@@ -308,7 +308,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
    * If the check fails the route is rejected with an [[pekko.http.javadsl.server.AuthorizationFailedRejection]].
    */
   def authorizeAsync(check: Supplier[CompletionStage[Boolean]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.authorizeAsync(check.get().toScala) {
+    D.authorizeAsync(check.get().asScala) {
       inner.get().delegate
     }
   }
@@ -321,6 +321,6 @@ abstract class SecurityDirectives extends SchemeDirectives {
   @CorrespondsTo("authorizeAsync")
   def authorizeAsyncWithRequestContext(check: pekko.japi.function.Function[RequestContext, CompletionStage[Boolean]],
       inner: Supplier[Route]): Route = RouteAdapter {
-    D.authorizeAsync(rc => check(RequestContext.wrap(rc)).toScala)(inner.get().delegate)
+    D.authorizeAsync(rc => check(RequestContext.wrap(rc)).asScala)(inner.get().delegate)
   }
 }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -32,10 +32,10 @@ import pekko.http.scaladsl.unmarshalling.Unmarshaller.{
 import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.{ Materializer, SystemMaterializer }
 import pekko.util.ByteString
+import pekko.util.FutureConverters._
 import scala.annotation.nowarn
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
 
 object Unmarshaller extends pekko.http.javadsl.unmarshalling.Unmarshallers {
@@ -55,7 +55,7 @@ object Unmarshaller extends pekko.http.javadsl.unmarshalling.Unmarshallers {
    * Creates an unmarshaller from an asynchronous Java function.
    */
   override def async[A, B](f: java.util.function.Function[A, CompletionStage[B]]): Unmarshaller[A, B] =
-    unmarshalling.Unmarshaller[A, B] { ctx => a => f(a).toScala }
+    unmarshalling.Unmarshaller[A, B] { ctx => a => f(a).asScala }
 
   /**
    * Creates an unmarshaller from a Java function.
@@ -144,7 +144,7 @@ abstract class Unmarshaller[-A, B] extends UnmarshallerBase[A, B] {
    * Apply this Unmarshaller to the given value.
    */
   def unmarshal(value: A, ec: ExecutionContext, mat: Materializer): CompletionStage[B] =
-    asScala.apply(value)(ec, mat).toJava
+    asScala.apply(value)(ec, mat).asJava
 
   /**
    * Apply this Unmarshaller to the given value. Uses the default materializer [[ExecutionContext]].
@@ -173,7 +173,7 @@ abstract class Unmarshaller[-A, B] extends UnmarshallerBase[A, B] {
   def thenApply[C](f: java.util.function.Function[B, C]): Unmarshaller[A, C] = asScala.map(f.apply)
 
   def flatMap[C](f: java.util.function.Function[B, CompletionStage[C]]): Unmarshaller[A, C] =
-    asScala.flatMap { ctx => mat => b => f.apply(b).toScala }
+    asScala.flatMap { ctx => mat => b => f.apply(b).asScala }
 
   def flatMap[C](u: Unmarshaller[_ >: B, C]): Unmarshaller[A, C] =
     asScala.flatMap { ctx => mat => b => u.asScala.apply(b)(ctx, mat) }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
@@ -27,10 +27,10 @@ import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.pattern.CircuitBreakerOpenException
 import pekko.http.javadsl.model.headers.{ HttpOrigin => JHttpOrigin }
 import pekko.http.scaladsl.model.headers.{ HttpOrigin => SHttpOrigin }
+import pekko.util.OptionConverters._
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.compat.java8.OptionConverters
 import scala.runtime.AbstractFunction1
 
 /**
@@ -41,7 +41,7 @@ import scala.runtime.AbstractFunction1
 trait Rejection extends pekko.http.javadsl.server.Rejection
 
 trait RejectionWithOptionalCause extends Rejection {
-  final def getCause: Optional[Throwable] = OptionConverters.toJava(cause)
+  final def getCause: Optional[Throwable] = cause.toJava
   def cause: Option[Throwable]
 }
 

--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -53,7 +53,7 @@ object PekkoDependency {
   }
 
   // Default version updated only when needed, https://pekko.apache.org/docs/pekko/current/project/downstream-upgrade-strategy.html
-  val minimumExpectedPekkoVersion = "0.0.0+26629-321c5721-SNAPSHOT"
+  val minimumExpectedPekkoVersion = "0.0.0+26656-898c6970-SNAPSHOT"
   val default = pekkoDependency(defaultVersion = minimumExpectedPekkoVersion)
   def docs = default
 


### PR DESCRIPTION
This PR implements all of the changes brought in from pekko-core regarding the usage of `OptionConverters`/`FutureConverters` and `FunctionConverters` from `org.apache.pekko.util`. For the most part the changes were mechanical  however I have annotated the PR for notable parts.