### PR TITLE
Revert "Fix broken generated java unidoc mappings"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,11 +45,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6


### PR DESCRIPTION
This reverts commit 610348328dd3ece1f83f8dad13c46af24c54798d. See https://github.com/apache/incubator-pekko-http/pull/204#discussion_r1265279415 for context.