### PR TITLE
add license entry for sbt BSD license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -278,3 +278,33 @@ pekko-http-core contains code based on code by Tim Kienzle with his permission t
 (C) 2000 by Tim Kientzle <kientzle@acm.org>
 
 ---------------
+
+pekko-http-core contains code from sbt 0.12 which was distributed under a BSD-style license
+<https://github.com/sbt/sbt/blob/0.12/LICENSE>.
+
+ - http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/util/AsciiTreeLayout.scala
+
+Copyright (c) 2008, 2009, 2010 Steven Blundy, Josh Cough, Mark Harrah, Stuart Roebuck, Tony Sloane, Vesa Vilhonen, Jason Zaugg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/util/AsciiTreeLayout.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/util/AsciiTreeLayout.scala
@@ -1,17 +1,10 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
- * This file is part of the Apache Pekko project, which was derived from Akka.
- */
-
 /* sbt -- Simple Build Tool
  * Copyright 2011 Mark Harrah, Eugene Yokota
  *
  * Copied from sbt 0.12 source code
  */
+
+// copied from https://github.com/sbt/sbt/blob/0.12/main/SettingGraph.scala
 
 package org.apache.pekko.http.impl.engine.http2.util
 

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -68,7 +68,8 @@ object CopyrightHeader extends AutoPlugin {
 
     override def apply(text: String, existingText: Option[String]): String = {
       val formatted = existingText match {
-        case Some(currentText) if isApacheCopyrighted(currentText) || isGenerated(currentText) =>
+        case Some(currentText)
+            if isApacheCopyrighted(currentText) || isGenerated(currentText) || isSbt012Licensed(currentText) =>
           currentText
         case Some(currentText) if isOnlyLightbendCopyrightAnnotated(currentText) =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(apacheFromAkkaSourceHeader,
@@ -112,4 +113,7 @@ object CopyrightHeader extends AutoPlugin {
   private def isOnlyLightbendCopyrightAnnotated(text: String): Boolean = {
     isLightbendCopyrighted(text) && !isApacheCopyrighted(text)
   }
+
+  private def isSbt012Licensed(text: String): Boolean =
+    StringUtils.containsIgnoreCase(text, "sbt -- Simple Build Tool")
 }


### PR DESCRIPTION
* part of -1 vote for RC
* sbt is now Apache licensed but back in sbt 0.12 days, it was BSD licensed