### PR TITLE
Use fetch tags from latest checkout action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,9 +13,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-http'
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: 0
           persist-credentials: false
 
       - name: Check project is formatted

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java 8
         uses: actions/setup-java@v3

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-http'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,9 +18,10 @@ jobs:
         PEKKO_VERSION: [default, main]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up JDK ${{ matrix.JDK }}
         uses: actions/setup-java@v3

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -27,9 +27,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-http'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           ref: 1.0.x
 
       - name: Set up JDK 8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-http'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up JDK 8
         uses: actions/setup-java@v3
@@ -41,9 +42,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-http'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up JDK 8
         uses: actions/setup-java@v3

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -18,7 +18,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-http'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Scala on JDK 8
         uses: actions/setup-java@v3
@@ -60,9 +63,10 @@ jobs:
         JDK: [8, 11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up JDK ${{ matrix.JDK }}
         uses: actions/setup-java@v3


### PR DESCRIPTION
The latest version of the checkout github actions now supports a `fetch-tags` flag which does as described, i.e. it will fetch all of our tags which removes the various workarounds that was used before (i.e. manually running `git fetch` command) etc etc, see https://github.com/actions/checkout/pull/579

This will also help in the erroneous errors that we get in CI, i.e. 

```
[error] Failed to derive version from git tags. Maybe run `git fetch --unshallow` or `git fetch upstream` on a fresh git clone from a fork? Derived version: 0.0.0+1-337943bd-SNAPSHOT`
```