### PR TITLE
build: sbt-header resolves boilerplace template files

### DIFF
--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -33,7 +33,8 @@ object CopyrightHeader extends AutoPlugin {
             HeaderFileType.scala -> cStyleComment,
             HeaderFileType.java -> cStyleComment,
             HeaderFileType.conf -> hashLineComment,
-            HeaderFileType("template") -> cStyleComment)))
+            HeaderFileType("template") -> cStyleComment),
+          headerSources ++= (sourceDirectory.value ** "*.scala.template").get))
     })
 
   val apacheFromAkkaSourceHeader: String =


### PR DESCRIPTION
closes https://github.com/apache/incubator-pekko-http/issues/244

```
>  sbt 'show http/headerSources' | tail -n 10
[info] * /Users/krrrr38/dev/src/github.com/apache/incubator-pekko-http/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
[info] * /Users/krrrr38/dev/src/github.com/apache/incubator-pekko-http/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala
[info] * /Users/krrrr38/dev/src/github.com/apache/incubator-pekko-http/http/src/main/boilerplate/org/apache/pekko/http/scaladsl/server/directives/FormFieldDirectivesInstances.scala.template
[info] * /Users/krrrr38/dev/src/github.com/apache/incubator-pekko-http/http/src/main/boilerplate/org/apache/pekko/http/scaladsl/server/directives/ParameterDirectivesInstances.scala.template
[info] * /Users/krrrr38/dev/src/github.com/apache/incubator-pekko-http/http/src/main/boilerplate/org/apache/pekko/http/scaladsl/server/util/ApplyConverterInstances.scala.template
[info] * /Users/krrrr38/dev/src/github.com/apache/incubator-pekko-http/http/src/main/boilerplate/org/apache/pekko/http/scaladsl/server/util/ConstructFromTupleInstances.scala.template
[info] * /Users/krrrr38/dev/src/github.com/apache/incubator-pekko-http/http/src/main/boilerplate/org/apache/pekko/http/scaladsl/server/util/TupleFoldInstances.scala.template
[info] * /Users/krrrr38/dev/src/github.com/apache/incubator-pekko-http/http/src/main/boilerplate/org/apache/pekko/http/scaladsl/server/util/TupleAppendOneInstances.scala.template
[info] * /Users/krrrr38/dev/src/github.com/apache/incubator-pekko-http/http/src/main/boilerplate/org/apache/pekko/http/javadsl/server/JavaPathMatchers.scala.template
[success] Total time: 0 s, completed 2023 Jul 23 09:05:39
```