### PR TITLE
Update parboiled apply performance fix

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,7 +67,7 @@ object Dependencies {
 
     val scalafix = "ch.epfl.scala" %% "scalafix-core" % Dependencies.scalafixVersion
 
-    val parboiled = "org.parboiled" %% "parboiled" % "2.4.1"
+    val parboiled = "org.parboiled" %% "parboiled" % "2.5.0"
 
     object Docs {
       val sprayJson = Compile.sprayJson % "test"


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-http/issues/103

This PR updates to the latest released Parboiled2 which aside from supporting Scala 3.3 LTS also contains all of the upstreamed performance fixes aside from https://github.com/sirthias/parboiled2/pull/418 which @jrudolph solved within pekko-http at https://github.com/jrudolph/incubator-pekko-http/commit/67f46c3e5afbd1086aae5ef4eade5d9b831540ac , that specific commit has been cherry picked onto this PR.