### PR TITLE
add parboiled2 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -279,6 +279,16 @@ pekko-http-core contains code based on code by Tim Kienzle with his permission t
 
 ---------------
 
+pekko-http-core contain code from parboiled2 <https://github.com/sirthias/parboiled2>
+distributed under the Apache 2.0 license.
+
+  - http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/Base64Parsing.scala
+
+Copyright © 2009-2013 Mathias Doenitz <http://parboiled2.org>
+Copyright © 2013 Alexander Myltsev
+
+---------------
+
 pekko-http-core and pekko-http-tests contain code based on akka-sse <https://github.com/hseeberger/akka-sse>
 distributed under the Apache 2.0 license.
 


### PR DESCRIPTION
Base64Parsing is from parboiled2.

https://github.com/apache/incubator-pekko-http/blob/38ff8037a5677a47a652330af407e96cc78f98e7/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/Base64Parsing.scala

We have removed a lot of parboiled2 code from pekko-http but Base64Parsing is still there - although only some of its code is used.

[parboiled2](https://github.com/sirthias/parboiled2) has no NOTICE file.

relates to #249 