### PR TITLE
Add javafmt to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # scalafmt
 90f8bf7e6d6f7a2d6c63313944613a95ff60091a
+
+# javafmt
+8d11f7fb91d7bbea9b2758d528d01d5e4c88ff13


### PR DESCRIPTION
Add the formatting commit from https://github.com/apache/incubator-pekko-http/pull/154 to `.git-blame-ignore-revs`