### PR TITLE
compile warning about var that could be a val

### DIFF
--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
@@ -72,7 +72,7 @@ private[coding] class GzipDecompressor(
     maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
   override def createLogic(attr: Attributes) = new ParsingLogic {
     private[this] val inflater = new Inflater(true)
-    private[this] var crc32: CRC32 = new CRC32
+    private[this] val crc32: CRC32 = new CRC32
 
     trait Step extends ParseStep[ByteString] {
       override def onTruncation(): Unit = failStage(new ZipException("Truncated GZIP stream"))


### PR DESCRIPTION
```
[warn] /Users/pj.fanning/code/incubator-pekko-http/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala:75:23: local var crc32 in <$anon: GzipDecompressor.this.ParsingLogic> is never updated: consider using immutable val
[warn]     private[this] var crc32: CRC32 = new CRC32
```