### PR TITLE
Update sbt-scalafix

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -43,7 +43,7 @@ addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-project-info" % "2.0.0").fo
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.4")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")


### PR DESCRIPTION
This is necessary due to the fact that scala 2.12 was updated to 2.13.11 (sbt-scalafix is sensitive to patch versions of Scala compiler)

Without this change you get this error when loading project in in Intellij

```
not found: https://repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_2.13.11/4.6.0/semanticdb-scalac_2.13.11-4.6.0.pom
not found: https://repository.apache.org/content/repositories/snapshots/org/scalameta/semanticdb-scalac_2.13.11/4.6.0/semanticdb-scalac_2.13.11-4.6.0.pom
not found: https://oss.sonatype.org/service/local/repositories/releases/content/org/scalameta/semanticdb-scalac_2.13.11/4.6.0/semanticdb-scalac_2.13.11-4.6.0.pom
not found: https://s01.oss.sonatype.org/content/repositories/releases/org/scalameta/semanticdb-scalac_2.13.11/4.6.0/semanticdb-scalac_2.13.11-4.6.0.pom
not found: https://jcenter.bintray.com/org/scalameta/semanticdb-scalac_2.13.11/4.6.0/semanticdb-scalac_2.13.11-4.6.0.pom
not found: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/org.scalameta/semanticdb-scalac_2.13.11/4.6.0/ivys/ivy.xml
not found: https://repo.typesafe.com/typesafe/ivy-releases/org.scalameta/semanticdb-scalac_2.13.11/4.6.0/ivys/ivy.xml
```