### PR TITLE
Use java.io.File.deleteOnExit

### DIFF
--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectives.scala
@@ -176,12 +176,9 @@ trait FileUploadDirectives {
       implicit val ec = ctx.executionContext
 
       def tempDest(fileInfo: FileInfo): File = {
-        val dest = Files.createTempFile("pekko-http-upload", ".tmp")
-        Runtime.getRuntime.addShutdownHook(new Thread() {
-          override def run(): Unit =
-            Files.deleteIfExists(dest)
-        })
-        dest.toFile
+        val dest = Files.createTempFile("pekko-http-upload", ".tmp").toFile
+        dest.deleteOnExit()
+        dest
       }
 
       storeUploadedFiles(fieldName, tempDest).map { files =>


### PR DESCRIPTION
This should properly restore the old behaviour, i.e. before https://github.com/apache/incubator-pekko-http/pull/170 was merged. Manually creating shut down hooks can create leaks and `java.io.File.deleteOnExit` only creates a single shutdownhook and maintains an internal collection of files to be deleted.

Doesn't resolve https://github.com/apache/incubator-pekko-http/issues/175 but at least it removes the current problematic cases of it.