### PR TITLE
Make sbt-header work against all Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,8 @@ commands := commands.value.filterNot { command =>
 ThisBuild / reproducibleBuildsCheckResolver :=
   "Apache Pekko Staging".at("https://repository.apache.org/content/groups/staging/")
 
-addCommandAlias("verifyCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; headerCheckAll; javafmtCheckAll")
-addCommandAlias("applyCodeStyle", "headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
+addCommandAlias("verifyCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; +headerCheckAll; javafmtCheckAll")
+addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
 
 inThisBuild(Def.settings(
   apiURL := {


### PR DESCRIPTION
So that it mirros https://github.com/apache/incubator-pekko-http/blob/main/.github/workflows/headers.yml#L29