### PR TITLE
Unwrap single string interpolation syntax

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -76,7 +76,7 @@ object HandleNotFoundWithThePath {
     RejectionHandler.newBuilder()
       .handleNotFound {
         extractUnmatchedPath { p =>
-          complete(NotFound, s"The path you requested [${p}] does not exist.")
+          complete(NotFound, s"The path you requested [$p] does not exist.")
         }
       }
       .result()

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
@@ -21,7 +21,7 @@ class SchemeDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     // #example-1
     val route =
       extractScheme { scheme =>
-        complete(s"The scheme is '${scheme}'")
+        complete(s"The scheme is '$scheme'")
       }
 
     // tests:

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -56,7 +56,7 @@ object CopyrightHeader extends AutoPlugin {
         case Some(currentText) if isOnlyLightbendCopyrightAnnotated(currentText) =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText) + NewLine * 2 + currentText
         case Some(currentText) =>
-          throw new IllegalStateException(s"Unable to detect copyright for header: [${currentText}]")
+          throw new IllegalStateException(s"Unable to detect copyright for header: [$currentText]")
         case None =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText)
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val h2specVersion = "1.5.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
-  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v${h2specVersion}/${h2specName}.zip"
+  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.zip"
 
   val scalaTestVersion = "3.2.9"
   val specs2Version = "4.10.6"


### PR DESCRIPTION
Unwraps single string interpolation i.e. `s"${something}"` into `s"$something"`. Make sure to do a rebase merge of this PR because I need to add its commit to `.git-blame-ignore-revs`