### PR TITLE
fix more akka naming

### DIFF
--- a/http-compatibility-tests/src/test/scala/org/apache/pekko/http/scaladsl/HostConnectionPoolCompatSpec.scala
+++ b/http-compatibility-tests/src/test/scala/org/apache/pekko/http/scaladsl/HostConnectionPoolCompatSpec.scala
@@ -14,11 +14,11 @@
 package org.apache.pekko.http.scaladsl
 
 import org.apache.pekko
-import pekko.http.impl.util.AkkaSpecWithMaterializer
+import pekko.http.impl.util.PekkoSpecWithMaterializer
 import pekko.stream.scaladsl.{ Keep, Sink, Source }
 import example.HostConnectionPoolCompat
 
-class HostConnectionPoolCompatSpec extends AkkaSpecWithMaterializer {
+class HostConnectionPoolCompatSpec extends PekkoSpecWithMaterializer {
   "HostConnectionPool" should {
     "be compatible" in {
       val hcp0 =

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolMasterActor.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolMasterActor.scala
@@ -204,7 +204,7 @@ private[http] final class PoolMasterActor extends Actor with ActorLogging {
     // Shutdown all known pools and signal their termination.
     case ShutdownAll(shutdownCompletedPromise) =>
       import context.dispatcher
-      // FIXME: shutdown pools directly without going through message, https://github.com/apache/incubator-pekko-http/issues/3184
+      // FIXME: shutdown pools directly without going through message, https://github.com/akka/akka-http/issues/3184
       Future.traverse(statusById.keys)(thisMaster.shutdown)
         .onComplete(_ => shutdownCompletedPromise.trySuccess(Done))
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/SlotState.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/SlotState.scala
@@ -241,7 +241,7 @@ private[pool] object SlotState {
       Connecting(requestContext)
 
     override def onConnectionAttemptFailed(ctx: SlotContext, cause: Throwable): SlotState = {
-      // TODO: register failed connection attempt to be able to backoff (see https://github.com/apache/incubator-pekko-http/issues/1391)
+      // TODO: register failed connection attempt to be able to backoff (see https://github.com/akka/akka-http/issues/1391)
       onConnectionFailure(ctx, "connection attempt failed", cause)
     }
     override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState =

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/ServerTerminator.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/ServerTerminator.scala
@@ -282,7 +282,7 @@ private[http] final class GracefulTerminatorStage(settings: ServerSettings)
 
       def installTerminationHandlers(deadline: Deadline): Unit = {
         // when no inflight requests, fail stage right away, could probably be a complete
-        // when https://github.com/apache/incubator-pekko-http/issues/3209 is fixed
+        // when https://github.com/akka/akka-http/issues/3209 is fixed
         if (!pendingUserHandlerResponse) failStage(new ServerTerminationDeadlineReached)
 
         setHandler(fromUser,

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
@@ -113,7 +113,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
    * This signal can for example be used to safely terminate the underlying ActorSystem.
    *
    * Note: This mechanism is currently NOT hooked into the Coordinated Shutdown mechanisms of Akka.
-   *       TODO: This feature request is tracked by: https://github.com/apache/incubator-pekko-http/issues/1210
+   *       TODO: This feature request is tracked by: https://github.com/akka/akka-http/issues/1210
    *
    * Note that this signal may be used for Coordinated Shutdown to proceed to next steps in the shutdown.
    * You may also explicitly depend on this completion stage to perform your next shutting down steps.

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -66,7 +66,7 @@ abstract class ConnectionPoolSettings private[pekko] () { self: ConnectionPoolSe
   def withMaxRetries(n: Int): ConnectionPoolSettings
   def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings
 
-  /** Client-side pipelining is not currently supported, see https://github.com/apache/incubator-pekko-http/issues/32 */
+  /** Client-side pipelining is not currently supported, see https://github.com/akka/akka-http/issues/32 */
   def withPipeliningLimit(newValue: Int): ConnectionPoolSettings
   def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings
   def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/model/parser/HttpHeaderSpec.scala
@@ -375,7 +375,7 @@ class HttpHeaderSpec extends AnyFreeSpec with Matchers {
     }
 
     "If-Match dispatching" in {
-      // https://github.com/apache/incubator-pekko-http/issues/443 Check dispatching for "if-match" does not throw "RuleNotFound"
+      // https://github.com/akka/akka-http/issues/443 Check dispatching for "if-match" does not throw "RuleNotFound"
       import scala.util._
       import org.parboiled2.DynamicRuleHandler
       import org.parboiled2.support.hlist.{ ::, HNil }

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/util/PekkoSpecWithMaterializer.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/util/PekkoSpecWithMaterializer.scala
@@ -49,9 +49,9 @@ abstract class PekkoSpecWithMaterializer(configOverrides: String)
     }
 }
 object PekkoSpecWithMaterializer {
-  // adapted version of AkkaSpec.getCallerName that also works for `AkkaSpecWithMaterializer`
+  // adapted version of PekkoSpec.getCallerName that also works for `PekkoSpecWithMaterializer`
   def callerName(): String =
     Thread.currentThread.getStackTrace.map(_.getClassName).drop(1)
-      .dropWhile(_.matches("(java.lang.Thread|.*AkkaSpecWithMaterializer.?$|.*StreamSpec.?$)"))
+      .dropWhile(_.matches("(java.lang.Thread|.*PekkoSpecWithMaterializer.?$|.*StreamSpec.?$)"))
       .head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
 }

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
@@ -651,7 +651,7 @@ abstract class ClientServerSpecBase(http2: Boolean) extends PekkoSpecWithMateria
 
     "complete a request/response when request has `Connection: close` set" in Utils.assertAllStagesStopped {
       // FIXME: There seems to be a potential connection leak here in the ProtocolSwitch stage?
-      // https://github.com/apache/incubator-pekko-http/issues/3963
+      // https://github.com/akka/akka-http/issues/3963
       if (http2) pending
 
       // In akka/akka#19542 / akka/akka-http#459 it was observed that when an akka-http closes the connection after
@@ -705,7 +705,7 @@ abstract class ClientServerSpecBase(http2: Boolean) extends PekkoSpecWithMateria
     "complete a request/response when the request side immediately closes the connection after sending the request" in Utils.assertAllStagesStopped {
       // FIXME: with HTTP/2 enabled the connection is closed directly after receiving closing from client (i.e. half-closed
       // HTTP connections are not allowed (whether they should be is a completely different question))
-      // https://github.com/apache/incubator-pekko-http/issues/3964
+      // https://github.com/akka/akka-http/issues/3964
       if (http2) pending
 
       val (hostname, port) = ("localhost", 8080)
@@ -874,7 +874,7 @@ Host: example.com
       new CloseDelimitedTLSSetup {
         killSwitch.shutdown() // simulate FIN in server -> client direction
         // pekko-http is currently lenient wrt TLS truncation which is *not* reported to the user
-        // FIXME: if https://github.com/apache/incubator-pekko-http/issues/235 is ever fixed, expect an error here
+        // FIXME: if https://github.com/akka/akka-http/issues/235 is ever fixed, expect an error here
         sinkProbe.expectComplete()
       }
     }
@@ -980,7 +980,7 @@ Host: example.com
     }
 
     "produce a useful error message when connecting to a HTTP endpoint over HTTPS" in Utils.assertAllStagesStopped {
-      // FIXME: it would be better if this wouldn't be necessary, see https://github.com/apache/incubator-pekko-http/issues/3159#issuecomment-628605844
+      // FIXME: it would be better if this wouldn't be necessary, see https://github.com/akka/akka-http/issues/3159#issuecomment-628605844
       val settings = ConnectionPoolSettings(system).withUpdatedConnectionSettings(_.withIdleTimeout(100.millis))
       val dummyFlow = Flow[HttpRequest].map(_ => ???)
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/GracefulTerminationSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/GracefulTerminationSpec.scala
@@ -107,7 +107,7 @@ class GracefulTerminationSpec
             val termination = serverBinding.terminate(hardDeadline = 1.second)
             // Right now graceful terminate will immediately kill the connection
             // even if a streamed response is still ongoing
-            // FIXME: https://github.com/apache/incubator-pekko-http/issues/3209
+            // FIXME: https://github.com/akka/akka-http/issues/3209
             eventually {
               responseEntity.expectEvent() shouldBe a[OnError]
             }
@@ -187,7 +187,7 @@ class GracefulTerminationSpec
       ensureServerDeliveredRequest(r1) // we want the request to be in the server user's hands before we cause termination
       serverBinding.terminate(hardDeadline = time)
       // avoid race condition between termination and sending out response
-      // FIXME: https://github.com/apache/incubator-pekko-http/issues/4060
+      // FIXME: https://github.com/akka/akka-http/issues/4060
       Thread.sleep(500)
       reply(_ => HttpResponse(StatusCodes.OK))
 
@@ -202,7 +202,7 @@ class GracefulTerminationSpec
       ensureServerDeliveredRequest(r1) // we want the request to be in the server user's hands before we cause termination
       serverBinding.terminate(hardDeadline = time)
       // avoid race condition between termination and sending out response
-      // FIXME: https://github.com/apache/incubator-pekko-http/issues/4060
+      // FIXME: https://github.com/akka/akka-http/issues/4060
       Thread.sleep(500)
       reply(_ => HttpResponse(StatusCodes.OK))
       r1.futureValue.status should ===(StatusCodes.OK)

--- a/http-core/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
@@ -57,7 +57,7 @@ object PekkoSpec {
 
   def getCallerName(clazz: Class[_]): String = {
     val s = Thread.currentThread.getStackTrace.map(_.getClassName).drop(1)
-      .dropWhile(_.matches("(java.lang.Thread|.*AkkaSpec.?$|.*StreamSpec.?$)"))
+      .dropWhile(_.matches("(java.lang.Thread|.*PekkoSpec.?$|.*StreamSpec.?$)"))
     val reduced = s.lastIndexWhere(_ == clazz.getName) match {
       case -1 => s
       case z  => s.drop(z + 1)

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RoutingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RoutingSpec.scala
@@ -31,7 +31,7 @@ trait GenericRoutingSpec extends Matchers with Directives with ScalatestRouteTes
   def echoComplete2[T, U]: (T, U) => Route = { (x, y) => complete(s"$x $y") }
 }
 
-// FIXME: currently cannot use `PekkoSpec` or `PekkoSpecWithMaterializer`, see https://github.com/apache/incubator-pekko-http/issues/3313
+// FIXME: currently cannot use `PekkoSpec` or `PekkoSpecWithMaterializer`, see https://github.com/akka/akka-http/issues/3313
 abstract class RoutingSpec extends AnyWordSpec with GenericRoutingSpec with WithLogCapturing with TestKitBase
     with ScalaFutures {
   override def testConfigSource: String =

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RoutingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RoutingSpec.scala
@@ -31,7 +31,7 @@ trait GenericRoutingSpec extends Matchers with Directives with ScalatestRouteTes
   def echoComplete2[T, U]: (T, U) => Route = { (x, y) => complete(s"$x $y") }
 }
 
-// FIXME: currently cannot use `AkkaSpec` or `AkkaSpecWithMaterializer`, see https://github.com/apache/incubator-pekko-http/issues/3313
+// FIXME: currently cannot use `PekkoSpec` or `PekkoSpecWithMaterializer`, see https://github.com/apache/incubator-pekko-http/issues/3313
 abstract class RoutingSpec extends AnyWordSpec with GenericRoutingSpec with WithLogCapturing with TestKitBase
     with ScalaFutures {
   override def testConfigSource: String =

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala
@@ -28,7 +28,7 @@ class IllegalHeadersIntegrationSpec extends RoutingSpec {
       complete(s"Accept:${req.header[Accept]}, byName:${req.headers.find(_.is("accept"))}")
     }
 
-    // see: https://github.com/apache/incubator-pekko-http/issues/1072
+    // see: https://github.com/akka/akka-http/issues/1072
     "not StackOverflow but be rejected properly" in {
       val theIllegalHeader = RawHeader("Accept", "*/xml")
       Get().addHeader(theIllegalHeader) ~!> route ~> check {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/Marshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/Marshaller.scala
@@ -115,7 +115,7 @@ object Marshaller {
    *
    * Please note that all passed in marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
-   * however in ticket as discussed in ticket https://github.com/apache/incubator-pekko-http/issues/243 it MAY be
+   * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Pekko HTTP.
    */
   def oneOf[A, B](ms: Marshaller[A, B]*): Marshaller[A, B] = {
@@ -128,7 +128,7 @@ object Marshaller {
    *
    * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
-   * however in ticket as discussed in ticket https://github.com/apache/incubator-pekko-http/issues/243 it MAY be
+   * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Pekko HTTP.
    */
   def oneOf[A, B](m1: Marshaller[A, B], m2: Marshaller[A, B]): Marshaller[A, B] = {
@@ -141,7 +141,7 @@ object Marshaller {
    *
    * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
-   * however in ticket as discussed in ticket https://github.com/apache/incubator-pekko-http/issues/243 it MAY be
+   * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Pekko HTTP.
    */
   def oneOf[A, B](m1: Marshaller[A, B], m2: Marshaller[A, B], m3: Marshaller[A, B]): Marshaller[A, B] = {
@@ -154,7 +154,7 @@ object Marshaller {
    *
    * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
-   * however in ticket as discussed in ticket https://github.com/apache/incubator-pekko-http/issues/243 it MAY be
+   * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Pekko HTTP.
    */
   def oneOf[A, B](
@@ -168,7 +168,7 @@ object Marshaller {
    *
    * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
-   * however in ticket as discussed in ticket https://github.com/apache/incubator-pekko-http/issues/243 it MAY be
+   * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Pekko HTTP.
    */
   def oneOf[A, B](m1: Marshaller[A, B], m2: Marshaller[A, B], m3: Marshaller[A, B], m4: Marshaller[A, B],

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshaller.scala
@@ -116,7 +116,7 @@ object Marshaller
    *
    * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
-   * however in ticket as discussed in ticket https://github.com/apache/incubator-pekko-http/issues/243 it MAY be
+   * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Pekko HTTP.
    */
   def oneOf[A, B](marshallers: Marshaller[A, B]*): Marshaller[A, B] =
@@ -128,7 +128,7 @@ object Marshaller
    *
    * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
-   * however in ticket as discussed in ticket https://github.com/apache/incubator-pekko-http/issues/243 it MAY be
+   * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Pekko HTTP.
    */
   def oneOf[T, A, B](values: T*)(f: T => Marshaller[A, B]): Marshaller[A, B] =

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
@@ -327,7 +327,7 @@ class Http2ClientSpec extends PekkoSpecWithMaterializer("""
         response.entity.contentType should ===(ContentTypes.`application/json`)
 
         // FIXME: contentLength is not reported in all cases with HTTP/2
-        // see https://github.com/apache/incubator-pekko-http/issues/3843
+        // see https://github.com/akka/akka-http/issues/3843
         // response.entity.isIndefiniteLength should ===(false)
         // response.entity.contentLengthOption should ===(Some(2000L))
 

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2PersistentClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2PersistentClientSpec.scala
@@ -58,7 +58,7 @@ class Http2PersistentClientPlaintextSpec extends Http2PersistentClientSpec(false
 
 abstract class Http2PersistentClientSpec(tls: Boolean) extends PekkoSpecWithMaterializer(
       // FIXME: would rather use remote-address-attribute, but that doesn't work with HTTP/2
-      // see https://github.com/apache/incubator-pekko-http/issues/3707
+      // see https://github.com/akka/akka-http/issues/3707
       """pekko.http.server.remote-address-attribute = on
      pekko.http.server.preview.enable-http2 = on
      pekko.http.client.http2.log-frames = on
@@ -72,7 +72,7 @@ abstract class Http2PersistentClientSpec(tls: Boolean) extends PekkoSpecWithMate
   private val notSevere = Set("ChannelReadable", "WriteAck")
   override protected def isSevere(event: Logging.LogEvent): Boolean =
     event.level <= Logging.WarningLevel &&
-    // fix for https://github.com/apache/incubator-pekko-http/issues/3732 / https://github.com/akka/akka/issues/29330
+    // fix for https://github.com/akka/akka-http/issues/3732 / https://github.com/akka/akka/issues/29330
     !notSevere.exists(cand => event.message.toString.contains(cand))
 
   case class RequestId(id: String) extends RequestResponseAssociation

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
@@ -393,7 +393,7 @@ class Http2ServerSpec extends PekkoSpecWithMaterializer("""
 
           receivedRequest.entity.contentType should ===(ContentTypes.`application/json`)
           // FIXME: contentLength is not reported in all cases with HTTP/2
-          // see https://github.com/apache/incubator-pekko-http/issues/3843
+          // see https://github.com/akka/akka-http/issues/3843
           // receivedRequest.entity.isIndefiniteLength should ===(false)
           // receivedRequest.entity.contentLengthOption should ===(Some(1337L))
           entityDataIn.expectBytes(ByteString("x" * 1337))
@@ -418,7 +418,7 @@ class Http2ServerSpec extends PekkoSpecWithMaterializer("""
               // error is not surfaced anywhere
             })
 
-        // Reproducing https://github.com/apache/incubator-pekko-http/issues/2957
+        // Reproducing https://github.com/akka/akka-http/issues/2957
         "close the stream when we receive a RST after we have half-closed ourselves as well".inAssertAllStagesStopped(
           new WaitingForRequestData {
             // Client sends the request, but doesn't close the stream yet. This is a bit weird, but it's what grpcurl does ;)
@@ -821,7 +821,7 @@ class Http2ServerSpec extends PekkoSpecWithMaterializer("""
           network.sendSETTING(Http2Protocol.SettingIdentifier.SETTINGS_INITIAL_WINDOW_SIZE, bytesToSend)
           network.updateFromServerWindows(TheStreamId, _ + missingWindow) // test probe doesn't automatically update window
           network.expectDATA(TheStreamId, false, missingWindow)
-          network.expectSettingsAck() // FIXME: bug: we must send ACK before making use of the new setting, see https://github.com/apache/incubator-pekko-http/issues/3553
+          network.expectSettingsAck() // FIXME: bug: we must send ACK before making use of the new setting, see https://github.com/akka/akka-http/issues/3553
 
           entityDataOut.sendComplete()
           network.expectDATA(TheStreamId, true, 0)

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/RequestParsingSpec.scala
@@ -536,7 +536,7 @@ class RequestParsingSpec extends PekkoSpecWithMaterializer with Inside with Insp
         inside(request.entity) {
           case entity: HttpEntity =>
             // FIXME: contentLength is not reported in all cases with HTTP/2
-            // see https://github.com/apache/incubator-pekko-http/issues/3843
+            // see https://github.com/akka/akka-http/issues/3843
             // entity.contentLength should ===(123.toLong)
             entity.contentType should ===(ContentType(MediaTypes.`image/jpeg`))
         }


### PR DESCRIPTION
* raised https://github.com/apache/incubator-pekko-http/issues/355 for follow up
* some issue links were incorrectly updated to point to pekko-http issues but the pekko links don't work