### PR TITLE
add utf8-decoder license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -214,3 +214,25 @@ pekko-http-core contains code from scala-collection-compat in the `org.apache.pe
 distributed under the Apache 2.0 license.
 Copyright (c) 2002-2023 EPFL
 Copyright (c) 2011-2023 Lightbend, Inc.
+
+---------------
+
+pekko-http-core contains code from https://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+in `org.apache.pekko.http.impl.engine.ws.Utf8Decoder.scala` that was distributed under a MIT license.
+
+Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/Utf8Decoder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/Utf8Decoder.scala
@@ -11,23 +11,7 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package org.apache.pekko.http.impl.engine.ws
-
-import org.apache.pekko
-import pekko.annotation.InternalApi
-import pekko.util.ByteString
-
-import scala.util.Try
-
-/**
- * A Utf8 -> Utf16 (= Java char) decoder.
- *
- * This decoder is based on the one of Bjoern Hoehrmann from
- *
- * http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
- *
- * which is licensed under this license:
- *
+/*
  * Copyright (C) 2008-2017 Bjoern Hoehrmann <bjoern@hoehrmann.de>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
@@ -46,6 +30,21 @@ import scala.util.Try
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.apache.pekko.http.impl.engine.ws
+
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.util.ByteString
+
+import scala.util.Try
+
+/**
+ * A Utf8 -> Utf16 (= Java char) decoder.
+ *
+ * This decoder is based on the one of Bjoern Hoehrmann from
+ * https://bjoern.hoehrmann.de/utf-8/decoder/dfa/ (MIT License).
  *
  * INTERNAL API
  */


### PR DESCRIPTION
* pekko-http-core already uses the root LICENSE because so far all mods to the standard license relate to pekko-http-core
* all other jars use the standard Apache License (which may change)