### PR TITLE
allow test with pekko 1.0.x snapshot

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         SCALA_VERSION: [2.12, 2.13, 3]
         JDK: [8, 11, 17, 20]
-        PEKKO_VERSION: [default, main]
+        PEKKO_VERSION: ['default', 'main', '1.0.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -44,6 +44,7 @@ object PekkoDependency {
       case None =>
         Option(System.getProperty("pekko.http.build.pekko.version")) match {
           case Some("main")           => mainSnapshot
+          case Some("snapshot-1.0.x") => snapshot10x
           case Some("default") | None => Artifact(defaultVersion)
           case Some(other)            => Artifact(other, true)
         }
@@ -55,6 +56,7 @@ object PekkoDependency {
   val default = pekkoDependency(defaultVersion = minimumExpectedPekkoVersion)
   def docs = default
 
+  lazy val snapshot10x = Artifact(determineLatestSnapshot("1.0", false), true)
   lazy val mainSnapshot = Artifact(determineLatestSnapshot(), true)
 
   val pekkoVersion: String = default match {
@@ -93,21 +95,22 @@ object PekkoDependency {
       }
   }
 
-  private def determineLatestSnapshot(prefix: String = ""): String = {
+  private def determineLatestSnapshot(prefix: String = "", allowRCVersions: Boolean = true): String = {
     import sbt.librarymanagement.Http.http
     import gigahorse.GigahorseSupport.url
     import scala.concurrent.Await
     import scala.concurrent.duration._
 
-    val snapshotVersionR = """href=".*/((\d+)\.(\d+)\.(\d+)(-(M|RC)(\d+))?\+(\d+)-[0-9a-f]+-SNAPSHOT)/"""".r
+    lazy val snapshotRCVersionR = """href=".*/((\d+)\.(\d+)\.(\d+)(-(M|RC)(\d+))?\+(\d+)-[0-9a-f]+-SNAPSHOT)/"""".r
+    lazy val snapshotVersionR = """href=".*/((\d+)\.(\d+)\.(\d+)\+(\d+)-[0-9a-f]+-SNAPSHOT)/"""".r
 
     // pekko-cluster-sharding-typed_2.13 seems to be the last nightly published by `pekko-publish-nightly` so if that's there then it's likely the rest also made it
     val body = Await.result(http.run(url(
         s"${Resolver.ApacheMavenSnapshotsRepo.root}org/apache/pekko/pekko-cluster-sharding-typed_2.13/")),
       10.seconds).bodyAsString
 
-    val allVersions =
-      snapshotVersionR.findAllMatchIn(body)
+    val allVersions = if (allowRCVersions) {
+      snapshotRCVersionR.findAllMatchIn(body)
         .map {
           case Groups(full, ep, maj, min, _, _, tagNumber, offset) =>
             (
@@ -117,8 +120,21 @@ object PekkoDependency {
               Option(tagNumber).map(_.toInt),
               offset.toInt) -> full
         }
-        .filter(_._2.startsWith(prefix))
-        .toVector.sortBy(_._1)
-    allVersions.last._2
+    } else {
+      snapshotVersionR.findAllMatchIn(body)
+        .map {
+          case Groups(full, ep, maj, min, offset) =>
+            (
+              ep.toInt,
+              maj.toInt,
+              min.toInt,
+              None,
+              offset.toInt) -> full
+        }
+    }
+    allVersions
+      .filter(_._2.startsWith(prefix))
+      .toVector.sortBy(_._1)
+      .last._2
   }
 }

--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -44,7 +44,7 @@ object PekkoDependency {
       case None =>
         Option(System.getProperty("pekko.http.build.pekko.version")) match {
           case Some("main")           => mainSnapshot
-          case Some("snapshot-1.0.x") => snapshot10x
+          case Some("1.0.x")          => snapshot10x
           case Some("default") | None => Artifact(defaultVersion)
           case Some(other)            => Artifact(other, true)
         }

--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -119,8 +119,8 @@ object PekkoDependency {
               Option(tagNumber).map(_.toInt).getOrElse(Integer.MAX_VALUE),
               offset.toInt) -> full
         }
-      .filter(_._2.startsWith(prefix))
-      .toVector.sortBy(_._1)
+        .filter(_._2.startsWith(prefix))
+        .toVector.sortBy(_._1)
 
     allVersions.last._2
   }

--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -108,6 +108,8 @@ object PekkoDependency {
         s"${Resolver.ApacheMavenSnapshotsRepo.root}org/apache/pekko/pekko-cluster-sharding-typed_2.13/")),
       10.seconds).bodyAsString
 
+    // we use tagNumber set as Integer.MAX_VALUE when there is no tagNumber
+    // this ensures that RC and Milistone versions are treated as older than non-RC/non-milestone versions
     val allVersions =
       snapshotVersionR.findAllMatchIn(body)
         .map {


### PR DESCRIPTION
* adjusts the tagNumber logic to treat build numbers without an RC or M tag as newer than ones that have them
* example
```
sbt -Dpekko.http.build.pekko.version=1.0.x package
```