### PR TITLE
Rename RuleSuite package from akka to pekko

### DIFF
--- a/http-scalafix/scalafix-tests/src/test/scala/org/apache/pekko/http/fix/RuleSuite.scala
+++ b/http-scalafix/scalafix-tests/src/test/scala/org/apache/pekko/http/fix/RuleSuite.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2020-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.http.fix
+package org.apache.pekko.http.fix
 
 import org.scalatest.FunSpecLike
 import scalafix.testkit.AbstractSemanticRuleSuite


### PR DESCRIPTION
I found this when working on Scala 3 PR which also fixes this issue, but does it incorrectly so its a lot cleaner if I fix this separately. 