### PR TITLE
avoid unapply due to issue reported by Play team (scala 3 only)

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/ProtocolSwitch.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/ProtocolSwitch.scala
@@ -62,10 +62,10 @@ private[http] object ProtocolSwitch {
               new InHandler {
                 def onPush(): Unit =
                   grab(netIn) match {
-                    case first @ SessionBytes(session, bytes) =>
+                    case first: SessionBytes =>
                       val chosen = chosenProtocolAccessor(first)
                       chosen match {
-                        case "h2" => install(http2Stack.addAttributes(HttpAttributes.tlsSessionInfo(session)), first)
+                        case "h2" => install(http2Stack.addAttributes(HttpAttributes.tlsSessionInfo(first.session)), first)
                         case _    => install(http1Stack, first)
                       }
                     case SessionTruncated =>

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/ProtocolSwitch.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/ProtocolSwitch.scala
@@ -65,8 +65,9 @@ private[http] object ProtocolSwitch {
                     case first: SessionBytes =>
                       val chosen = chosenProtocolAccessor(first)
                       chosen match {
-                        case "h2" => install(http2Stack.addAttributes(HttpAttributes.tlsSessionInfo(first.session)), first)
-                        case _    => install(http1Stack, first)
+                        case "h2" =>
+                          install(http2Stack.addAttributes(HttpAttributes.tlsSessionInfo(first.session)), first)
+                        case _ => install(http1Stack, first)
                       }
                     case SessionTruncated =>
                       failStage(new SSLException("TLS session was truncated (probably missing a close_notify packet)."))


### PR DESCRIPTION
* relates to https://github.com/apache/incubator-pekko-http/issues/183
* simplifies the code, we don't really need the unapply