### PR TITLE
Use release 8 scalac flag to allow building on JDK11+

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -35,10 +35,8 @@ object Common extends AutoPlugin {
       "-Wconf:cat=deprecation&msg=since Akka 2\\.6\\.:s",
       // tolerate deprecations from Akka HTTP 10.2.0 until Pekko 1.1.x where we clean up
       "-Wconf:cat=deprecation&msg=since Akka HTTP 10\\.2\\.:s",
-      "-Wconf:msg=reached max recursion depth:s") ++
-    (if (isJdk8) Seq.empty
-     else if (scalaBinaryVersion.value == "2.12") Seq("-target:jvm-1.8")
-     else Seq("-release", "8")),
+      "-Wconf:msg=reached max recursion depth:s",
+      "-release:8"),
     scalacOptions ++= onlyOnScala2(Seq(
       "-Xlint",
       // Silence deprecation notices for changes introduced in Scala 2.12


### PR DESCRIPTION
This PR is the equivalent of https://github.com/apache/incubator-pekko/pull/258 but for pekko-http. The context behind these changes are complicated (read the linked pekko PR for more detail) but long story short the `release` scalac flag for Scala 2 changed at some point. The original version of `release` flag (which the code currently in pekko-http was written for) only makes scalac produce JDK 8 bytecode but it ignores the JDK 8 runtime `rt.jar`. This is almost never what you want, so a the same flag was updated in later versions of Scala (see https://github.com/scala/scala/pull/9982) which also brings in the correct `rt.jar`, i.e. if you build a project using JDK 11 with the `-release:8` flag then not only will it produce JDK8 bytecode but it will also bring in JDK 8's `rt.jar`.

That part about bringing in the `rt.jar` 8 jar is critical because, because there was a change from JDK 8 to JDK9's stdlib where if you compile a codebase with JDK9+, because of a newly added overloaded method that is only available in JDK9+ the produced bytecode will reference that new method rather than the JDK8 one. This is what was documented in https://github.com/apache/incubator-pekko/pull/258/files#diff-c11a10bd9e773399e4272cd1ee5dff72545afb2f8bed23f2d1bbc49d4e1fc03fL61-L66.

tl;dr Since we are using the most modern versions of scalac, we can just use `release:8` and it handles the corner cases described above. pekko-core had code in sbt to prevent building without an available JDK 8, pekko-http had the same core issue with the deprecated flag but it seems that this same check wasn't added.

To verify that this PR does in fact produce the same bytecode as if the project was compiled under JDK 8 https://github.com/lightbend-labs/jardiff was used. Its fairly easy to verify this yourself, clone incubator-pekko into a new directory (lets call it `incubator-pekko-2`) and compile it under JDK 8 using `sbt ++compile`. Then compile this branch/PR in an `incubator-pekko` folder using JDK 11 and create a new folder called `diff-temp`. Then you can just run

```
jardiff -g ~/github/diff-temp/ ~/github/incubator-pekko-http/http-core/target/scala-2.12/ ~/github/incubator-pekko-http-2/http-core/target/scala-2.12/
```

Which creates a git repository in `diff-temp` showing the bytecode diff. Using a git diff viewer (I use Intellij) you get the following

![image](https://github.com/apache/incubator-pekko-http/assets/2337269/8145cbcc-d7bf-4730-bb2e-bf9c4fd62810)

As you can see while there are some difference its not anything of consequence (i.e. `Version` has changed but thats because the project version which is derived from the git has changed).

If we however run the jardiff tool without the changes in this PR/branch we get the following

![image](https://github.com/apache/incubator-pekko-http/assets/2337269/3fd016e8-dfb2-41e9-808f-520d1bf7686f)

Notice how we now have differences in `HttpHeaderParser`/`CustomCharsetByteStringRenderer`, and if we view what the difference is we get

![image](https://github.com/apache/incubator-pekko-http/assets/2337269/8c7e7b71-cf9e-4c42-a204-f281a100063c)

Which is precisely the problem talked about earlier.

