### PR TITLE
Cache snapshots to prevent overloading Apache Nexus repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,9 @@ inThisBuild(Def.settings(
   },
   scalafixScalaBinaryVersion := scalaBinaryVersion.value,
   apacheSonatypeProjectProfile := "pekko",
-  versionScheme := Some("semver-spec")))
+  versionScheme := Some("semver-spec"),
+  // TODO: Remove when Pekko has a proper release
+  updateOptions := updateOptions.value.withLatestSnapshots(false)))
 
 // When this is updated the set of modules in Http.allModules should also be updated
 lazy val userProjects: Seq[ProjectReference] = List[ProjectReference](

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,8 +26,10 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1") // for 
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.5.0")
+
 // allow access to snapshots for pekko-sbt-paradox
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 // We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
 // only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8


### PR DESCRIPTION
The Apache Snapshots nexus repo is sometimes giving us request refused, likely because we are overloading the repo with excessive amount of requests.  This is due to the fact that we are using `SNAPSHOT` versions which by default don't cache because they are mutable (i.e. you can reupload snapshots with different implementations as much as you like).

Since for both pekko and its project forks the snapshot version is derived from git hash, there is no disadvantage to caching the snapshot.