### PR TITLE
try h2spec 2.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import org.apache.pekko
 import pekko._
 import pekko.ValidatePullRequest._
 import PekkoDependency._
-import Dependencies.{ h2specExe, h2specName }
+import Dependencies.{ h2specExe, h2specName, h2specArtifactExtension }
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import java.nio.file.Files
 import java.nio.file.attribute.{ PosixFileAttributeView, PosixFilePermission }
@@ -187,7 +187,7 @@ lazy val http2Tests = project("http2-tests")
         if (!h2spec.exists) {
           log.info("Extracting h2spec to " + h2spec)
 
-          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = "zip")))
+          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = h2specArtifactExtension)))
             IO.unzip(zip, (Test / target).value)
 
           // Set the executable bit on the expected path to fail if it doesn't exist

--- a/build.sbt
+++ b/build.sbt
@@ -187,9 +187,11 @@ lazy val http2Tests = project("http2-tests")
         if (!h2spec.exists) {
           log.info("Extracting h2spec to " + h2spec)
 
-          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName,
-              extension = h2specArtifactExtension)))
-            IO.unzip(zip, (Test / target).value)
+          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = "zip")))
+            IO.unzip(zip, (Test / target).value / h2specName)
+
+          for (tarGz <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = "gz")))
+            Untar.unTarGz(tarGz, (Test / target).value / h2specName)
 
           // Set the executable bit on the expected path to fail if it doesn't exist
           for (view <- Option(Files.getFileAttributeView(h2spec.toPath, classOf[PosixFileAttributeView]))) {

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import org.apache.pekko
 import pekko._
 import pekko.ValidatePullRequest._
 import PekkoDependency._
-import Dependencies.{ h2specExe, h2specName, h2specArtifactExtension }
+import Dependencies.{ h2specArtifactExtension, h2specExe, h2specName }
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import java.nio.file.Files
 import java.nio.file.attribute.{ PosixFileAttributeView, PosixFilePermission }
@@ -187,7 +187,8 @@ lazy val http2Tests = project("http2-tests")
         if (!h2spec.exists) {
           log.info("Extracting h2spec to " + h2spec)
 
-          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = h2specArtifactExtension)))
+          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName,
+              extension = h2specArtifactExtension)))
             IO.unzip(zip, (Test / target).value)
 
           // Set the executable bit on the expected path to fail if it doesn't exist

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -171,7 +171,7 @@ class H2SpecIntegrationSpec extends PekkoSpec(
         "-k", "-t",
         "-p", port.toString,
         "-j", junitOutput.getPath) ++
-        specSectionNumber.toList.flatMap(number => Seq("-s", number))
+        specSectionNumber.toList.flatMap(number => Seq(s"http2/$number"))
 
       log.debug(s"Executing h2spec: $command")
       val aggregateTckLogs = ProcessLogger(

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -171,7 +171,7 @@ class H2SpecIntegrationSpec extends PekkoSpec(
         "-k", "-t",
         "-p", port.toString,
         "-j", junitOutput.getPath) ++
-        specSectionNumber.toList.flatMap(number => Seq(s"http2/$number"))
+        specSectionNumber.toList.map(number => s"http2/$number")
 
       log.debug(s"Executing h2spec: $command")
       val aggregateTckLogs = ProcessLogger(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,8 @@ object Dependencies {
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specArtifactExtension = if (h2specExe == "exe") "zip" else "tar.gz"
-  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.$h2specArtifactExtension"
+  val h2specUrl =
+    s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.$h2specArtifactExtension"
 
   val scalaTestVersion = "3.2.14"
   val specs2Version = "4.10.6"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,8 @@ object Dependencies {
   val h2specVersion = "2.6.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
-  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.zip"
+  val h2specArtifactExtension = if (h2specExe == "exe") "zip" else "tar.gz"
+  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.$h2specArtifactExtension"
 
   val scalaTestVersion = "3.2.14"
   val specs2Version = "4.10.6"
@@ -186,8 +187,7 @@ object DependencyHelpers {
   }
 
   def exeIfWindows: String = {
-    val os = System.getProperty("os.name").toLowerCase()
-    if (os.startsWith("win")) ".exe"
+    if (osName.startsWith("win")) ".exe"
     else ""
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   val jacksonDatabindVersion = "2.14.3"
   val jacksonXmlVersion = jacksonDatabindVersion
   val junitVersion = "4.13.2"
-  val h2specVersion = "1.5.0"
+  val h2specVersion = "2.6.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.zip"

--- a/project/Untar.scala
+++ b/project/Untar.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko
+
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
+import org.apache.commons.io.IOUtils
+
+import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream}
+import scala.util.Using
+
+object Untar {
+
+  // extracts files from `.tar.gz` / `.tgz` files
+  def unTarGz(tarFile: File, toDirectory: File): Unit = {
+    Using(new FileInputStream(tarFile)) { tarFileStream =>
+      val buffIn = new BufferedInputStream(tarFileStream)
+      val gzIn = new GzipCompressorInputStream(buffIn)
+      Using(new TarArchiveInputStream(gzIn)) { tis =>
+        toDirectory.mkdirs()
+        var entry = tis.getNextTarEntry
+        while (entry ne null) {
+          val name = entry.getName
+          val outFile = new File(toDirectory, name)
+          Using(new FileOutputStream(outFile)) { fos =>
+            IOUtils.copy(tis, fos)
+          }
+          entry = tis.getNextTarEntry
+        }
+      }
+    }
+  }
+}

--- a/project/Untar.scala
+++ b/project/Untar.scala
@@ -21,7 +21,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.apache.commons.io.IOUtils
 
-import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream}
+import java.io.{ BufferedInputStream, File, FileInputStream, FileOutputStream }
 import scala.util.Using
 
 object Untar {


### PR DESCRIPTION
* relates to #262 
* the h2spec v2 GitHub release files are now `.tar.gz` -- except the Windows one which is `.zip`
* the h2spec v2 GitHub release artifacts have no directories embedded in them
* the `h2spec` command no longer supports the `-s` option so that causes some test failures
    * needs investigation 