### PR TITLE
Remove unneeded parser settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,9 +120,7 @@ lazy val parsing = project("parsing")
   .settings(AutomaticModuleName.settings("pekko.http.parsing"))
   .addPekkoModuleDependency("pekko-actor", "provided")
   .settings(Dependencies.parsing)
-  .settings(
-    scalacOptions --= Seq("-Xfatal-warnings", "-Xlint", "-Ywarn-dead-code"), // disable warnings for parboiled code
-    scalacOptions += "-language:_")
+  .settings(scalacOptions += "-language:_")
   .settings(scalaMacroSupport)
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
   .enablePlugins(ReproducibleBuildsPlugin)


### PR DESCRIPTION
As noted in the comments these options were needed for Parboiled but since we are now using upstream parboiled rather than manually inlined source (see https://github.com/apache/incubator-pekko-http/pull/14) the settings are no longer relevant.