### PR TITLE
update license and notice with akka-see license/notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -279,6 +279,19 @@ pekko-http-core contains code based on code by Tim Kienzle with his permission t
 
 ---------------
 
+pekko-http-core contains code based on akka-sse <https://github.com/hseeberger/akka-sse>
+distributed under the Apache 2.0 license.
+
+  - http-tests/src/test/java/org/apache/pekko/http/javadsl/marshalling/sse/EventStreamMarshallingTest.java
+  - http-tests/src/test/java/org/apache/pekko/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java
+  - http-core/src/test/java/org/apache/pekko/http/javadsl/model/sse/ServerSentEventTest.java
+  - http-core/src/main/java/org/apache/pekko/http/javadsl/model/sse/ServerSentEvent.java
+  - http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/LastEventId.java
+
+Copyright 2015 Heiko Seeberger
+
+---------------
+
 pekko-http-core contains code from sbt 0.12 which was distributed under a BSD-style license
 <https://github.com/sbt/sbt/blob/0.12/LICENSE>.
 

--- a/LICENSE
+++ b/LICENSE
@@ -279,7 +279,7 @@ pekko-http-core contains code based on code by Tim Kienzle with his permission t
 
 ---------------
 
-pekko-http-core contains code based on akka-sse <https://github.com/hseeberger/akka-sse>
+pekko-http-core and pekko-http-tests contain code based on akka-sse <https://github.com/hseeberger/akka-sse>
 distributed under the Apache 2.0 license.
 
   - http-tests/src/test/java/org/apache/pekko/http/javadsl/marshalling/sse/EventStreamMarshallingTest.java

--- a/NOTICE
+++ b/NOTICE
@@ -31,6 +31,13 @@ limitations under the License.
 
 ---------------
 
+pekko-http-core contains code based on akka-sse <https://github.com/hseeberger/akka-sse>
+distributed under the Apache 2.0 license.
+
+Copyright 2015 Heiko Seeberger
+
+---------------
+
 pekko-http-cors contains code that was donated by Lomig Mégard to the Apache Software Foundation
 via a Software Grant Agreement <https://www.apache.org/licenses/contributor-agreements.html#grants>
 See <https://github.com/lomigmegard/pekko-http-cors/issues/33>.

--- a/NOTICE
+++ b/NOTICE
@@ -31,7 +31,7 @@ limitations under the License.
 
 ---------------
 
-pekko-http-core contains code based on akka-sse <https://github.com/hseeberger/akka-sse>
+pekko-http-core and pekko-http-tests contain code based on akka-sse <https://github.com/hseeberger/akka-sse>
 distributed under the Apache 2.0 license.
 
 Copyright 2015 Heiko Seeberger


### PR DESCRIPTION
* relates to #250 
* http-tests module is not published as a jar, so no need to worry about getting a tailored LICENSE/NOTICE included in its jar