### PR TITLE
remove unused variable

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/ProtocolSwitch.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/ProtocolSwitch.scala
@@ -49,7 +49,6 @@ private[http] object ProtocolSwitch {
           val terminatorPromise = Promise[ServerTerminator]()
 
           object Logic extends GraphStageLogic(shape) {
-            logic =>
 
             // --- inner ports, bound to actual server in install call ---
             val serverDataIn = new SubSinkInlet[SslTlsOutbound]("ServerImpl.netIn")


### PR DESCRIPTION
saw this declaration when investigating #183 

I'm not sure why the `logic` var was added. I appears to be unused. No compile or test issues occurred after removing this line.