### PR TITLE
Fix broken generated java unidoc mappings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,11 +45,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-http/issues/216

The code which generates the api mappings for documentation originates from sbt-api-mappings. sbt-api-mappings tries to calculate the JDK version and if the calculated version is less than 11 it uses the broken reference as described in the issue, i.e.

https://github.com/ThoughtWorksInc/sbt-api-mappings/blob/5b1e4f11647421d287d3a26ed7fb077474ea7a3e/src/main/scala/com/thoughtworks/sbtApiMappings/BootstrapApiMappings.scala#L30-L44

Setting JDK 11 for publishing docs should be enough and its likely this is one of the reason why pekko-http core requires JDK 11 specifically for their documentation generation as well.