### PR TITLE
Make h2spec 2.6.0 work

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import org.apache.pekko
 import pekko._
 import pekko.ValidatePullRequest._
 import PekkoDependency._
-import Dependencies.{ h2specExe, h2specName }
+import Dependencies.{ h2specExe, h2specName, h2specArtifactExtension }
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import java.nio.file.Files
 import java.nio.file.attribute.{ PosixFileAttributeView, PosixFilePermission }
@@ -187,7 +187,7 @@ lazy val http2Tests = project("http2-tests")
         if (!h2spec.exists) {
           log.info("Extracting h2spec to " + h2spec)
 
-          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = "zip")))
+          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = h2specArtifactExtension)))
             IO.unzip(zip, (Test / target).value)
 
           // Set the executable bit on the expected path to fail if it doesn't exist

--- a/build.sbt
+++ b/build.sbt
@@ -187,9 +187,11 @@ lazy val http2Tests = project("http2-tests")
         if (!h2spec.exists) {
           log.info("Extracting h2spec to " + h2spec)
 
-          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName,
-              extension = h2specArtifactExtension)))
-            IO.unzip(zip, (Test / target).value)
+          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = "zip")))
+            IO.unzip(zip, (Test / target).value / h2specName)
+
+          for (tarGz <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = "gz")))
+            Untar.unTarGz(tarGz, (Test / target).value / h2specName)
 
           // Set the executable bit on the expected path to fail if it doesn't exist
           for (view <- Option(Files.getFileAttributeView(h2spec.toPath, classOf[PosixFileAttributeView]))) {

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import org.apache.pekko
 import pekko._
 import pekko.ValidatePullRequest._
 import PekkoDependency._
-import Dependencies.{ h2specExe, h2specName, h2specArtifactExtension }
+import Dependencies.{ h2specArtifactExtension, h2specExe, h2specName }
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import java.nio.file.Files
 import java.nio.file.attribute.{ PosixFileAttributeView, PosixFilePermission }
@@ -187,7 +187,8 @@ lazy val http2Tests = project("http2-tests")
         if (!h2spec.exists) {
           log.info("Extracting h2spec to " + h2spec)
 
-          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = h2specArtifactExtension)))
+          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName,
+              extension = h2specArtifactExtension)))
             IO.unzip(zip, (Test / target).value)
 
           // Set the executable bit on the expected path to fail if it doesn't exist

--- a/http-core/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.testkit
 import org.scalactic.{ CanEqual, TypeCheckedTripleEquals }
 
 import language.postfixOps
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{ BeforeAndAfterAll, TestSuite }
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.{ Logging, LoggingAdapter }
@@ -27,6 +27,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import pekko.dispatch.Dispatchers
 import pekko.testkit.TestEvent._
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -66,12 +67,8 @@ object PekkoSpec {
 
 }
 
-abstract class PekkoSpec(_system: ActorSystem)
-    extends TestKit(_system) with AnyWordSpecLike with Matchers with BeforeAndAfterAll with WatchedByCoroner
-    with TypeCheckedTripleEquals with ScalaFutures {
-
-  implicit val patience: PatienceConfig = PatienceConfig(testKitSettings.DefaultTimeout.duration)
-
+abstract class PekkoSpec(_system: ActorSystem) extends PekkoBaseSpec(_system) with AnyWordSpecLike
+    with BeforeAndAfterAll {
   def this(config: Config) = this(ActorSystem(
     PekkoSpec.getCallerName(getClass),
     ConfigFactory.load(config.withFallback(PekkoSpec.testConf))))
@@ -81,8 +78,6 @@ abstract class PekkoSpec(_system: ActorSystem)
   def this(configMap: Map[String, _]) = this(PekkoSpec.mapToConfig(configMap))
 
   def this() = this(ActorSystem(PekkoSpec.getCallerName(getClass), PekkoSpec.testConf))
-
-  val log: LoggingAdapter = Logging(system, this.getClass.asInstanceOf[Class[Any]])
 
   override val invokeBeforeAllAndAfterAllEvenIfNoTestsAreExpected = true
 
@@ -97,6 +92,53 @@ abstract class PekkoSpec(_system: ActorSystem)
     afterTermination()
     stopCoroner()
   }
+}
+
+// FreeSpec version of PekkoSpec, unfortunately, some boilerplate is needed to make it work
+abstract class PekkoFreeSpec(_system: ActorSystem) extends PekkoBaseSpec(_system) with AnyFreeSpecLike
+    with BeforeAndAfterAll {
+  def this(config: Config) = this(ActorSystem(
+    PekkoSpec.getCallerName(getClass),
+    ConfigFactory.load(config.withFallback(PekkoSpec.testConf))))
+
+  def this(s: String) = this(ConfigFactory.parseString(s))
+
+  def this(configMap: Map[String, _]) = this(PekkoSpec.mapToConfig(configMap))
+
+  def this() = this(ActorSystem(PekkoSpec.getCallerName(getClass), PekkoSpec.testConf))
+
+  override val invokeBeforeAllAndAfterAllEvenIfNoTestsAreExpected = true
+
+  final override def beforeAll(): Unit = {
+    startCoroner()
+    atStartup()
+  }
+
+  final override def afterAll(): Unit = {
+    beforeTermination()
+    shutdown()
+    afterTermination()
+    stopCoroner()
+  }
+}
+
+abstract class PekkoBaseSpec(_system: ActorSystem)
+    extends TestKit(_system) with Matchers with WatchedByCoroner
+    with TypeCheckedTripleEquals with ScalaFutures with TestSuite {
+
+  implicit val patience: PatienceConfig = PatienceConfig(testKitSettings.DefaultTimeout.duration)
+
+  def this(config: Config) = this(ActorSystem(
+    PekkoSpec.getCallerName(getClass),
+    ConfigFactory.load(config.withFallback(PekkoSpec.testConf))))
+
+  def this(s: String) = this(ConfigFactory.parseString(s))
+
+  def this(configMap: Map[String, _]) = this(PekkoSpec.mapToConfig(configMap))
+
+  def this() = this(ActorSystem(PekkoSpec.getCallerName(getClass), PekkoSpec.testConf))
+
+  val log: LoggingAdapter = Logging(system, this.getClass.asInstanceOf[Class[Any]])
 
   protected def atStartup(): Unit = {}
 

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -171,7 +171,7 @@ class H2SpecIntegrationSpec extends PekkoSpec(
         "-k", "-t",
         "-p", port.toString,
         "-j", junitOutput.getPath) ++
-        specSectionNumber.toList.flatMap(number => Seq("-s", number))
+        specSectionNumber.toList.flatMap(number => Seq(s"http2/$number"))
 
       log.debug(s"Executing h2spec: $command")
       val aggregateTckLogs = ProcessLogger(

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -171,7 +171,7 @@ class H2SpecIntegrationSpec extends PekkoSpec(
         "-k", "-t",
         "-p", port.toString,
         "-j", junitOutput.getPath) ++
-        specSectionNumber.toList.flatMap(number => Seq(s"http2/$number"))
+        specSectionNumber.toList.map(number => s"http2/$number")
 
       log.debug(s"Executing h2spec: $command")
       val aggregateTckLogs = ProcessLogger(

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.http.impl.engine.http2
 
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
-
 import org.apache.pekko
 import pekko.http.impl.util.{ ExampleHttpContexts, WithLogCapturing }
 import pekko.http.scaladsl.Http
@@ -29,7 +28,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.sys.process._
 
-class H2SpecIntegrationSpec extends PekkoSpec(
+class H2SpecIntegrationSpec extends PekkoFreeSpec(
       """
      pekko {
        loglevel = DEBUG
@@ -62,98 +61,237 @@ class H2SpecIntegrationSpec extends PekkoSpec(
       .futureValue
   val port = binding.localAddress.getPort
 
-  "H2Spec" must {
+  "H2Spec" - {
 
     /**
-     * We explicitly list all cases we want to run, also because perhaps some of them we'll find to be not quite correct?
-     * This list was obtained via a run from the console and grepping such that we get all the \\. containing lines.
+     * This list can be exported using `h2spec --dryrun`
      */
-    val testCases =
+    val testCaseDesc =
       """
+      3. Starting HTTP/2
         3.5. HTTP/2 Connection Preface
+          1: Sends client connection preface
+          2: Sends invalid connection preface
+
+      4. HTTP Frames
+        4.1. Frame Format
+          1: Sends a frame with unknown type
+          2: Sends a frame with undefined flag
+          (pending) 3: Sends a frame with reserved field bit
+
         4.2. Frame Size
+          1: Sends a DATA frame with 2^14 octets in length
+          (pending) 2: Sends a large size DATA frame that exceeds the SETTINGS_MAX_FRAME_SIZE
+          (pending) 3: Sends a large size HEADERS frame that exceeds the SETTINGS_MAX_FRAME_SIZE
+
         4.3. Header Compression and Decompression
+          1: Sends invalid header block fragment
+          2: Sends a PRIORITY frame while sending the header blocks
+          3: Sends a HEADERS frame to another stream while sending the header blocks
+
+      5. Streams and Multiplexing
         5.1. Stream States
+          1: idle: Sends a DATA frame
+          2: idle: Sends a RST_STREAM frame
+          3: idle: Sends a WINDOW_UPDATE frame
+          4: idle: Sends a CONTINUATION frame
+          (pending) 5: half closed (remote): Sends a DATA frame
+          (pending) 6: half closed (remote): Sends a HEADERS frame
+          7: half closed (remote): Sends a CONTINUATION frame
+          (pending) 8: closed: Sends a DATA frame after sending RST_STREAM frame
+          (pending) 9: closed: Sends a HEADERS frame after sending RST_STREAM frame
+          10: closed: Sends a CONTINUATION frame after sending RST_STREAM frame
+          (pending) 11: closed: Sends a DATA frame
+          (pending) 12: closed: Sends a HEADERS frame
+          13: closed: Sends a CONTINUATION frame
+
           5.1.1. Stream Identifiers
+            (pending) 1: Sends even-numbered stream identifier
+            2: Sends stream identifier that is numerically smaller than previous
+
           5.1.2. Stream Concurrency
+            (pending) 1: Sends HEADERS frames that causes their advertised concurrent stream limit to be exceeded
+
         5.3. Stream Priority
           5.3.1. Stream Dependencies
+            1: Sends HEADERS frame that depends on itself
+            2: Sends PRIORITY frame that depend on itself
+
+        5.4. Error Handling
+          5.4.1. Connection Error Handling
+            1: Sends an invalid PING frame for connection close
+
         5.5. Extending HTTP/2
+          1: Sends an unknown extension frame
+          (pending) 2: Sends an unknown extension frame in the middle of a header block
+
+      6. Frame Definitions
         6.1. DATA
+          (pending) 1: Sends a DATA frame with 0x0 stream identifier
+          (pending) 2: Sends a DATA frame on the stream that is not in "open" or "half-closed (local)" state
+          (pending) 3: Sends a DATA frame with invalid pad length
+
         6.2. HEADERS
+          1: Sends a HEADERS frame without the END_HEADERS flag, and a PRIORITY frame
+          2: Sends a HEADERS frame to another stream while sending a HEADERS frame
+          3: Sends a HEADERS frame with 0x0 stream identifier
+          4: Sends a HEADERS frame with invalid pad length
+
         6.3. PRIORITY
+          1: Sends a PRIORITY frame with 0x0 stream identifier
+          2: Sends a PRIORITY frame with a length other than 5 octets
+
         6.4. RST_STREAM
+          1: Sends a RST_STREAM frame with 0x0 stream identifier
+          2: Sends a RST_STREAM frame on a idle stream
+          3: Sends a RST_STREAM frame with a length other than 4 octets
+
         6.5. SETTINGS
+          1: Sends a SETTINGS frame with ACK flag and payload
+          2: Sends a SETTINGS frame with a stream identifier other than 0x0
+          3: Sends a SETTINGS frame with a length other than a multiple of 6 octets
+
           6.5.2. Defined SETTINGS Parameters
+            (pending) 1: SETTINGS_ENABLE_PUSH (0x2): Sends the value other than 0 or 1
+            2: SETTINGS_INITIAL_WINDOW_SIZE (0x4): Sends the value above the maximum flow control window size
+            (pending) 3: SETTINGS_MAX_FRAME_SIZE (0x5): Sends the value below the initial value
+            (pending) 4: SETTINGS_MAX_FRAME_SIZE (0x5): Sends the value above the maximum allowed frame size
+            5: Sends a SETTINGS frame with unknown identifier
+
+          6.5.3. Settings Synchronization
+            1: Sends multiple values of SETTINGS_INITIAL_WINDOW_SIZE
+            2: Sends a SETTINGS frame without ACK flag
+
         6.7. PING
+          1: Sends a PING frame
+          2: Sends a PING frame with ACK
+          3: Sends a PING frame with a stream identifier field value other than 0x0
+          4: Sends a PING frame with a length field value other than 8
+
         6.8. GOAWAY
+          1: Sends a GOAWAY frame with a stream identifier other than 0x0
+
         6.9. WINDOW_UPDATE
-          6.9.1. The Flow Control Window
-          6.9.2. Initial Flow Control Window Size
+          1: Sends a WINDOW_UPDATE frame with a flow control window increment of 0
+          2: Sends a WINDOW_UPDATE frame with a flow control window increment of 0 on a stream
+          (pending) 3: Sends a WINDOW_UPDATE frame with a length other than 4 octets
+
+          6.9.1. The Flow-Control Window
+            1: Sends SETTINGS frame to set the initial window size to 1 and sends HEADERS frame
+            (pending) 2: Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1
+            (pending) 3: Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream
+
+          6.9.2. Initial Flow-Control Window Size
+            1: Changes SETTINGS_INITIAL_WINDOW_SIZE after sending HEADERS frame
+            2: Sends a SETTINGS frame for window size to be negative
+            3: Sends a SETTINGS_INITIAL_WINDOW_SIZE settings with an exceeded maximum window size value
+
         6.10. CONTINUATION
+          1: Sends multiple CONTINUATION frames preceded by a HEADERS frame
+          2: Sends a CONTINUATION frame followed by any frame other than CONTINUATION
+          3: Sends a CONTINUATION frame with 0x0 stream identifier
+          4: Sends a CONTINUATION frame preceded by a HEADERS frame with END_HEADERS flag
+          5: Sends a CONTINUATION frame preceded by a CONTINUATION frame with END_HEADERS flag
+          6: Sends a CONTINUATION frame preceded by a DATA frame
+
+      7. Error Codes
+        1: Sends a GOAWAY frame with unknown error code
+        2: Sends a RST_STREAM frame with unknown error code
+
+      8. HTTP Message Exchanges
         8.1. HTTP Request/Response Exchange
+          1: Sends a second HEADERS frame without the END_STREAM flag
+
           8.1.2. HTTP Header Fields
+            (pending) 1: Sends a HEADERS frame that contains the header field name in uppercase letters
+
             8.1.2.1. Pseudo-Header Fields
+              1: Sends a HEADERS frame that contains a unknown pseudo-header field
+              2: Sends a HEADERS frame that contains the pseudo-header field defined for response
+              3: Sends a HEADERS frame that contains a pseudo-header field as trailers
+              4: Sends a HEADERS frame that contains a pseudo-header field that appears in a header block after a regular header field
+
             8.1.2.2. Connection-Specific Header Fields
+              1: Sends a HEADERS frame that contains the connection-specific header field
+              2: Sends a HEADERS frame that contains the TE header field with any value other than "trailers"
+
             8.1.2.3. Request Pseudo-Header Fields
+              1: Sends a HEADERS frame with empty ":path" pseudo-header field
+              2: Sends a HEADERS frame that omits ":method" pseudo-header field
+              3: Sends a HEADERS frame that omits ":scheme" pseudo-header field
+              4: Sends a HEADERS frame that omits ":path" pseudo-header field
+              5: Sends a HEADERS frame with duplicated ":method" pseudo-header field
+              6: Sends a HEADERS frame with duplicated ":scheme" pseudo-header field
+              7: Sends a HEADERS frame with duplicated ":path" pseudo-header field
+
             8.1.2.6. Malformed Requests and Responses
-        8.2. Server Push
-      """.split("\n").map(_.trim).filterNot(_.isEmpty)
+              (pending) 1: Sends a HEADERS frame with the "content-length" header field which does not equal the DATA frame payload length
+              (pending) 2: Sends a HEADERS frame with the "content-length" header field which does not equal the sum of the multiple DATA frames payload length
+      """
 
-    /** Cases that are known to fail, but we haven't triaged yet */
-    val pendingTestCases = Seq(
-      "4.2",
-      "4.3",
-      "5.1",
-      "5.1.1",
-      "5.1.2",
-      "5.5",
-      "6.1",
-      "6.3",
-      "6.5.2",
-      "6.9",
-      "6.9.1",
-      "6.10",
-      "8.1.2",
-      "8.1.2.1",
-      "8.1.2.2",
-      "8.1.2.6")
+    sealed trait TestElement
+    case class TestGroup(
+        number: String,
+        name: String,
+        elements: Seq[TestElement]) extends TestElement
+    case class TestExample(
+        number: String,
+        name: String,
+        isPending: Boolean) extends TestElement
 
-    /**
-     * Cases that are known to fail because the TCK's expectations are
-     * different from our interpretation of the specs
-     */
-    val disabledTestCases = Seq()
+    def parseTests(desc: String): TestGroup = {
+      val lines =
+        desc.split("\n")
+          .map(_.trim)
+          .filterNot(x => x.isEmpty || x.startsWith("#"))
+
+      val GroupR = """((?:\d+\.)+)\s+(.*)""".r
+      val ExampleR = """(\(pending\)\s+)?(\d+): (.*)""".r
+
+      def parse(lines: Seq[String]): Seq[TestElement] = lines match {
+        case ExampleR(pending, number, name) +: rest =>
+          Seq(TestExample(number, name, pending ne null)) ++ parse(rest)
+        case GroupR(number, name) +: rest =>
+          def isChild(c: String): Boolean = c.startsWith(number) || c.contains(":")
+          // naive O(n^2) implementation, because of unbounded look-ahead
+          val _endOfGroup = rest.indexWhere(!isChild(_))
+          val endOfGroup = if (_endOfGroup == -1) rest.length else _endOfGroup
+          val groupElementLines = rest.take(endOfGroup)
+          val elements = parse(groupElementLines)
+          val group = TestGroup(number.dropRight(1), name, elements)
+          Seq(group) ++ parse(rest.drop(endOfGroup))
+        case Nil => Seq.empty
+      }
+      TestGroup("", "HTTP/2", parse(lines))
+    }
+    val testStructure: TestGroup = parseTests(testCaseDesc)
 
     // execution of tests ------------------------------------------------------------------
-    /*
-    FIXME: don't fail any tests on jenkins for now
-    val runningOnJenkins = System.getenv.containsKey("BUILD_NUMBER")
-
-    if (true) {
-      "pass the entire h2spec, producing junit test report" in {
-        runSpec(junitOutput = new File("target/test-reports/h2spec-junit.xml"))
-      }
-    } else*/
     {
-      val testNamesWithSectionNumbers =
-        testCases.zip(testCases.map(_.trim).filterNot(_.isEmpty)
-          .map(l => l.take(l.lastIndexOf('.'))))
+      def setup(structure: TestGroup): Unit =
+        s"${structure.number} ${structure.name}" - {
+          val examples = structure.elements.collect { case e: TestExample => e }
+          examples.foreach {
+            case TestExample(number, name, isPending) =>
+              val exampleNumber = s"${structure.number}/$number"
+              if (isPending)
+                name ignore {
+                  // no need to run ignored tests, but we might reenable under pendingUntilFixed
+                  // to find out when they are fixed
+                  // runSpec(specSectionNumber = Some(exampleNumber),
+                  //   junitOutput = new File(s"target/test-reports/h2spec-junit-$number.xml"))
+                }
+              else
+                name in {
+                  runSpec(specSectionNumber = Some(exampleNumber),
+                    junitOutput = new File(s"target/test-reports/h2spec-junit-$number.xml"))
+                }
+          }
+          val subgroups = structure.elements.collect { case g: TestGroup => g }
+          subgroups.foreach(setup)
+        }
 
-      testNamesWithSectionNumbers.foreach {
-        case (name, sectionNr) =>
-          if (!disabledTestCases.contains(sectionNr))
-            if (pendingTestCases.contains(sectionNr))
-              s"pass rule: $name" ignore {
-                runSpec(specSectionNumber = Some(sectionNr),
-                  junitOutput = new File(s"target/test-reports/h2spec-junit-$sectionNr.xml"))
-              }
-            else
-              s"pass rule: $name" in {
-                runSpec(specSectionNumber = Some(sectionNr),
-                  junitOutput = new File(s"target/test-reports/h2spec-junit-$sectionNr.xml"))
-              }
-      }
+      setup(testStructure)
     }
     // end of execution of tests -----------------------------------------------------------
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,8 @@ object Dependencies {
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specArtifactExtension = if (h2specExe == "exe") "zip" else "tar.gz"
-  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.$h2specArtifactExtension"
+  val h2specUrl =
+    s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.$h2specArtifactExtension"
 
   val scalaTestVersion = "3.2.14"
   val specs2Version = "4.10.6"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,8 @@ object Dependencies {
   val h2specVersion = "2.6.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
-  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.zip"
+  val h2specArtifactExtension = if (h2specExe == "exe") "zip" else "tar.gz"
+  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.$h2specArtifactExtension"
 
   val scalaTestVersion = "3.2.14"
   val specs2Version = "4.10.6"
@@ -186,8 +187,7 @@ object DependencyHelpers {
   }
 
   def exeIfWindows: String = {
-    val os = System.getProperty("os.name").toLowerCase()
-    if (os.startsWith("win")) ".exe"
+    if (osName.startsWith("win")) ".exe"
     else ""
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   val jacksonDatabindVersion = "2.14.3"
   val jacksonXmlVersion = jacksonDatabindVersion
   val junitVersion = "4.13.2"
-  val h2specVersion = "1.5.0"
+  val h2specVersion = "2.6.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.zip"

--- a/project/Untar.scala
+++ b/project/Untar.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko
+
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
+import org.apache.commons.io.IOUtils
+
+import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream}
+import scala.util.Using
+
+object Untar {
+
+  // extracts files from `.tar.gz` / `.tgz` files
+  def unTarGz(tarFile: File, toDirectory: File): Unit = {
+    Using(new FileInputStream(tarFile)) { tarFileStream =>
+      val buffIn = new BufferedInputStream(tarFileStream)
+      val gzIn = new GzipCompressorInputStream(buffIn)
+      Using(new TarArchiveInputStream(gzIn)) { tis =>
+        toDirectory.mkdirs()
+        var entry = tis.getNextTarEntry
+        while (entry ne null) {
+          val name = entry.getName
+          val outFile = new File(toDirectory, name)
+          Using(new FileOutputStream(outFile)) { fos =>
+            IOUtils.copy(tis, fos)
+          }
+          entry = tis.getNextTarEntry
+        }
+      }
+    }
+  }
+}

--- a/project/Untar.scala
+++ b/project/Untar.scala
@@ -21,7 +21,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.apache.commons.io.IOUtils
 
-import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream}
+import java.io.{ BufferedInputStream, File, FileInputStream, FileOutputStream }
 import scala.util.Using
 
 object Untar {


### PR DESCRIPTION
All test cases were reexported using `h2spec --dryrun` and a new
parser to group and select test cases was introduced.

After all, this way allowed more test cases to be enabled.

Based on and superseding #263
Fixes #262.

Can you check if this version works for you, @lomigmegard (you might have to `clean` in `http2-tests` submodule, to make space for the new `h2spec` binary).