### PR TITLE
update list of 3rd party jars

### DIFF
--- a/docs/src/main/paradox/examples-and-extensions.md
+++ b/docs/src/main/paradox/examples-and-extensions.md
@@ -11,7 +11,7 @@ There are several [third party libraries](https://doc.akka.io/docs/akka-http/10.
 
 Some that support Apache Pekko HTTP include:
 
-- [aws-spi-pekko-http](https://github.com/pjfanning/aws-spi-pekko-http): Integrate some of the best JSON libs in Scala with Pekko HTTP.
+- [aws-spi-pekko-http](https://github.com/pjfanning/aws-spi-pekko-http): Provides a non-blocking HTTP Client that works with the [AWS Java SDK v2](https://github.com/aws/aws-sdk-java-v2).
 - [pekko-http-json](https://github.com/pjfanning/pekko-http-json): Integrate some of the best JSON libs in Scala with Pekko HTTP.
 - [pekko-streams-circe/pekko-http-json](https://github.com/mdedetrich/pekko-streams-circe): Includes streaming [Circe](https://circe.github.io/circe/) support that can be used with Pekko HTTP.
 - [swagger-pekko-http](https://github.com/swagger-akka-http/swagger-pekko-http): A Scala/Java library for generating Open API (a.k.a. Swagger) from annotated Pekko HTTP code.

--- a/docs/src/main/paradox/examples-and-extensions.md
+++ b/docs/src/main/paradox/examples-and-extensions.md
@@ -9,10 +9,11 @@ If you are aware of any interesting examples that use Apache Pekko HTTP, please 
 ## Extensions
 There are several [third party libraries](https://doc.akka.io/docs/akka-http/10.2/extensions.html) that expand the functionality of Akka HTTP.
 
-Some that support Apache Pekko HTTP snapshots include:
+Some that support Apache Pekko HTTP include:
 
-- [pekko-http-cors](https://github.com/lomigmegard/pekko-http-cors): Pekko HTTP directives implementing the CORS specifications defined by W3C.
+- [aws-spi-pekko-http](https://github.com/pjfanning/aws-spi-pekko-http): Integrate some of the best JSON libs in Scala with Pekko HTTP.
 - [pekko-http-json](https://github.com/pjfanning/pekko-http-json): Integrate some of the best JSON libs in Scala with Pekko HTTP.
+- [pekko-streams-circe/pekko-http-json](https://github.com/mdedetrich/pekko-streams-circe): Includes streaming [Circe](https://circe.github.io/circe/) support that can be used with Pekko HTTP.
 - [swagger-pekko-http](https://github.com/swagger-akka-http/swagger-pekko-http): A Scala/Java library for generating Open API (a.k.a. Swagger) from annotated Pekko HTTP code.
 
 If you are aware of any extensions that support Apache Pekko HTTP, please notify us or create a PR to modify this page.


### PR DESCRIPTION
* pekko-http-cors is now part of Apache Pekko