### PR TITLE
Integrate sbt-license-report

### DIFF
--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -5,6 +5,7 @@
 @@@ index
 
 * [Security Announcements](security.md)
+* [License Report](license-report.md)
 * [Release Notes](release-notes/index.md)
 * [introduction](introduction.md)
 * [usage](usage.md)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,10 +44,10 @@ object Dependencies {
     scalaVersion := allScalaVersions.head)
 
   object Provided {
-    val jsr305 = "com.google.code.findbugs" % "jsr305" % "3.0.2" % "provided" // ApacheV2
+    val jsr305 = "com.google.code.findbugs" % "jsr305" % "3.0.2" % "provided"
 
     val scalaReflect = ScalaVersionDependentModuleID.fromPF {
-      case v if v.startsWith("2.") => "org.scala-lang" % "scala-reflect" % v % "provided" // Scala License
+      case v if v.startsWith("2.") => "org.scala-lang" % "scala-reflect" % v % "provided"
     }
   }
 
@@ -55,47 +55,48 @@ object Dependencies {
     val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
 
     // For pekko-http spray-json support
-    val sprayJson = "io.spray" %% "spray-json" % "1.3.6" // ApacheV2
+    val sprayJson = "io.spray" %% "spray-json" % "1.3.6"
 
     // For pekko-http-jackson support
-    val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion // ApacheV2
+    val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 
     // For pekko-http-testkit-java
-    val junit = "junit" % "junit" % junitVersion // Common Public License 1.0
+    val junit = "junit" % "junit" % junitVersion
 
     val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3"
 
-    val scalafix = "ch.epfl.scala" %% "scalafix-core" % Dependencies.scalafixVersion // grab from plugin
+    val scalafix = "ch.epfl.scala" %% "scalafix-core" % Dependencies.scalafixVersion
 
-    val parboiled = "org.parboiled" %% "parboiled" % "2.4.1" // ApacheV2
+    val parboiled = "org.parboiled" %% "parboiled" % "2.4.1"
 
     object Docs {
       val sprayJson = Compile.sprayJson % "test"
       val gson = "com.google.code.gson" % "gson" % "2.9.0" % "test"
-      val jacksonXml = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % jacksonXmlVersion % "test" // ApacheV2
-      val reflections = "org.reflections" % "reflections" % "0.10.2" % "test" // WTFPL
+      val jacksonXml = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % jacksonXmlVersion % "test"
+      val reflections = "org.reflections" % "reflections" % "0.10.2" % "test"
     }
 
     object Test {
-      val sprayJson = Compile.sprayJson % "test" // ApacheV2
-      val junit = Compile.junit % "test" // Common Public License 1.0
+      val sprayJson = Compile.sprayJson % "test"
+      val junit = Compile.junit % "test"
       val specs2 = {
-        val specs2 = "org.specs2" %% "specs2-core" // MIT
+        val specs2 = "org.specs2" %% "specs2-core"
         ScalaVersionDependentModuleID.versioned {
           case v if v.startsWith("2.") => specs2 % "4.10.6"
           case _                       => specs2 % "4.15.0"
         }
       }
 
-      val scalacheck = "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test" // New BSD
-      val junitIntf = "com.github.sbt" % "junit-interface" % "0.13.3" % "test" // MIT
+      val scalacheck = "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test"
+      val junitIntf = "com.github.sbt" % "junit-interface" % "0.13.3" % "test"
 
-      val scalatest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test" // ApacheV2
+      val scalatest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
       val scalatestplusScalacheck = "org.scalatestplus" %% "scalacheck-1-15" % (scalaTestVersion + ".0") % "test"
       val scalatestplusJUnit = "org.scalatestplus" %% "junit-4-13" % (scalaTestVersion + ".0") % "test"
 
       // HTTP/2
-      val h2spec = ("io.github.summerwind" % h2specName % h2specVersion % "test").from(h2specUrl) // MIT
+
+      val h2spec = ("io.github.summerwind" % h2specName % h2specVersion % "test").from(h2specUrl)
     }
   }
 

--- a/project/LicenseReport.scala
+++ b/project/LicenseReport.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+import sbt._
+import sbtlicensereport.SbtLicenseReport
+import sbtlicensereport.SbtLicenseReport.autoImportImpl._
+import sbtlicensereport.license.{ DepModuleInfo, LicenseInfo, MarkDown }
+
+object LicenseReport extends AutoPlugin {
+
+  override lazy val projectSettings = Seq(
+    licenseReportTypes := Seq(MarkDown),
+    licenseReportMakeHeader := (language => language.header1("License Report")),
+    licenseConfigurations := Set("compile", "test", "provided"),
+    licenseDepExclusions := {
+      case DepModuleInfo("org.apache.pekko", _, _) => true // Inter pekko project dependencies are pointless
+      case DepModuleInfo(_, "scala-library", _)    => true // Scala library is part of Scala language
+      case DepModuleInfo(_, "scala-reflect", _)    => true // Scala reflect is part of Scala language
+    },
+    licenseOverrides := {
+      // H2spec is added directly by URI which is why it cannot resolve license information from Maven.
+      // License can be found at https://github.com/summerwind/h2spec/blob/master/LICENSE
+      case dep: DepModuleInfo if dep.name.toLowerCase.contains("h2spec") => LicenseInfo.MIT
+    },
+    licenseReportColumns := Seq(
+      Column.Category,
+      Column.License,
+      Column.Dependency,
+      Column.OriginatingArtifactName,
+      Column.Configuration))
+
+  override def requires = plugins.JvmPlugin && SbtLicenseReport
+
+  override def trigger = allRequirements
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,6 +16,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1") // for advanced PR validation features
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
+addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.5.0")
 // allow access to snapshots for pekko-sbt-paradox
 resolvers += Resolver.ApacheMavenSnapshotsRepo
 


### PR DESCRIPTION
Same as https://github.com/apache/incubator-pekko/pull/319 but for this project. Since pekko-http has a different doc layout, it is being placed in root under `Security Announcements!` i.e.

![image](https://github.com/apache/incubator-pekko-http/assets/2337269/07cdcdf4-406d-45ee-9e8c-10e1a23767a2)

Feel free to approve the PR but please don't merge it until the Scala 3 PR gets merged, the Scala 3 PR is already outstanding and I don't want to complicate it more by creating more merge conflicts.