### PR TITLE
upgrade pekko snapshot

### DIFF
--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -53,7 +53,7 @@ object PekkoDependency {
   }
 
   // Default version updated only when needed, https://pekko.apache.org/docs/pekko/current/project/downstream-upgrade-strategy.html
-  val minimumExpectedPekkoVersion = "0.0.0+26671-d5a1b2ef-SNAPSHOT"
+  val minimumExpectedPekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
   val default = pekkoDependency(defaultVersion = minimumExpectedPekkoVersion)
   def docs = default
 


### PR DESCRIPTION
to get a version that uses Scala 3.3.0