### PR TITLE
no need to cast to ActorMaterializer

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
@@ -24,7 +24,6 @@ import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.Http
 import pekko.macros.LogHelper
-import pekko.stream.ActorMaterializer
 import pekko.stream.Attributes
 import pekko.stream.FlowShape
 import pekko.stream.Inlet

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
@@ -69,7 +69,7 @@ private[http] object PoolInterface {
     import poolId.hcps
     import hcps._
     import setup.{ connectionContext, settings }
-    implicit val system = fm.asInstanceOf[ActorMaterializer].system
+    implicit val system = fm.system
     val log: LoggingAdapter = Logging(system, poolId)(PoolLogSource)
 
     log.debug("Creating pool.")

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
@@ -85,7 +85,7 @@ sealed trait HttpEntity extends jm.HttpEntity {
    */
   def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[HttpEntity.Strict] = {
     import pekko.http.impl.util._
-    val config = fm.asInstanceOf[ActorMaterializer].system.settings.config
+    val config = fm.system.settings.config
     toStrict(timeout, config.getPossiblyInfiniteBytes("pekko.http.parsing.max-to-strict-bytes"))
   }
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/util/PekkoSpecWithMaterializer.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/util/PekkoSpecWithMaterializer.scala
@@ -42,7 +42,7 @@ abstract class PekkoSpecWithMaterializer(configOverrides: String)
       // shutdown materializer first, otherwise it will only be shutdown during
       // main system guardian being shutdown which will be after the logging has
       // reverted to stdout logging that cannot be intercepted
-      materializer.asInstanceOf[ActorMaterializer].shutdown()
+      materializer.shutdown()
       Http().shutdownAllConnectionPools()
       // materializer shutdown is async but cannot be watched
       Thread.sleep(10)

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/util/PekkoSpecWithMaterializer.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/util/PekkoSpecWithMaterializer.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.http.impl.util
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.scaladsl.Http
-import pekko.stream.{ ActorMaterializer, Materializer, SystemMaterializer }
+import pekko.stream.{ Materializer, SystemMaterializer }
 import pekko.testkit.PekkoSpec
 import pekko.testkit.EventFilter
 import com.typesafe.config.ConfigFactory


### PR DESCRIPTION
* these changes were taken from #347 but I don't want to backport all of that
* see also https://github.com/apache/incubator-pekko-http/pull/352
* ActorMaterializer is deprecated and it would be good not to assume all Materializers are ActorMaterializer