### PR TITLE
docs: remove left-over javascript file

### DIFF
--- a/docs/src/main/paradox/assets/js/scrollToFragment.js
+++ b/docs/src/main/paradox/assets/js/scrollToFragment.js
@@ -1,5 +1,0 @@
-$(document).ready(function() {
-  if(window.location.hash.length > 0) {
-    window.scrollTo(0, $(window.location.hash).offset().top);
-  }
-});


### PR DESCRIPTION
It was not used any more, but more importantly it does not seem to be necessary any more, as the underlying bug in Firefox seems to be fixed by now.

See https://github.com/lightbend/paradox/issues/443 for a history of the problem.