### PR TITLE
Set determineLatestSnapshot to properly resolve latest release

### DIFF
--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -57,7 +57,7 @@ object PekkoDependency {
   val default = pekkoDependency(defaultVersion = minimumExpectedPekkoVersion)
   def docs = default
 
-  lazy val mainSnapshot = Artifact(determineLatestSnapshot("0.0.0"), true)
+  lazy val mainSnapshot = Artifact(determineLatestSnapshot(), true)
 
   val pekkoVersion: String = default match {
     case Artifact(version, _) => version


### PR DESCRIPTION
Updates Pekko to 1.0.1. Also reverts `mainSnapshot` to what the original version should be now that we have a valid Pekko release