### PR TITLE
fix snapshot check

### DIFF
--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -99,7 +99,7 @@ object PekkoDependency {
     import scala.concurrent.Await
     import scala.concurrent.duration._
 
-    val snapshotVersionR = """href=".*/((\d+)\.(\d+)\.(\d+)(-(M|RC)(\d+))?\+(\d+)-[0-9a-f]+-SNAPSHOT)/""""".r
+    val snapshotVersionR = """href=".*/((\d+)\.(\d+)\.(\d+)(-(M|RC)(\d+))?\+(\d+)-[0-9a-f]+-SNAPSHOT)/"""".r
 
     // pekko-cluster-sharding-typed_2.13 seems to be the last nightly published by `pekko-publish-nightly` so if that's there then it's likely the rest also made it
     val body = Await.result(http.run(url(
@@ -109,11 +109,12 @@ object PekkoDependency {
     val allVersions =
       snapshotVersionR.findAllMatchIn(body)
         .map {
-          case Groups(full, ep, maj, min, offset) =>
+          case Groups(full, ep, maj, min, _, _, tagNumber, offset) =>
             (
               ep.toInt,
               maj.toInt,
               min.toInt,
+              Option(tagNumber).map(_.toInt),
               offset.toInt) -> full
         }
         .filter(_._2.startsWith(prefix))


### PR DESCRIPTION
problems with #294 
* I added a stray `"` into the regex
* the Group match has to handle 3 extra subgroups that the regex change brings in
  * for `1.1.0-M0+22-4f570ea2-SNAPSHOT`, the 3 extra subgroups are `-M0`, `-M`, `0`
  * if there is no `-M0` (or `-RC0`), the extra subgroups are all null
* the sorting will do for now but it doesn't take into account whether the tag is M or RC and there are other problems
* I did play around with sbt.librarymanagement.VersionNumber but it doesn't have a comparator (or scala.Ordering implementation).
  * I will try this again to see if I can create my own comparator for sbt.librarymanagement.VersionNumber
  * using this PR to get the build working for now
* I have tested these changes on my laptop