### PR TITLE
build: fix nightly scala 3 compilation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,10 +41,10 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: Compile everything
-        run: sbt -Dpekko.http.build.pekko.version=${{ matrix.PEKKO_VERSION }} ++${{ matrix.SCALA_VERSION }} Test/compile
+        run: sbt -Dpekko.http.build.pekko.version=${{ matrix.PEKKO_VERSION }} "++ ${{ matrix.SCALA_VERSION }}" Test/compile
 
       - name: Run all tests JDK ${{ matrix.JDK }}, Scala ${{ matrix.SCALA_VERSION }}, Akka ${{ matrix.PEKKO_VERSION }}
-        run: sbt -Dpekko.http.parallelExecution=false -Dpekko.test.timefactor=2 -Dpekko.http.build.pekko.version=${{ matrix.PEKKO_VERSION }} ++${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues test
+        run: sbt -Dpekko.http.parallelExecution=false -Dpekko.test.timefactor=2 -Dpekko.http.build.pekko.version=${{ matrix.PEKKO_VERSION }} "++ ${{ matrix.SCALA_VERSION }}" mimaReportBinaryIssues test
 
       - name: Upload test results
         uses: actions/upload-artifact@v3  # upload test results


### PR DESCRIPTION
Because ``++3` isn't supported by the sbt cross-building parser.