### PR TITLE
Add pekko-http-cors module

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -21,3 +21,9 @@ Copyright (c) 2011-2023 Lightbend, Inc.
 Scala includes software developed at
 LAMP/EPFL (https://lamp.epfl.ch/) and
 Lightbend, Inc. (https://www.lightbend.com/).
+
+---------------
+
+pekko-http-cors contains code that was donated by Lomig Mégard to the Apache Software Foundation
+via a Software Grant Agreement <https://www.apache.org/licenses/contributor-agreements.html#grants>
+See <https://github.com/lomigmegard/pekko-http-cors/issues/33>.

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val userProjects: Seq[ProjectReference] = List[ProjectReference](
   http2Tests,
   http,
   httpCaching,
+  httpCors,
   httpTestkit,
   httpMarshallersScala,
   httpMarshallersJava,
@@ -250,7 +251,7 @@ lazy val httpTests = project("http-tests")
 
 lazy val httpJmhBench = project("http-bench-jmh")
   .settings(commonSettings)
-  .dependsOn(http, http2Tests % "compile->compile,test")
+  .dependsOn(http, httpCors, http2Tests % "compile->compile,test")
   .addPekkoModuleDependency("pekko-stream")
   .enablePlugins(JmhPlugin)
   .enablePlugins(NoPublish) // don't release benchs
@@ -297,6 +298,17 @@ lazy val httpCaching = project("http-caching")
   .addPekkoModuleDependency("pekko-stream", "provided")
   .addPekkoModuleDependency("pekko-stream-testkit", "provided")
   .settings(Dependencies.httpCaching)
+  .dependsOn(http, httpCore, httpTestkit % "test")
+  .enablePlugins(BootstrapGenjavadoc)
+
+lazy val httpCors = project("http-cors")
+  .settings(
+    name := "pekko-http-cors")
+  .settings(commonSettings)
+  .settings(AutomaticModuleName.settings("pekko.http.cors"))
+  .addPekkoModuleDependency("pekko-stream", "provided")
+  .addPekkoModuleDependency("pekko-stream-testkit", "provided")
+  .settings(Dependencies.httpCors)
   .dependsOn(http, httpCore, httpTestkit % "test")
   .enablePlugins(BootstrapGenjavadoc)
 
@@ -389,7 +401,7 @@ lazy val docs = project("docs")
   .addPekkoModuleDependency("pekko-stream-testkit", "provided", PekkoDependency.docs)
   .addPekkoModuleDependency("pekko-actor-testkit-typed", "provided", PekkoDependency.docs)
   .dependsOn(
-    httpCore, http, httpXml, http2Tests, httpMarshallersJava, httpMarshallersScala, httpCaching,
+    httpCore, http, httpXml, http2Tests, httpMarshallersJava, httpMarshallersScala, httpCaching, httpCors,
     httpTests % "compile;test->test", httpTestkit % "compile;test->test", httpScalafixRules % ScalafixConfig)
   .settings(Dependencies.docs)
   .settings(

--- a/docs/src/main/paradox/common/cors.md
+++ b/docs/src/main/paradox/common/cors.md
@@ -1,0 +1,108 @@
+# Cors
+
+Apache Pekko HTTP's cors module provides support for the [W3C cors standard](https://www.w3.org/TR/cors/)
+
+## Dependency
+
+To use Apache Pekko HTTP Cors, add the module to your project:
+
+@@dependency [sbt,Gradle,Maven] {
+bomGroup2="org.apache.pekko" bomArtifact2="pekko-http-bom_$scala.binary.version$" bomVersionSymbols2="PekkoHttpVersion"
+symbol="PekkoHttpVersion"
+value="$project.version$"
+group="org.apache.pekko"
+artifact="pekko-http-cors_$scala.binary.version$"
+version="PekkoHttpVersion"
+}
+
+## Quick Start
+The simplest way to enable CORS in your application is to use the `cors` directive.
+Settings are passed as a parameter to the directive, with your overrides loaded from the `application.conf`.
+
+@@@ div { .group-scala }
+```scala
+import org.apache.pekko.http.cors.scaladsl.CorsDirectives._
+
+val route: Route = cors() {
+  complete(...)
+}
+```
+@@@
+@@@ div { .group-java }
+```java
+import static org.apache.pekko.http.cors.javadsl.CorsDirectives.*;
+
+final Route route = cors(() -> {
+    complete(...)
+})
+```
+@@@
+
+The settings can be updated programmatically too.
+@@@ div { .group-scala }
+```scala
+val settings = CorsSettings(...).withAllowGenericHttpRequests(false)
+val strictRoute: Route = cors(settings) {
+  complete(...)
+}
+```
+@@@
+@@@ div { .group-java }
+```java
+final CorsSettings settings = CorsSettings.create(...).withAllowGenericHttpRequests(false);
+final Route route = cors(settings, () -> {
+    complete(...)
+});
+```
+@@@
+
+## Rejection
+The CORS directives can reject requests using the `CorsRejection` class. Requests can be either malformed or not allowed to access the resource.
+
+A rejection handler is provided by the library to return meaningful HTTP responses. Read the pekko documentation (link TODO) to learn more about rejections, or if you need to write your own handler.
+
+Scala
+:   @@snip [CorsServerExample.scala](/docs/src/test/scala/docs/http/scaladsl/server/cors/CorsServerExample.scala) { #cors-server-example }
+
+Java
+:   @@snip [CorsServerExample.java](/docs/src/test/java/docs/http/javadsl/server/cors/CorsServerExample.java) { #cors-server-example }
+
+#### allowGenericHttpRequests / getAllowGenericHttpRequests
+If `true`, allow generic requests (that are outside the scope of the specification) to pass through the directive. Else, strict CORS filtering is applied and any invalid request will be rejected.
+
+#### allowCredentials / getAllowCredentials
+Indicates whether the resource supports user credentials.  If `true`, the header `Access-Control-Allow-Credentials` is set in the response, indicating the actual request can include user credentials.
+
+Examples of user credentials are: cookies, HTTP authentication or client-side certificates.
+
+#### allowedOrigins / getAllowedOrigins
+List of origins that the CORS filter must allow. Can also be set to `*` to allow access to the resource from any origin. Controls the content of the `Access-Control-Allow-Origin` response header:
+* if parameter is `*` **and** credentials are not allowed, a `*` is set in `Access-Control-Allow-Origin`.
+* otherwise, the origins given in the `Origin` request header are echoed.
+
+Hostname starting with `*.` will match any sub-domain. The scheme and the port are always strictly matched.
+
+The actual or preflight request is rejected if any of the origins from the request is not allowed.
+
+#### allowedHeaders / getAllowedHeaders
+List of request headers that can be used when making an actual request. Controls the content of the `Access-Control-Allow-Headers` header in a preflight response:
+* if parameter is `*`, the headers from `Access-Control-Request-Headers` are echoed.
+* otherwise the parameter list is returned as part of the header.
+
+#### allowedMethods / getAllowedMethods
+List of methods that can be used when making an actual request. The list is returned as part of the `Access-Control-Allow-Methods` preflight response header.
+
+The preflight request will be rejected if the `Access-Control-Request-Method` header's method is not part of the list.
+
+#### exposedHeaders / getAllowedMethods
+List of headers (other than [simple response headers](https://www.w3.org/TR/cors/#simple-response-header)) that browsers are allowed to access. If not empty, this list is returned as part of the `Access-Control-Expose-Headers` header in the actual response.
+
+#### maxAge / getMaxAge
+When set, the amount of seconds the browser is allowed to cache the results of a preflight request. This value is returned as part of the `Access-Control-Max-Age` preflight response header. If @scala[`None`]@java[`OptionalLong.empty()`], the header is not added to the preflight response.
+
+## Benchmarks
+
+Benchmarks for Apache Pekko cors are located within the @github[http-bench-jmh project](/http-bench-jmh/src/main/scala/org/apache/pekko/http/cors/CorsBenchmark.scala) along with
+@github[instructions](/http-bench-jmh/README.md) on how to run them.
+
+Please look at the original project [Akka Http Cors](https://github.com/lomigmegard/akka-http-cors) for previous benchmarks with Akka Http.

--- a/docs/src/main/paradox/common/index.md
+++ b/docs/src/main/paradox/common/index.md
@@ -20,5 +20,6 @@ which are specific to one side only.
 * [xml-support](sse-support.md)
 * [timeouts](timeouts.md)
 * [caching](caching.md)
+* [cors](cors.md)
 
 @@@

--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -15,4 +15,7 @@ pekko-http
 pekko-http-caching
 :  @@snip [reference.conf](/http-caching/src/main/resources/reference.conf)
 
+pekko-http-cors
+:  @@snip [reference.conf](/http-cors/src/main/resources/reference.conf)
+
 The other Apache Pekko HTTP modules do not offer any configuration via [Typesafe Config](https://github.com/lightbend/config).

--- a/docs/src/main/paradox/migration-guide/index.md
+++ b/docs/src/main/paradox/migration-guide/index.md
@@ -11,3 +11,8 @@
 * Where class names have "Akka" in the name, the Pekko ones have "Pekko" - e.g. PekkoException instead of AkkaException
 * Configs in `application.conf` use "pekko" prefix instead of "akka"
 * We will soon provide a more detailed guide for migrating from Akka HTTP v10.2 to Apache Pekko HTTP
+* If you happen to be using [akka-http-cors](https://github.com/lomigmegard/akka-http-cors) this has been directly integrated into
+  Apache Pekko Http which means you should use the @ref:[pekko-http-cors artifact](../common/cors.md) instead. Note that the root configuration naming 
+  has also been updated (i.e. changing from `akka-http-cors` to `pekko.http.cors`) to make it consistent with the rest of Apache Pekko Http.
+  * In addition there is a single breaking change, the return type of the `org.apache.pekko.http.cors.javadsl.settings.CorsSettings.getMaxAge`
+  method has been changed from `java.util.Optional<Long>` to `java.util.OptionalLong` since it's more idiomatic.

--- a/docs/src/test/java/docs/http/javadsl/server/cors/CorsServerExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/cors/CorsServerExample.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package docs.http.javadsl.server.cors;
+
+// #cors-server-example
+import org.apache.pekko.http.javadsl.model.StatusCodes;
+import org.apache.pekko.http.javadsl.server.*;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.apache.pekko.http.cors.javadsl.CorsDirectives.cors;
+import static org.apache.pekko.http.cors.javadsl.CorsDirectives.corsRejectionHandler;
+
+public class CorsServerExample extends HttpApp {
+
+  public static void main(String[] args) throws ExecutionException, InterruptedException {
+    final CorsServerExample app = new CorsServerExample();
+    app.startServer("127.0.0.1", 9000);
+  }
+
+  protected Route routes() {
+
+    // Your CORS settings are loaded from `application.conf`
+
+    // Your rejection handler
+    final RejectionHandler rejectionHandler =
+        corsRejectionHandler().withFallback(RejectionHandler.defaultHandler());
+
+    // Your exception handler
+    final ExceptionHandler exceptionHandler =
+        ExceptionHandler.newBuilder()
+            .match(
+                NoSuchElementException.class,
+                ex -> complete(StatusCodes.NOT_FOUND, ex.getMessage()))
+            .build();
+
+    // Combining the two handlers only for convenience
+    final Function<Supplier<Route>, Route> handleErrors =
+        inner ->
+            Directives.allOf(
+                s -> handleExceptions(exceptionHandler, s),
+                s -> handleRejections(rejectionHandler, s),
+                inner);
+
+    // Note how rejections and exceptions are handled *before* the CORS directive (in the inner
+    // route).
+    // This is required to have the correct CORS headers in the response even when an error occurs.
+    return handleErrors.apply(
+        () ->
+            cors(
+                () ->
+                    handleErrors.apply(
+                        () ->
+                            concat(
+                                path("ping", () -> complete("pong")),
+                                path(
+                                    "pong",
+                                    () ->
+                                        failWith(
+                                            new NoSuchElementException(
+                                                "pong not found, try with ping")))))));
+  }
+}
+// #cors-server-example

--- a/docs/src/test/scala/docs/http/scaladsl/server/cors/CorsServerExample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/cors/CorsServerExample.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package docs.http.scaladsl.server.cors
+
+// #cors-server-example
+import org.apache.pekko
+import pekko.http.scaladsl.model.StatusCodes
+import pekko.http.scaladsl.server._
+
+object CorsServerExample extends HttpApp {
+  def main(args: Array[String]): Unit = {
+    CorsServerExample.startServer("127.0.0.1", 9000)
+  }
+
+  protected def routes: Route = {
+    import pekko.http.cors.scaladsl.CorsDirectives._
+
+    // Your CORS settings are loaded from `application.conf`
+
+    // Your rejection handler
+    val rejectionHandler = corsRejectionHandler.withFallback(RejectionHandler.default)
+
+    // Your exception handler
+    val exceptionHandler = ExceptionHandler { case e: NoSuchElementException =>
+      complete(StatusCodes.NotFound -> e.getMessage)
+    }
+
+    // Combining the two handlers only for convenience
+    val handleErrors = handleRejections(rejectionHandler) & handleExceptions(exceptionHandler)
+
+    // Note how rejections and exceptions are handled *before* the CORS directive (in the inner route).
+    // This is required to have the correct CORS headers in the response even when an error occurs.
+    handleErrors {
+      cors() {
+        handleErrors {
+          path("ping") {
+            complete("pong")
+          } ~
+          path("pong") {
+            failWith(new NoSuchElementException("pong not found, try with ping"))
+          }
+        }
+      }
+    }
+  }
+}
+// #cors-server-example

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/cors/CorsBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/cors/CorsBenchmark.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.scaladsl.Http
+import pekko.http.scaladsl.Http.ServerBinding
+import pekko.http.scaladsl.model.headers.{ `Access-Control-Request-Method`, Origin }
+import pekko.http.scaladsl.model.{ HttpMethods, HttpRequest }
+import pekko.http.scaladsl.server.Directives
+import pekko.http.scaladsl.unmarshalling.Unmarshal
+import pekko.http.cors.scaladsl.CorsDirectives
+import pekko.http.cors.scaladsl.settings.CorsSettings
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContext }
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class CorsBenchmark extends Directives with CorsDirectives {
+  private val config = ConfigFactory.parseString("pekko.loglevel = ERROR").withFallback(ConfigFactory.load())
+
+  implicit private val system: ActorSystem = ActorSystem("CorsBenchmark", config)
+  implicit private val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  private val http = Http()
+  private val corsSettings = CorsSettings.default
+
+  private var binding: ServerBinding = _
+  private var request: HttpRequest = _
+  private var requestCors: HttpRequest = _
+  private var requestPreflight: HttpRequest = _
+
+  @Setup
+  def setup(): Unit = {
+    val route = {
+      path("baseline") {
+        get {
+          complete("ok")
+        }
+      } ~ path("cors") {
+        cors(corsSettings) {
+          get {
+            complete("ok")
+          }
+        }
+      }
+    }
+    val origin = Origin("http://example.com")
+
+    binding = Await.result(http.newServerAt("127.0.0.1", 0).bind(route), 1.second)
+    val base = s"http://${binding.localAddress.getHostString}:${binding.localAddress.getPort}"
+
+    request = HttpRequest(uri = base + "/baseline")
+    requestCors = HttpRequest(
+      method = HttpMethods.GET,
+      uri = base + "/cors",
+      headers = List(origin))
+    requestPreflight = HttpRequest(
+      method = HttpMethods.OPTIONS,
+      uri = base + "/cors",
+      headers = List(origin, `Access-Control-Request-Method`(HttpMethods.GET)))
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    val f = for {
+      _ <- http.shutdownAllConnectionPools()
+      _ <- binding.terminate(1.second)
+      _ <- system.terminate()
+    } yield ()
+    Await.ready(f, 5.seconds)
+  }
+
+  @Benchmark
+  def baseline(): Unit = {
+    val f = http.singleRequest(request).flatMap(r => Unmarshal(r.entity).to[String])
+    assert(Await.result(f, 1.second) == "ok")
+  }
+
+  @Benchmark
+  def default_cors(): Unit = {
+    val f = http.singleRequest(requestCors).flatMap(r => Unmarshal(r.entity).to[String])
+    assert(Await.result(f, 1.second) == "ok")
+  }
+
+  @Benchmark
+  def default_preflight(): Unit = {
+    val f = http.singleRequest(requestPreflight).flatMap(r => Unmarshal(r.entity).to[String])
+    assert(Await.result(f, 1.second) == "")
+  }
+}

--- a/http-cors/src/main/java/org/apache/pekko/http/cors/javadsl/model/HttpHeaderRange.java
+++ b/http-cors/src/main/java/org/apache/pekko/http/cors/javadsl/model/HttpHeaderRange.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.javadsl.model;
+
+import org.apache.pekko.http.impl.util.Util;
+import org.apache.pekko.http.cors.scaladsl.model.HttpHeaderRange$;
+
+/** @see HttpHeaderRanges for convenience access to often used values. */
+public abstract class HttpHeaderRange {
+  public abstract boolean matches(String header);
+
+  public static HttpHeaderRange create(String... headers) {
+    return HttpHeaderRange$.MODULE$.apply(Util.convertArray(headers));
+  }
+}

--- a/http-cors/src/main/java/org/apache/pekko/http/cors/javadsl/model/HttpHeaderRanges.java
+++ b/http-cors/src/main/java/org/apache/pekko/http/cors/javadsl/model/HttpHeaderRanges.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.javadsl.model;
+
+public final class HttpHeaderRanges {
+  private HttpHeaderRanges() {}
+
+  public static final HttpHeaderRange ALL =
+      org.apache.pekko.http.cors.scaladsl.model.HttpHeaderRange.$times$.MODULE$;
+}

--- a/http-cors/src/main/java/org/apache/pekko/http/cors/javadsl/model/HttpOriginMatcher.java
+++ b/http-cors/src/main/java/org/apache/pekko/http/cors/javadsl/model/HttpOriginMatcher.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.javadsl.model;
+
+import org.apache.pekko.http.impl.util.Util;
+import org.apache.pekko.http.javadsl.model.headers.HttpOrigin;
+import org.apache.pekko.http.cors.scaladsl.model.HttpOriginMatcher$;
+
+public abstract class HttpOriginMatcher {
+
+  public abstract boolean matches(HttpOrigin origin);
+
+  public static HttpOriginMatcher ALL =
+      org.apache.pekko.http.cors.scaladsl.model.HttpOriginMatcher.$times$.MODULE$;
+
+  public static HttpOriginMatcher create(HttpOrigin... origins) {
+    return HttpOriginMatcher$.MODULE$.apply(
+        Util.<HttpOrigin, org.apache.pekko.http.scaladsl.model.headers.HttpOrigin>convertArray(
+            origins));
+  }
+
+  public static HttpOriginMatcher strict(HttpOrigin... origins) {
+    return HttpOriginMatcher$.MODULE$.strict(
+        Util.<HttpOrigin, org.apache.pekko.http.scaladsl.model.headers.HttpOrigin>convertArray(
+            origins));
+  }
+}

--- a/http-cors/src/main/resources/reference.conf
+++ b/http-cors/src/main/resources/reference.conf
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+
+########################################
+# pekko-http-cors Reference Config File #
+########################################
+
+# This is the reference config file that contains all the default settings.
+# Make your edits/overrides in your application.conf.
+
+pekko.http.cors {
+
+  # If enabled, allow generic requests (that are outside the scope of the specification)
+  # to pass through the directive. Else, strict CORS filtering is applied and any
+  # invalid request will be rejected.
+  allow-generic-http-requests = yes
+
+  # Indicates whether the resource supports user credentials.  If enabled, the header
+  # `Access-Control-Allow-Credentials` is set in the response, indicating that the
+  # actual request can include user credentials. Examples of user credentials are:
+  # cookies, HTTP authentication or client-side certificates.
+  allow-credentials = yes
+
+  # List of origins that the CORS filter must allow. Can also be set to `*` to allow
+  # access to the resource from any origin. Controls the content of the
+  # `Access-Control-Allow-Origin` response header: if parameter is `*` and credentials
+  # are not allowed, a `*` is set in `Access-Control-Allow-Origin`. Otherwise, the
+  # origins given in the `Origin` request header are echoed.
+  #
+  # Hostname starting with `*.` will match any sub-domain.
+  # The scheme and the port are always strictly matched.
+  #
+  # The actual or preflight request is rejected if any of the origins from the request
+  # is not allowed.
+  allowed-origins = "*"
+
+  # List of request headers that can be used when making an actual request. Controls
+  # the content of the `Access-Control-Allow-Headers` header in a preflight response:
+  # if parameter is `*`, the headers from `Access-Control-Request-Headers` are echoed.
+  # Otherwise the parameter list is returned as part of the header.
+  allowed-headers = "*"
+
+  # List of methods that can be used when making an actual request. The list is
+  # returned as part of the `Access-Control-Allow-Methods` preflight response header.
+  #
+  # The preflight request will be rejected if the `Access-Control-Request-Method`
+  # header's method is not part of the list.
+  allowed-methods = ["GET", "POST", "HEAD", "OPTIONS"]
+
+  # List of headers (other than simple response headers) that browsers are allowed to access.
+  # If not empty, this list is returned as part of the `Access-Control-Expose-Headers`
+  # header in the actual response.
+  exposed-headers = []
+
+  # When set, the amount of seconds the browser is allowed to cache the results of a preflight request.
+  # This value is returned as part of the `Access-Control-Max-Age` preflight response header.
+  # If `null`, the header is not added to the preflight response.
+  max-age = 1800 seconds
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/CorsJavaMapping.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/CorsJavaMapping.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors
+
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.http.impl.util.JavaMapping
+
+@InternalApi
+private[pekko] object CorsJavaMapping {
+
+  object Implicits {
+    implicit object CorsSettingsMapping
+        extends JavaMapping.Inherited[javadsl.settings.CorsSettings, scaladsl.settings.CorsSettings]
+  }
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/CorsDirectives.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/CorsDirectives.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.javadsl
+
+import java.util.function.Supplier
+
+import org.apache.pekko
+import pekko.http.javadsl.server.{ RejectionHandler, Route }
+import pekko.http.javadsl.server.directives.RouteAdapter
+import pekko.http.cors.CorsJavaMapping.Implicits._
+import pekko.http.cors.javadsl.settings.CorsSettings
+import pekko.http.cors.scaladsl
+import pekko.http.impl.util.JavaMapping
+
+object CorsDirectives {
+
+  import pekko.http.cors.scaladsl.{ CorsDirectives => D }
+
+  def cors(inner: Supplier[Route]): Route =
+    RouteAdapter {
+      D.cors() {
+        inner.get.delegate
+      }
+    }
+
+  def cors(settings: CorsSettings, inner: Supplier[Route]): Route =
+    RouteAdapter {
+      D.cors(JavaMapping.toScala(settings)) {
+        inner.get.delegate
+      }
+    }
+
+  def corsRejectionHandler: RejectionHandler =
+    new RejectionHandler(scaladsl.CorsDirectives.corsRejectionHandler)
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/CorsRejection.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/CorsRejection.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.javadsl
+
+import org.apache.pekko
+import pekko.http.javadsl.model.HttpMethod
+import pekko.http.javadsl.model.headers.HttpOrigin
+import pekko.http.javadsl.server.CustomRejection
+
+/**
+ * Rejection created by the CORS directives. Signal the CORS request was rejected. The reason of the rejection is
+ * specified in the cause.
+ */
+trait CorsRejection extends CustomRejection {
+  def cause: CorsRejection.Cause
+}
+
+object CorsRejection {
+
+  /**
+   * Signals the cause of the failed CORS request.
+   */
+  trait Cause {
+
+    /**
+     * Description of this Cause in a human-readable format. Can be used for debugging or custom Rejection handlers.
+     */
+    def description: String
+  }
+
+  /**
+   * Signals the CORS request was malformed.
+   */
+  trait Malformed extends Cause
+
+  /**
+   * Signals the CORS request was rejected because its origin was invalid. An empty list means the Origin header was
+   * `null`.
+   */
+  trait InvalidOrigin extends Cause {
+    def getOrigins: java.util.List[HttpOrigin]
+  }
+
+  /**
+   * Signals the CORS request was rejected because its method was invalid.
+   */
+  trait InvalidMethod extends Cause {
+    def getMethod: HttpMethod
+  }
+
+  /**
+   * Signals the CORS request was rejected because its headers were invalid.
+   */
+  trait InvalidHeaders extends Cause {
+    def getHeaders: java.util.List[String]
+  }
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/settings/CorsSettings.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/settings/CorsSettings.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.javadsl.settings
+
+import java.util.OptionalLong
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.annotation.DoNotInherit
+import pekko.http.javadsl.model.HttpMethod
+import pekko.http.cors.javadsl.model.{ HttpHeaderRange, HttpOriginMatcher }
+import pekko.http.cors.scaladsl
+import pekko.http.cors.scaladsl.settings.CorsSettingsImpl
+import com.typesafe.config.Config
+
+/**
+ * Public API but not intended for subclassing
+ */
+@DoNotInherit
+abstract class CorsSettings { self: CorsSettingsImpl =>
+
+  def getAllowGenericHttpRequests: Boolean
+  def getAllowCredentials: Boolean
+  def getAllowedOrigins: HttpOriginMatcher
+  def getAllowedHeaders: HttpHeaderRange
+  def getAllowedMethods: java.lang.Iterable[HttpMethod]
+  def getExposedHeaders: java.lang.Iterable[String]
+  def getMaxAge: OptionalLong
+
+  def withAllowGenericHttpRequests(newValue: Boolean): CorsSettings
+  def withAllowCredentials(newValue: Boolean): CorsSettings
+  def withAllowedOrigins(newValue: HttpOriginMatcher): CorsSettings
+  def withAllowedHeaders(newValue: HttpHeaderRange): CorsSettings
+  def withAllowedMethods(newValue: java.lang.Iterable[HttpMethod]): CorsSettings
+  def withExposedHeaders(newValue: java.lang.Iterable[String]): CorsSettings
+  def withMaxAge(newValue: OptionalLong): CorsSettings
+}
+
+object CorsSettings {
+
+  /**
+   * Creates an instance of settings using the given Config.
+   */
+  def create(config: Config): CorsSettings = scaladsl.settings.CorsSettings(config)
+
+  /**
+   * Creates an instance of settings using the given String of config overrides to override settings set in the class
+   * loader of this class (i.e. by application.conf or reference.conf files in the class loader of this class).
+   */
+  def create(configOverrides: String): CorsSettings = scaladsl.settings.CorsSettings(configOverrides)
+
+  /**
+   * Creates an instance of CorsSettings using the configuration provided by the given ActorSystem.
+   */
+  def create(system: ActorSystem): CorsSettings = scaladsl.settings.CorsSettings(system)
+
+  /**
+   * Settings from the default loaded configuration. Note that application code may want to use the `apply()` methods
+   * instead to have more control over the source of the configuration.
+   */
+  @deprecated("Use other CorsSettings constructors", "1.0.0")
+  def defaultSettings: CorsSettings = scaladsl.settings.CorsSettings.defaultSettings
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsDirectives.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsDirectives.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.scaladsl
+
+import org.apache.pekko
+import pekko.http.scaladsl.model.HttpMethods._
+import pekko.http.scaladsl.model.headers._
+import pekko.http.scaladsl.model.{ HttpMethod, HttpResponse, StatusCodes }
+import pekko.http.scaladsl.server._
+import pekko.http.scaladsl.server.directives._
+import pekko.http.cors.javadsl
+import pekko.http.cors.scaladsl.model.HttpOriginMatcher
+import pekko.http.cors.scaladsl.settings.CorsSettings
+
+import scala.collection.immutable.Seq
+
+/**
+ * Provides directives that implement the CORS mechanism, enabling cross origin requests.
+ *
+ * @see
+ *   [[https://www.w3.org/TR/cors/ CORS W3C Recommendation]]
+ * @see
+ *   [[https://www.ietf.org/rfc/rfc6454.txt RFC 6454]]
+ */
+trait CorsDirectives {
+  import BasicDirectives._
+  import RouteDirectives._
+
+  /**
+   * Wraps its inner route with support for the CORS mechanism, enabling cross origin requests.
+   *
+   * In particular the recommendation written by the W3C in https://www.w3.org/TR/cors/ is implemented by this
+   * directive.
+   *
+   * The settings are loaded from the Actor System configuration.
+   */
+  def cors(): Directive0 = {
+    extractActorSystem.flatMap { system =>
+      cors(CorsSettings(system))
+    }
+  }
+
+  /**
+   * Wraps its inner route with support for the CORS mechanism, enabling cross origin requests.
+   *
+   * In particular the recommendation written by the W3C in https://www.w3.org/TR/cors/ is implemented by this
+   * directive.
+   *
+   * @param settings
+   *   the settings used by the CORS filter
+   */
+  def cors(settings: CorsSettings): Directive0 = {
+    import settings._
+
+    /** Return the invalid origins, or `Nil` if one is valid. */
+    def validateOrigins(origins: Seq[HttpOrigin]): List[CorsRejection.Cause] =
+      if (allowedOrigins == HttpOriginMatcher.* || origins.exists(allowedOrigins.matches)) {
+        Nil
+      } else {
+        CorsRejection.InvalidOrigin(origins) :: Nil
+      }
+
+    /** Return the method if invalid, `Nil` otherwise. */
+    def validateMethod(method: HttpMethod): List[CorsRejection.Cause] =
+      if (allowedMethods.contains(method)) {
+        Nil
+      } else {
+        CorsRejection.InvalidMethod(method) :: Nil
+      }
+
+    /** Return the list of invalid headers, or `Nil` if they are all valid. */
+    def validateHeaders(headers: Seq[String]): List[CorsRejection.Cause] = {
+      val invalidHeaders = headers.filterNot(allowedHeaders.matches)
+      if (invalidHeaders.isEmpty) {
+        Nil
+      } else {
+        CorsRejection.InvalidHeaders(invalidHeaders) :: Nil
+      }
+    }
+
+    extractRequest.flatMap { request =>
+      import request._
+
+      (method, header[Origin].map(_.origins.toSeq), header[`Access-Control-Request-Method`].map(_.method)) match {
+        case (OPTIONS, Some(origins), Some(requestMethod)) if origins.lengthCompare(1) <= 0 =>
+          // Case 1: pre-flight CORS request
+
+          val headers = header[`Access-Control-Request-Headers`].map(_.headers.toSeq).getOrElse(Seq.empty)
+
+          validateOrigins(origins) ::: validateMethod(requestMethod) ::: validateHeaders(headers) match {
+            case Nil    => complete(HttpResponse(StatusCodes.OK, preflightResponseHeaders(origins, headers)))
+            case causes => reject(causes.map(CorsRejection(_)): _*)
+          }
+
+        case (_, Some(origins), None) =>
+          // Case 2: simple/actual CORS request
+
+          validateOrigins(origins) match {
+            case Nil =>
+              mapResponseHeaders { oldHeaders =>
+                actualResponseHeaders(origins) ++ oldHeaders.filterNot(h => CorsDirectives.headersToClean.exists(h.is))
+              }
+            case causes =>
+              reject(causes.map(CorsRejection(_)): _*)
+          }
+
+        case _ if allowGenericHttpRequests =>
+          // Case 3a: not a valid CORS request, but allowed
+
+          pass
+
+        case _ =>
+          // Case 3b: not a valid CORS request, forbidden
+
+          reject(CorsRejection(CorsRejection.Malformed))
+      }
+    }
+  }
+}
+
+object CorsDirectives extends CorsDirectives {
+  import RouteDirectives._
+
+  private val headersToClean: List[String] = List(
+    `Access-Control-Allow-Origin`,
+    `Access-Control-Expose-Headers`,
+    `Access-Control-Allow-Credentials`,
+    `Access-Control-Allow-Methods`,
+    `Access-Control-Allow-Headers`,
+    `Access-Control-Max-Age`).map(_.lowercaseName)
+
+  def corsRejectionHandler: RejectionHandler =
+    RejectionHandler
+      .newBuilder()
+      .handleAll[javadsl.CorsRejection] { rejections =>
+        val causes = rejections.map(_.cause.description).mkString(", ")
+        complete((StatusCodes.BadRequest, s"CORS: $causes"))
+      }
+      .result()
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsRejection.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsRejection.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.scaladsl
+
+import org.apache.pekko
+import pekko.http.javadsl.model.headers
+import pekko.http.scaladsl.model.HttpMethod
+import pekko.http.scaladsl.model.headers.HttpOrigin
+import pekko.http.scaladsl.server.Rejection
+import pekko.http.cors.javadsl
+
+import java.util
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
+
+/**
+ * Rejection created by the CORS directives. Signal the CORS request was rejected. The reason of the rejection is
+ * specified in the cause.
+ */
+final case class CorsRejection(cause: CorsRejection.Cause) extends javadsl.CorsRejection with Rejection
+
+object CorsRejection {
+
+  /**
+   * Signals the cause of the failed CORS request.
+   */
+  sealed trait Cause extends javadsl.CorsRejection.Cause
+
+  /**
+   * Signals the CORS request was malformed.
+   */
+  case object Malformed extends javadsl.CorsRejection.Malformed with Cause {
+    override def description: String = "malformed request"
+  }
+
+  /**
+   * Signals the CORS request was rejected because its origin was invalid. An empty list means the Origin header was
+   * `null`.
+   */
+  final case class InvalidOrigin(origins: Seq[HttpOrigin]) extends javadsl.CorsRejection.InvalidOrigin with Cause {
+    override def description: String = s"invalid origin '${if (origins.isEmpty) "null" else origins.mkString(" ")}'"
+    override def getOrigins: util.List[headers.HttpOrigin] =
+      (origins: Seq[pekko.http.javadsl.model.headers.HttpOrigin]).asJava
+  }
+
+  /**
+   * Signals the CORS request was rejected because its method was invalid.
+   */
+  final case class InvalidMethod(method: HttpMethod) extends javadsl.CorsRejection.InvalidMethod with Cause {
+    override def description: String = s"invalid method '${method.value}'"
+    override def getMethod: pekko.http.javadsl.model.HttpMethod = method
+  }
+
+  /**
+   * Signals the CORS request was rejected because its headers were invalid.
+   */
+  final case class InvalidHeaders(headers: Seq[String]) extends javadsl.CorsRejection.InvalidHeaders with Cause {
+    override def description: String = s"invalid headers '${headers.mkString(" ")}'"
+    override def getHeaders: util.List[String] = headers.asJava
+  }
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/model/HttpHeaderRange.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/model/HttpHeaderRange.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.scaladsl.model
+
+import org.apache.pekko
+import pekko.http.cors.javadsl
+import pekko.util.Helpers
+
+import scala.collection.immutable.Seq
+
+abstract class HttpHeaderRange extends javadsl.model.HttpHeaderRange
+
+object HttpHeaderRange {
+  case object `*` extends HttpHeaderRange {
+    def matches(header: String) = true
+  }
+
+  final case class Default(headers: Seq[String]) extends HttpHeaderRange {
+    private val lowercaseHeaders: Seq[String] = headers.map(Helpers.toRootLowerCase)
+    def matches(header: String): Boolean = lowercaseHeaders.contains(Helpers.toRootLowerCase(header))
+  }
+
+  def apply(headers: String*): Default = Default(Seq(headers: _*))
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/model/HttpOriginMatcher.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/model/HttpOriginMatcher.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.scaladsl.model
+
+import org.apache.pekko
+import pekko.http.javadsl.{ model => jm }
+import pekko.http.scaladsl.model.headers.HttpOrigin
+import pekko.http.cors.javadsl
+
+import scala.collection.immutable.Seq
+
+/**
+ * HttpOrigin matcher.
+ */
+abstract class HttpOriginMatcher extends javadsl.model.HttpOriginMatcher {
+  def matches(origin: HttpOrigin): Boolean
+
+  /** Java API */
+  def matches(origin: jm.headers.HttpOrigin): Boolean = matches(origin.asInstanceOf[HttpOrigin])
+}
+
+object HttpOriginMatcher {
+  case object `*` extends HttpOriginMatcher {
+    def matches(origin: HttpOrigin) = true
+  }
+
+  final case class Default(origins: Seq[HttpOrigin]) extends HttpOriginMatcher {
+    private class StrictHostMatcher(origin: HttpOrigin) extends (HttpOrigin => Boolean) {
+      override def apply(origin: HttpOrigin): Boolean = origin == this.origin
+    }
+
+    private class WildcardHostMatcher(wildcardOrigin: HttpOrigin) extends (HttpOrigin => Boolean) {
+      private val suffix: String = wildcardOrigin.host.host.address.stripPrefix("*")
+      override def apply(origin: HttpOrigin): Boolean = {
+        origin.scheme == wildcardOrigin.scheme &&
+        origin.host.port == wildcardOrigin.host.port &&
+        origin.host.host.address.endsWith(suffix)
+      }
+    }
+
+    private val matchers: Seq[HttpOrigin => Boolean] = {
+      origins.map { origin =>
+        if (hasWildcard(origin)) new WildcardHostMatcher(origin) else new StrictHostMatcher(origin)
+      }
+    }
+
+    override def matches(origin: HttpOrigin): Boolean = matchers.exists(_.apply(origin))
+    override def toString: String = origins.mkString(" ")
+  }
+
+  final case class Strict(origins: Seq[HttpOrigin]) extends HttpOriginMatcher {
+    override def matches(origin: HttpOrigin): Boolean = origins.contains(origin)
+    override def toString: String = origins.mkString(" ")
+  }
+
+  private def hasWildcard(origin: HttpOrigin): Boolean =
+    origin.host.host.isNamedHost && origin.host.host.address.startsWith("*.")
+
+  /**
+   * Build a matcher that will accept any of the given origins. Wildcard in the hostname will not be interpreted.
+   */
+  def strict(origins: HttpOrigin*): HttpOriginMatcher =
+    Strict(origins.toList)
+
+  /**
+   * Build a matcher that will accept any of the given origins. Hostname starting with `*.` will match any sub-domain.
+   * The scheme and the port are always strictly matched.
+   */
+  def apply(origins: HttpOrigin*): HttpOriginMatcher = {
+    if (origins.exists(hasWildcard))
+      Default(origins.toList)
+    else
+      Strict(origins.toList)
+  }
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettings.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettings.scala
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.scaladsl.settings
+
+import java.util.OptionalLong
+import java.util.concurrent.TimeUnit
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.annotation.DoNotInherit
+import pekko.http.cors.javadsl
+import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
+import pekko.http.cors.javadsl.{ model => jmcorsmodel }
+import pekko.http.impl.util.SettingsCompanionImpl
+import pekko.http.javadsl.{ model => jmmodel }
+import pekko.http.scaladsl.model.headers.HttpOrigin
+import pekko.http.scaladsl.model.{ HttpHeader, HttpMethod, HttpMethods }
+import pekko.util.OptionConverters._
+import com.typesafe.config.ConfigException.{ Missing, WrongType }
+import com.typesafe.config.{ Config, ConfigFactory }
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
+import scala.util.Try
+
+/**
+ * Settings used by the CORS directives.
+ *
+ * Public API but not intended for subclassing.
+ */
+@DoNotInherit
+abstract class CorsSettings private[pekko] () extends javadsl.settings.CorsSettings { self: CorsSettingsImpl =>
+
+  /**
+   * If `true`, allow generic requests (that are outside the scope of the specification) to pass through the directive.
+   * Else, strict CORS filtering is applied and any invalid request will be rejected.
+   *
+   * Default: `true`
+   */
+  def allowGenericHttpRequests: Boolean
+
+  /**
+   * Indicates whether the resource supports user credentials. If `true`, the header `Access-Control-Allow-Credentials`
+   * is set in the response, indicating that the actual request can include user credentials. Examples of user
+   * credentials are: cookies, HTTP authentication or client-side certificates.
+   *
+   * Default: `true`
+   *
+   * @see
+   *   [[https://www.w3.org/TR/cors/#access-control-allow-credentials-response-header Access-Control-Allow-Credentials]]
+   */
+  def allowCredentials: Boolean
+
+  /**
+   * List of origins that the CORS filter must allow. Can also be set to `*` to allow access to the resource from any
+   * origin. Controls the content of the `Access-Control-Allow-Origin` response header: if parameter is `*` and
+   * credentials are not allowed, a `*` is set in `Access-Control-Allow-Origin`. Otherwise, the origins given in the
+   * `Origin` request header are echoed.
+   *
+   * Hostname starting with `*.` will match any sub-domain. The scheme and the port are always strictly matched.
+   *
+   * The actual or preflight request is rejected if any of the origins from the request is not allowed.
+   *
+   * Default: `HttpOriginMatcher.*`
+   *
+   * @see
+   *   [[https://www.w3.org/TR/cors/#access-control-allow-origin-response-header Access-Control-Allow-Origin]]
+   */
+  def allowedOrigins: HttpOriginMatcher
+
+  /**
+   * List of request headers that can be used when making an actual request. Controls the content of the
+   * `Access-Control-Allow-Headers` header in a preflight response: if parameter is `*`, the headers from
+   * `Access-Control-Request-Headers` are echoed. Otherwise the parameter list is returned as part of the header.
+   *
+   * Default: `HttpHeaderRange.*`
+   *
+   * @see
+   *   [[https://www.w3.org/TR/cors/#access-control-allow-headers-response-header Access-Control-Allow-Headers]]
+   */
+  def allowedHeaders: HttpHeaderRange
+
+  /**
+   * List of methods that can be used when making an actual request. The list is returned as part of the
+   * `Access-Control-Allow-Methods` preflight response header.
+   *
+   * The preflight request will be rejected if the `Access-Control-Request-Method` header's method is not part of the
+   * list.
+   *
+   * Default: `Seq(GET, POST, HEAD, OPTIONS)`
+   *
+   * @see
+   *   [[https://www.w3.org/TR/cors/#access-control-allow-methods-response-header Access-Control-Allow-Methods]]
+   */
+  def allowedMethods: Seq[HttpMethod]
+
+  /**
+   * List of headers (other than simple response headers) that browsers are allowed to access. If not empty, this list
+   * is returned as part of the `Access-Control-Expose-Headers` header in the actual response.
+   *
+   * Default: `Seq.empty`
+   *
+   * @see
+   *   [[https://www.w3.org/TR/cors/#simple-response-header Simple response headers]]
+   * @see
+   *   [[https://www.w3.org/TR/cors/#access-control-expose-headers-response-header Access-Control-Expose-Headers]]
+   */
+  def exposedHeaders: Seq[String]
+
+  /**
+   * When set, the amount of seconds the browser is allowed to cache the results of a preflight request. This value is
+   * returned as part of the `Access-Control-Max-Age` preflight response header. If `None`, the header is not added to
+   * the preflight response.
+   *
+   * Default: `Some(30 * 60)`
+   *
+   * @see
+   *   [[https://www.w3.org/TR/cors/#access-control-max-age-response-header Access-Control-Max-Age]]
+   */
+  def maxAge: Option[Long]
+
+  /* Java APIs */
+
+  override def getAllowGenericHttpRequests: Boolean = this.allowGenericHttpRequests
+  override def getAllowCredentials: Boolean = this.allowCredentials
+  override def getAllowedOrigins: jmcorsmodel.HttpOriginMatcher = this.allowedOrigins
+  override def getAllowedHeaders: jmcorsmodel.HttpHeaderRange = this.allowedHeaders
+  override def getAllowedMethods: java.lang.Iterable[jmmodel.HttpMethod] =
+    (this.allowedMethods: Seq[pekko.http.javadsl.model.HttpMethod]).asJava
+  override def getExposedHeaders: java.lang.Iterable[String] = this.exposedHeaders.asJava
+  override def getMaxAge: OptionalLong = this.maxAge.toJavaPrimitive
+
+  override def withAllowGenericHttpRequests(newValue: Boolean): CorsSettings = {
+    copy(allowGenericHttpRequests = newValue)
+  }
+  override def withAllowCredentials(newValue: Boolean): CorsSettings = {
+    copy(allowCredentials = newValue)
+  }
+  override def withAllowedOrigins(newValue: javadsl.model.HttpOriginMatcher): CorsSettings = {
+    copy(allowedOrigins = newValue.asInstanceOf[HttpOriginMatcher])
+  }
+  override def withAllowedHeaders(newValue: javadsl.model.HttpHeaderRange): CorsSettings = {
+    copy(allowedHeaders = newValue.asInstanceOf[HttpHeaderRange])
+  }
+  override def withAllowedMethods(
+      newValue: java.lang.Iterable[pekko.http.javadsl.model.HttpMethod]): CorsSettings = {
+    copy(allowedMethods = newValue.asScala.toList.asInstanceOf[List[HttpMethod]])
+  }
+  override def withExposedHeaders(newValue: java.lang.Iterable[String]): CorsSettings = {
+    copy(exposedHeaders = newValue.asScala.toList)
+  }
+  override def withMaxAge(newValue: OptionalLong): CorsSettings = {
+    copy(maxAge = newValue.toScala)
+  }
+
+  // overloads for Scala idiomatic use
+  def withAllowedOrigins(newValue: HttpOriginMatcher): CorsSettings = copy(allowedOrigins = newValue)
+  def withAllowedHeaders(newValue: HttpHeaderRange): CorsSettings = copy(allowedHeaders = newValue)
+  def withAllowedMethods(newValue: Seq[HttpMethod]): CorsSettings = copy(allowedMethods = newValue)
+  def withExposedHeaders(newValue: Seq[String]): CorsSettings = copy(exposedHeaders = newValue)
+  def withMaxAge(newValue: Option[Long]): CorsSettings = copy(maxAge = newValue)
+
+  private[pekko] def preflightResponseHeaders(origins: Seq[HttpOrigin], requestHeaders: Seq[String]): List[HttpHeader]
+  private[pekko] def actualResponseHeaders(origins: Seq[HttpOrigin]): List[HttpHeader]
+}
+
+object CorsSettings extends SettingsCompanionImpl[CorsSettings]("pekko.http.cors") {
+
+  /**
+   * Creates an instance of CorsSettings using the configuration provided by the given ActorSystem.
+   */
+  implicit def default(implicit system: ActorSystem): CorsSettings = apply(system)
+
+  /**
+   * Settings from the default loaded configuration. Note that application code may want to use the `apply()` methods
+   * instead to have more control over the source of the configuration.
+   */
+  @deprecated("Use other CorsSettings constructors", "1.0.0")
+  def defaultSettings: CorsSettings = apply(ConfigFactory.load(getClass.getClassLoader))
+
+  def fromSubConfig(root: Config, config: Config): CorsSettings = {
+    def parseStringList(path: String): List[String] =
+      Try(config.getStringList(path).asScala.toList).recover { case _: WrongType =>
+        config.getString(path).split(" ").toList
+      }.get
+
+    def parseSeconds(path: String): Option[Long] =
+      Try(Some(config.getLong(path))).recover {
+        case _: WrongType => Some(config.getDuration(path, TimeUnit.SECONDS))
+        case _: Missing   => None
+      }.get
+
+    CorsSettingsImpl(
+      allowGenericHttpRequests = config.getBoolean("allow-generic-http-requests"),
+      allowCredentials = config.getBoolean("allow-credentials"),
+      allowedOrigins = parseStringList("allowed-origins") match {
+        case List("*") => HttpOriginMatcher.*
+        case origins   => HttpOriginMatcher(origins.map(HttpOrigin(_)): _*)
+      },
+      allowedHeaders = parseStringList("allowed-headers") match {
+        case List("*") => HttpHeaderRange.*
+        case headers   => HttpHeaderRange(headers: _*)
+      },
+      allowedMethods = parseStringList("allowed-methods")
+        .map(method => HttpMethods.getForKey(method).getOrElse(HttpMethod.custom(method))),
+      exposedHeaders = parseStringList("exposed-headers"),
+      maxAge = parseSeconds("max-age"))
+  }
+
+}

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettingsImpl.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettingsImpl.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.scaladsl.settings
+
+import org.apache.pekko
+import pekko.http.scaladsl.model.{ HttpHeader, HttpMethod }
+import pekko.http.scaladsl.model.headers._
+import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
+
+import scala.collection.immutable.Seq
+
+/** INTERNAL API */
+final private[pekko] case class CorsSettingsImpl(
+    allowGenericHttpRequests: Boolean,
+    allowCredentials: Boolean,
+    allowedOrigins: HttpOriginMatcher,
+    allowedHeaders: HttpHeaderRange,
+    allowedMethods: Seq[HttpMethod],
+    exposedHeaders: Seq[String],
+    maxAge: Option[Long]) extends CorsSettings {
+  override def productPrefix = "CorsSettings"
+
+  private def accessControlExposeHeaders: Option[`Access-Control-Expose-Headers`] =
+    if (exposedHeaders.nonEmpty)
+      Some(`Access-Control-Expose-Headers`(exposedHeaders))
+    else
+      None
+
+  private def accessControlAllowCredentials: Option[`Access-Control-Allow-Credentials`] =
+    if (allowCredentials)
+      Some(`Access-Control-Allow-Credentials`(true))
+    else
+      None
+
+  private def accessControlMaxAge: Option[`Access-Control-Max-Age`] =
+    maxAge.map(`Access-Control-Max-Age`.apply)
+
+  private def accessControlAllowMethods: `Access-Control-Allow-Methods` =
+    `Access-Control-Allow-Methods`(allowedMethods)
+
+  private def accessControlAllowHeaders(requestHeaders: Seq[String]): Option[`Access-Control-Allow-Headers`] =
+    allowedHeaders match {
+      case HttpHeaderRange.Default(headers)             => Some(`Access-Control-Allow-Headers`(headers))
+      case HttpHeaderRange.* if requestHeaders.nonEmpty => Some(`Access-Control-Allow-Headers`(requestHeaders))
+      case _                                            => None
+    }
+
+  private def accessControlAllowOrigin(origins: Seq[HttpOrigin]): `Access-Control-Allow-Origin` =
+    if (allowedOrigins == HttpOriginMatcher.* && !allowCredentials)
+      `Access-Control-Allow-Origin`.*
+    else
+      `Access-Control-Allow-Origin`.forRange(HttpOriginRange.Default(origins))
+
+  // Cache headers that are always included in a preflight response
+  private val basePreflightResponseHeaders: List[HttpHeader] =
+    List(accessControlAllowMethods) ++ accessControlMaxAge ++ accessControlAllowCredentials
+
+  // Cache headers that are always included in an actual response
+  private val baseActualResponseHeaders: List[HttpHeader] =
+    accessControlExposeHeaders.toList ++ accessControlAllowCredentials
+
+  def preflightResponseHeaders(origins: Seq[HttpOrigin], requestHeaders: Seq[String]): List[HttpHeader] =
+    accessControlAllowHeaders(requestHeaders) match {
+      case Some(h) => h :: accessControlAllowOrigin(origins) :: basePreflightResponseHeaders
+      case None    => accessControlAllowOrigin(origins) :: basePreflightResponseHeaders
+    }
+
+  def actualResponseHeaders(origins: Seq[HttpOrigin]): List[HttpHeader] =
+    accessControlAllowOrigin(origins) :: baseActualResponseHeaders
+}

--- a/http-cors/src/test/scala/org/apache/pekko/http/cors/CorsDirectivesSpec.scala
+++ b/http-cors/src/test/scala/org/apache/pekko/http/cors/CorsDirectivesSpec.scala
@@ -1,0 +1,372 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors
+
+import org.apache.pekko
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
+import pekko.http.scaladsl.server.{ Directives, Route }
+import pekko.http.scaladsl.testkit.ScalatestRouteTest
+import pekko.http.cors.scaladsl.CorsRejection
+import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
+import pekko.http.cors.scaladsl.settings.CorsSettings
+
+import scala.collection.immutable.Seq
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CorsDirectivesSpec extends AnyWordSpec with Matchers with Directives with ScalatestRouteTest {
+  import HttpMethods._
+  import pekko.http.cors.scaladsl.CorsDirectives._
+
+  val actual = "actual"
+  val exampleOrigin = HttpOrigin("http://example.com")
+  val exampleStatus = StatusCodes.Created
+
+  val referenceSettings = CorsSettings("")
+
+  // override config for the ActorSystem to test `cors()`
+  override def testConfigSource: String =
+    """
+      |pekko.http.cors {
+      |  allow-credentials = false
+      |}
+      |""".stripMargin
+
+  def route(settings: CorsSettings, responseHeaders: Seq[HttpHeader] = Nil): Route =
+    cors(settings) {
+      complete(HttpResponse(exampleStatus, responseHeaders, HttpEntity(actual)))
+    }
+
+  "The cors() directive" should {
+    "extract its settings from the actor system" in {
+      val route = cors() {
+        complete(HttpResponse(exampleStatus, Nil, HttpEntity(actual)))
+      }
+
+      Get() ~> Origin(exampleOrigin) ~> route ~> check {
+        responseAs[String] shouldBe actual
+        response.status shouldBe exampleStatus
+        response.headers should contain theSameElementsAs Seq(
+          `Access-Control-Allow-Origin`.*)
+      }
+    }
+  }
+
+  "The cors(settings) directive" should {
+    "not affect actual requests when not strict" in {
+      val settings = referenceSettings
+      val responseHeaders = Seq(Host("my-host"), `Access-Control-Max-Age`(60))
+      Get() ~> {
+        route(settings, responseHeaders)
+      } ~> check {
+        responseAs[String] shouldBe actual
+        response.status shouldBe exampleStatus
+        // response headers should be untouched, including the CORS-related ones
+        response.headers shouldBe responseHeaders
+      }
+    }
+
+    "reject requests without Origin header when strict" in {
+      val settings = referenceSettings.withAllowGenericHttpRequests(false)
+      Get() ~> {
+        route(settings)
+      } ~> check {
+        rejection shouldBe CorsRejection(CorsRejection.Malformed)
+      }
+    }
+
+    "accept actual requests with a single Origin" in {
+      val settings = referenceSettings
+      Get() ~> Origin(exampleOrigin) ~> {
+        route(settings)
+      } ~> check {
+        responseAs[String] shouldBe actual
+        response.status shouldBe exampleStatus
+        response.headers should contain theSameElementsAs Seq(
+          `Access-Control-Allow-Origin`(exampleOrigin),
+          `Access-Control-Allow-Credentials`(true))
+      }
+    }
+
+    "accept pre-flight requests with a null origin when allowed-origins = `*`" in {
+      val settings = referenceSettings
+      Options() ~> Origin(Seq.empty) ~> `Access-Control-Request-Method`(GET) ~> {
+        route(settings)
+      } ~> check {
+        status shouldBe StatusCodes.OK
+        response.headers should contain theSameElementsAs Seq(
+          `Access-Control-Allow-Origin`.`null`,
+          `Access-Control-Allow-Methods`(settings.allowedMethods),
+          `Access-Control-Max-Age`(1800),
+          `Access-Control-Allow-Credentials`(true))
+      }
+    }
+
+    "reject pre-flight requests with a null origin when allowed-origins != `*`" in {
+      val settings = referenceSettings.withAllowedOrigins(HttpOriginMatcher(exampleOrigin))
+      Options() ~> Origin(Seq.empty) ~> `Access-Control-Request-Method`(GET) ~> {
+        route(settings)
+      } ~> check {
+        rejection shouldBe CorsRejection(CorsRejection.InvalidOrigin(Seq.empty))
+      }
+    }
+
+    "accept actual requests with a null Origin" in {
+      val settings = referenceSettings
+      Get() ~> Origin(Seq.empty) ~> {
+        route(settings)
+      } ~> check {
+        responseAs[String] shouldBe actual
+        response.status shouldBe exampleStatus
+        response.headers should contain theSameElementsAs Seq(
+          `Access-Control-Allow-Origin`.`null`,
+          `Access-Control-Allow-Credentials`(true))
+      }
+    }
+
+    "accept actual requests with an Origin matching an allowed subdomain" in {
+      val subdomainMatcher = HttpOriginMatcher(HttpOrigin("http://*.example.com"))
+      val subdomainOrigin = HttpOrigin("http://sub.example.com")
+
+      val settings = referenceSettings.withAllowedOrigins(subdomainMatcher)
+      Get() ~> Origin(subdomainOrigin) ~> {
+        route(settings)
+      } ~> check {
+        responseAs[String] shouldBe actual
+        response.status shouldBe exampleStatus
+        response.headers should contain theSameElementsAs Seq(
+          `Access-Control-Allow-Origin`(subdomainOrigin),
+          `Access-Control-Allow-Credentials`(true))
+      }
+    }
+
+    "return `Access-Control-Allow-Origin: *` to actual request only when credentials are not allowed" in {
+      val settings = referenceSettings.withAllowCredentials(false)
+      Get() ~> Origin(exampleOrigin) ~> {
+        route(settings)
+      } ~> check {
+        responseAs[String] shouldBe actual
+        response.status shouldBe exampleStatus
+        response.headers shouldBe Seq(
+          `Access-Control-Allow-Origin`.*)
+      }
+    }
+
+    "return `Access-Control-Expose-Headers` to actual request with all the exposed headers in the settings" in {
+      val exposedHeaders = Seq("X-a", "X-b", "X-c")
+      val settings = referenceSettings.withExposedHeaders(exposedHeaders)
+      Get() ~> Origin(exampleOrigin) ~> {
+        route(settings)
+      } ~> check {
+        responseAs[String] shouldBe actual
+        response.status shouldBe exampleStatus
+        response.headers shouldBe Seq(
+          `Access-Control-Allow-Origin`(exampleOrigin),
+          `Access-Control-Expose-Headers`(exposedHeaders),
+          `Access-Control-Allow-Credentials`(true))
+      }
+    }
+
+    "remove CORS-related headers from the original response before adding the new ones" in {
+      val settings = referenceSettings.withExposedHeaders(Seq("X-good"))
+      val responseHeaders = Seq(
+        Host("my-host"), // untouched
+        `Access-Control-Allow-Origin`("http://bad.com"), // replaced
+        `Access-Control-Expose-Headers`("X-bad"), // replaced
+        `Access-Control-Allow-Credentials`(false), // replaced
+        `Access-Control-Allow-Methods`(HttpMethods.POST), // removed
+        `Access-Control-Allow-Headers`("X-bad"), // removed
+        `Access-Control-Max-Age`(60) // removed
+      )
+      Get() ~> Origin(exampleOrigin) ~> {
+        route(settings, responseHeaders)
+      } ~> check {
+        responseAs[String] shouldBe actual
+        response.status shouldBe exampleStatus
+        response.headers should contain theSameElementsAs Seq(
+          `Access-Control-Allow-Origin`(exampleOrigin),
+          `Access-Control-Expose-Headers`("X-good"),
+          `Access-Control-Allow-Credentials`(true),
+          Host("my-host"))
+      }
+    }
+
+    "accept valid pre-flight requests" in {
+      val settings = referenceSettings
+      Options() ~> Origin(exampleOrigin) ~> `Access-Control-Request-Method`(GET) ~> {
+        route(settings)
+      } ~> check {
+        response.entity shouldBe HttpEntity.Empty
+        status shouldBe StatusCodes.OK
+        response.headers should contain theSameElementsAs Seq(
+          `Access-Control-Allow-Origin`(exampleOrigin),
+          `Access-Control-Allow-Methods`(settings.allowedMethods),
+          `Access-Control-Max-Age`(1800),
+          `Access-Control-Allow-Credentials`(true))
+      }
+    }
+
+    "accept actual requests with OPTION method" in {
+      val settings = referenceSettings
+      Options() ~> Origin(exampleOrigin) ~> {
+        route(settings)
+      } ~> check {
+        responseAs[String] shouldBe actual
+        response.status shouldBe exampleStatus
+        response.headers should contain theSameElementsAs Seq(
+          `Access-Control-Allow-Origin`(exampleOrigin),
+          `Access-Control-Allow-Credentials`(true))
+      }
+    }
+
+    "reject actual requests with invalid origin" when {
+      "the origin is null" in {
+        val settings = referenceSettings.withAllowedOrigins(HttpOriginMatcher(exampleOrigin))
+        Get() ~> Origin(Seq.empty) ~> {
+          route(settings)
+        } ~> check {
+          rejection shouldBe CorsRejection(CorsRejection.InvalidOrigin(Seq.empty))
+        }
+      }
+      "there is one origin" in {
+        val settings = referenceSettings.withAllowedOrigins(HttpOriginMatcher(exampleOrigin))
+        val invalidOrigin = HttpOrigin("http://invalid.com")
+        Get() ~> Origin(invalidOrigin) ~> {
+          route(settings)
+        } ~> check {
+          rejection shouldBe CorsRejection(CorsRejection.InvalidOrigin(Seq(invalidOrigin)))
+        }
+      }
+    }
+
+    "reject pre-flight requests with invalid origin" in {
+      val settings = referenceSettings.withAllowedOrigins(HttpOriginMatcher(exampleOrigin))
+      val invalidOrigin = HttpOrigin("http://invalid.com")
+      Options() ~> Origin(invalidOrigin) ~> `Access-Control-Request-Method`(GET) ~> {
+        route(settings)
+      } ~> check {
+        rejection shouldBe CorsRejection(CorsRejection.InvalidOrigin(Seq(invalidOrigin)))
+      }
+    }
+
+    "reject pre-flight requests with invalid method" in {
+      val settings = referenceSettings
+      val invalidMethod = PATCH
+      Options() ~> Origin(exampleOrigin) ~> `Access-Control-Request-Method`(invalidMethod) ~> {
+        route(settings)
+      } ~> check {
+        rejection shouldBe CorsRejection(CorsRejection.InvalidMethod(invalidMethod))
+      }
+    }
+
+    "reject pre-flight requests with invalid header" in {
+      val settings = referenceSettings.withAllowedHeaders(HttpHeaderRange())
+      val invalidHeader = "X-header"
+      Options() ~> Origin(exampleOrigin) ~> `Access-Control-Request-Method`(GET) ~>
+      `Access-Control-Request-Headers`(invalidHeader) ~> {
+        route(settings)
+      } ~> check {
+        rejection shouldBe CorsRejection(CorsRejection.InvalidHeaders(Seq(invalidHeader)))
+      }
+    }
+
+    "reject pre-flight requests with multiple origins" in {
+      val settings = referenceSettings.withAllowGenericHttpRequests(false)
+      Options() ~> Origin(exampleOrigin, exampleOrigin) ~> `Access-Control-Request-Method`(GET) ~> {
+        route(settings)
+      } ~> check {
+        rejection shouldBe CorsRejection(CorsRejection.Malformed)
+      }
+    }
+  }
+
+  "the default rejection handler" should {
+    val settings = referenceSettings
+      .withAllowGenericHttpRequests(false)
+      .withAllowedOrigins(HttpOriginMatcher(exampleOrigin))
+      .withAllowedHeaders(HttpHeaderRange())
+    val sealedRoute = handleRejections(corsRejectionHandler) { route(settings) }
+
+    "handle the malformed request cause" in {
+      Get() ~> {
+        sealedRoute
+      } ~> check {
+        status shouldBe StatusCodes.BadRequest
+        entityAs[String] shouldBe "CORS: malformed request"
+      }
+    }
+
+    "handle a request with invalid origin" when {
+      "the origin is null" in {
+        Get() ~> Origin(Seq.empty) ~> {
+          sealedRoute
+        } ~> check {
+          status shouldBe StatusCodes.BadRequest
+          entityAs[String] shouldBe s"CORS: invalid origin 'null'"
+        }
+      }
+      "there is one origin" in {
+        Get() ~> Origin(HttpOrigin("http://invalid.com")) ~> {
+          sealedRoute
+        } ~> check {
+          status shouldBe StatusCodes.BadRequest
+          entityAs[String] shouldBe s"CORS: invalid origin 'http://invalid.com'"
+        }
+      }
+      "there are two origins" in {
+        Get() ~> Origin(HttpOrigin("http://invalid1.com"), HttpOrigin("http://invalid2.com")) ~> {
+          sealedRoute
+        } ~> check {
+          status shouldBe StatusCodes.BadRequest
+          entityAs[String] shouldBe s"CORS: invalid origin 'http://invalid1.com http://invalid2.com'"
+        }
+      }
+    }
+
+    "handle a pre-flight request with invalid method" in {
+      Options() ~> Origin(exampleOrigin) ~> `Access-Control-Request-Method`(PATCH) ~> {
+        sealedRoute
+      } ~> check {
+        status shouldBe StatusCodes.BadRequest
+        entityAs[String] shouldBe s"CORS: invalid method 'PATCH'"
+      }
+    }
+
+    "handle a pre-flight request with invalid headers" in {
+      Options() ~> Origin(exampleOrigin) ~> `Access-Control-Request-Method`(GET) ~>
+      `Access-Control-Request-Headers`("X-a", "X-b") ~> {
+        sealedRoute
+      } ~> check {
+        status shouldBe StatusCodes.BadRequest
+        entityAs[String] shouldBe s"CORS: invalid headers 'X-a X-b'"
+      }
+    }
+
+    "handle multiple CORS rejections" in {
+      Options() ~> Origin(HttpOrigin("http://invalid.com")) ~> `Access-Control-Request-Method`(PATCH) ~>
+      `Access-Control-Request-Headers`("X-a", "X-b") ~> {
+        sealedRoute
+      } ~> check {
+        status shouldBe StatusCodes.BadRequest
+        entityAs[String] shouldBe
+        s"CORS: invalid origin 'http://invalid.com', invalid method 'PATCH', invalid headers 'X-a X-b'"
+      }
+    }
+  }
+}

--- a/http-cors/src/test/scala/org/apache/pekko/http/cors/scaladsl/model/HttpOriginMatcherSpec.scala
+++ b/http-cors/src/test/scala/org/apache/pekko/http/cors/scaladsl/model/HttpOriginMatcherSpec.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.scaladsl.model
+
+import org.apache.pekko.http.scaladsl.model.headers.HttpOrigin
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class HttpOriginMatcherSpec extends AnyWordSpec with Matchers with Inspectors {
+  "The `*` matcher" should {
+    "match any Origin" in {
+      val origins = Seq(
+        "http://localhost",
+        "http://192.168.1.1",
+        "http://test.com",
+        "http://test.com:8080",
+        "https://test.com",
+        "https://test.com:4433").map(HttpOrigin.apply)
+
+      forAll(origins) { o => HttpOriginMatcher.*.matches(o) shouldBe true }
+    }
+
+    "be printed as `*`" in {
+      HttpOriginMatcher.*.toString shouldBe "*"
+    }
+  }
+
+  "The strict() method" should {
+    "build a strict matcher, comparing exactly the origins" in {
+      val positives = Seq(
+        "http://localhost",
+        "http://test.com",
+        "https://test.ch:12345",
+        "https://*.test.uk.co").map(HttpOrigin.apply)
+
+      val negatives = Seq(
+        "http://localhost:80",
+        "https://localhost",
+        "http://test.com:8080",
+        "https://test.ch",
+        "https://abc.test.uk.co").map(HttpOrigin.apply)
+
+      val matcher = HttpOriginMatcher.strict(positives: _*)
+
+      forAll(positives) { o => matcher.matches(o) shouldBe true }
+
+      forAll(negatives) { o => matcher.matches(o) shouldBe false }
+    }
+
+    "build a matcher with a toString() method that is a valid range" in {
+      val matcher = HttpOriginMatcher(Seq("http://test.com", "https://test.ch:12345").map(HttpOrigin.apply): _*)
+      matcher.toString shouldBe "http://test.com https://test.ch:12345"
+    }
+  }
+
+  "The apply() method" should {
+    "build a matcher accepting sub-domains with wildcards" in {
+      val matcher = HttpOriginMatcher(
+        Seq(
+          "http://test.com",
+          "https://test.ch:12345",
+          "https://*.test.uk.co",
+          "http://*.abc.com:8080",
+          "http://*abc.com", // Must start with `*.`
+          "http://abc.*.middle.com" // The wildcard can't be in the middle
+        ).map(HttpOrigin.apply): _*)
+
+      val positives = Seq(
+        "http://test.com",
+        "https://test.ch:12345",
+        "https://sub.test.uk.co",
+        "https://sub1.sub2.test.uk.co",
+        "http://sub.abc.com:8080").map(HttpOrigin.apply)
+
+      val negatives = Seq(
+        "http://test.com:8080",
+        "http://sub.test.uk.co", // must compare the scheme
+        "http://sub.abc.com", // must compare the port
+        "http://abc.test.com", // no wildcard
+        "http://sub.abc.com",
+        "http://subabc.com",
+        "http://abc.sub.middle.com",
+        "http://abc.middle.com").map(HttpOrigin.apply)
+
+      forAll(positives) { o => matcher.matches(o) shouldBe true }
+
+      forAll(negatives) { o => matcher.matches(o) shouldBe false }
+    }
+
+    "build a matcher with a toString() method that is a valid range" in {
+      val matcher = HttpOriginMatcher(Seq("http://test.com", "https://*.test.ch:12345").map(HttpOrigin.apply): _*)
+      matcher.toString shouldBe "http://test.com https://*.test.ch:12345"
+    }
+  }
+}

--- a/http-cors/src/test/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettingsSpec.scala
+++ b/http-cors/src/test/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettingsSpec.scala
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.cors.scaladsl.settings
+
+import org.apache.pekko
+import pekko.http.scaladsl.model.headers.HttpOrigin
+import pekko.http.scaladsl.model.{ HttpMethod, HttpMethods }
+import pekko.http.scaladsl.testkit.ScalatestRouteTest
+import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
+import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CorsSettingsSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+  import HttpMethods._
+
+  // Override some configs loaded through the Actor system
+  override def testConfigSource =
+    """
+      pekko.http.cors {
+        allow-credentials = false
+      }
+    """
+
+  val validConfig = ConfigFactory.parseString(
+    """
+      pekko.http.cors {
+        allow-generic-http-requests = true
+        allow-credentials = true
+        allowed-origins = "*"
+        allowed-headers = "*"
+        allowed-methods = ["GET", "OPTIONS", "XXX"]
+        exposed-headers = []
+        max-age = 30 minutes
+      }
+    """)
+
+  val referenceSettings = CorsSettings("")
+
+  "CorsSettings" should {
+
+    "load settings from the actor system by default" in {
+      val settings1 = CorsSettings.default
+      val settings2 = CorsSettings(system)
+
+      settings1 should not be referenceSettings
+      settings1 shouldBe settings2
+
+      referenceSettings.allowCredentials shouldBe true
+      settings1.allowCredentials shouldBe false
+    }
+
+    "cache the settings from the actor system" in {
+      val settings1 = CorsSettings(system)
+      val settings2 = CorsSettings(system)
+
+      settings1 shouldBe theSameInstanceAs(settings2)
+    }
+
+    "return valid cors settings from a valid config object" in {
+      val corsSettings = CorsSettings(validConfig)
+      corsSettings.allowGenericHttpRequests shouldBe true
+      corsSettings.allowCredentials shouldBe true
+      corsSettings.allowedOrigins shouldBe HttpOriginMatcher.*
+      corsSettings.allowedHeaders shouldBe HttpHeaderRange.*
+      corsSettings.allowedMethods shouldBe List(GET, OPTIONS, HttpMethod.custom("XXX"))
+      corsSettings.exposedHeaders shouldBe List.empty
+      corsSettings.maxAge shouldBe Some(1800)
+    }
+
+    "support space separated list of origins" in {
+      val config = validConfig.withValue(
+        "pekko.http.cors.allowed-origins",
+        ConfigValueFactory.fromAnyRef("http://test.com http://any.com"))
+      val corsSettings = CorsSettings(config)
+      corsSettings.allowedOrigins shouldBe HttpOriginMatcher(
+        HttpOrigin("http://test.com"),
+        HttpOrigin("http://any.com"))
+    }
+
+    "support wildcard subdomains" in {
+      val config = validConfig.withValue(
+        "pekko.http.cors.allowed-origins",
+        ConfigValueFactory.fromAnyRef("http://*.test.com"))
+      val corsSettings = CorsSettings(config)
+      corsSettings.allowedOrigins.matches(HttpOrigin("http://sub.test.com")) shouldBe true
+    }
+
+    "support numeric values on max-age as seconds" in {
+      val corsSettings = CorsSettings(
+        validConfig.withValue("pekko.http.cors.max-age", ConfigValueFactory.fromAnyRef(1800)))
+      corsSettings.maxAge shouldBe Some(1800)
+    }
+
+    "support null value on max-age" in {
+      val corsSettings = CorsSettings(
+        validConfig.withValue("pekko.http.cors.max-age", ConfigValueFactory.fromAnyRef(null)))
+      corsSettings.maxAge shouldBe None
+    }
+
+    "support undefined on max-age" in {
+      val corsSettings = CorsSettings(validConfig.withoutPath("pekko.http.cors.max-age"))
+      corsSettings.maxAge shouldBe None
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -118,6 +118,8 @@ object Dependencies {
     Provided.jsr305,
     Test.scalatest)
 
+  lazy val httpCors = l ++= Seq(Test.scalatest)
+
   lazy val http = Seq()
 
   lazy val http2Tests = l ++= Seq(Test.h2spec)


### PR DESCRIPTION
This PR adds pekko-http-cors support to pekko-http via the merge of akka-http-cors/pekko-http-cors (see https://github.com/lomigmegard/pekko-http-cors/issues/33). Notable points

* Legal disclaimers have been added (both to the root `LEGAL` file and to the `META-INF` jar indicating that the code was granted to ASF via SGA)
* The code is exactly the same as https://github.com/lomigmegard/pekko-http-cors with the expected package/import changes with these exceptions
  * One breaking code change where `org.apache.pekko.http.cors.javadsl.settings.CorsSettings.getMaxAge` was changed from `Optional[Long]` to `OptionalLong` since this is consistent within the rest of the Akka/Pekko ecosystem (and is also idiomatic for Java use)
  * A non breaking change where explicit return types where added to the `get*` public Java API methods in `CorsSettings`
  * ~~`application.conf` was renamed to `reference.conf` (using `application.conf` was likely an oversight, it should be used for actual applications where as `reference.conf` should be used for libraries).~~ This was an accident on my part
  * The root typesafe config was changed from `pekko-http-cors` to `pekko.http.cors` to be consistent with the rest of the Pekko Http.
* Migration notes have been added including the previously listed changes
* Docs have been added to the standard place (i.e. `docs/src/main/paradox/common/cors.md`) which is largely inspired by https://github.com/lomigmegard/pekko-http-cors/blob/master/README.md however I have made some liberties in changes so its more consistent with Pekko documentation, specifically
  * The original docs had inline source code that was Scala, this was updated to use different groupings for Java/Scala which means that Java equivalents had to be added.
  * The mention of default values has been removed since this is already documented in `reference.conf` and has been added to `docs/src/main/paradox/configuration.md`.
  * The sample code is directly included using the Scala/java `@@snip` rather than just referencing it.
  * In general there is an argument that the various sub headings such as `#### allowGenericHttpRequests / getAllowGenericHttpRequests` should also be removed because they are duplicated in the scala docs and is also not typical with Pekko Http documentation (let me know what you think on this point).
  * This is the first case where have new code derived from somewhere outside of Akka via a SGA which means that our standard sbt-header-check needed to be updated in order to ignore the `pekko-http-cors` project. Note that only sources have been ignored, resources (such as `reference.conf`) still get checked mainly for the `# SPDX-License-Identifier: Apache-2.0` header. This is on the presumption that headers are not recommended/necessary for non derived/SGA approved Apache source code.
  
@lomigmegard Pinging you so you can also review the PR and let me know your thoughts. The most critical thing here is any changes that you think would need to be done now otherwise they would break users in the future (i.e. the `Optional[Long]` to `OptionalLong` is an example of this) which you weren't able to do in akka-http-cors due to breaking downstream users.