### PR TITLE
test: avoid frequent timeouts in ResponseParserSpec

### DIFF
--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -434,7 +434,7 @@ abstract class ResponseParserSpec(mode: String, newLine: String) extends PekkoSp
         }.concatSubstreams
 
     def collectBlocking[T](source: Source[T, Any]): Seq[T] =
-      Await.result(source.limit(100000).runWith(Sink.seq), 1000.millis.dilated)
+      Await.result(source.limit(100000).runWith(Sink.seq), 2000.millis.dilated)
 
     protected def parserSettings: ParserSettings = ParserSettings(system)
 


### PR DESCRIPTION
Seems to have happened quite often recently (mostly seen on Scala 3.3 Java 8 runs, not sure if that's something to investigate but likely not).