### PR TITLE
remove broken link from docs - cannot find another link that works

### DIFF
--- a/docs/src/main/paradox/client-side/host-level.md
+++ b/docs/src/main/paradox/client-side/host-level.md
@@ -175,7 +175,7 @@ by failing requests with a @apidoc[BufferOverflowException] when the internal bu
 exist or too many requests have been issued to the pool.
 
 To mimic the request-level API we can put an explicit queue in front of the pool and decide ourselves what to do when
-this explicit queue overflows. This example shows how to do this. (Thanks go to [kazuhiro's blog for the initial idea](https://kazuhiro.github.io/scala/akka/akka-http/akka-streams/2016/01/31/connection-pooling-with-akka-http-and-source-queue.html).)
+this explicit queue overflows. This example shows how to do this.
 
 You can tweak the `QueueSize` setting according to your memory constraints. In any case, you need to think about a strategy
 about what to do when requests fail because the queue overflowed (e.g. try again later or just fail).

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -195,7 +195,7 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
 
     val QueueSize = 10
 
-    // This idea came initially from this blog post:
+    // This idea came initially from this blog post (link broken):
     // http://kazuhiro.github.io/scala/akka/akka-http/akka-streams/2016/01/31/connection-pooling-with-akka-http-and-source-queue.html
     val poolClientFlow = Http().cachedHostConnectionPool[Promise[HttpResponse]]("pekko.apache.org")
     val queue =


### PR DESCRIPTION
@kazuhiro if you could provide an alternate link for the broken one, we will use it

https://kazuhiro.github.io/scala/akka/akka-http/akka-streams/2016/01/31/connection-pooling-with-akka-http-and-source-queue.html