### PR TITLE
Use c.abort in macro error cases

### DIFF
--- a/parsing/src/main/scala-2/org/apache/pekko/http/ccompat/pre213macro.scala
+++ b/parsing/src/main/scala-2/org/apache/pekko/http/ccompat/pre213macro.scala
@@ -26,7 +26,7 @@ object pre213macro {
       else
         method
     case _ =>
-      throw new IllegalArgumentException("Please annotate single expressions")
+      c.abort(c.enclosingPosition, "Please annotate single expressions")
   }
 }
 class pre213 extends StaticAnnotation {

--- a/parsing/src/main/scala-2/org/apache/pekko/http/ccompat/since213macro.scala
+++ b/parsing/src/main/scala-2/org/apache/pekko/http/ccompat/since213macro.scala
@@ -26,7 +26,7 @@ object since213macro {
       else
         c.Expr[Nothing](EmptyTree)
     case _ =>
-      throw new IllegalArgumentException("Please annotate single expressions")
+      c.abort(c.enclosingPosition, "Please annotate single expressions")
   }
 }
 class since213 extends StaticAnnotation {


### PR DESCRIPTION
(cherry picked from commit 591a0e6d5bfebcdf28b1f19897a2929d59bc2a1b)