### PR TITLE
Fix compilation errors found in Scala3 Open Community Build

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
@@ -373,7 +373,7 @@ final class HttpRequest(
   /**
    * All cookies provided by the client in one or more `Cookie` headers.
    */
-  def cookies: immutable.Seq[HttpCookiePair] = for (`Cookie`(cookies) <- headers; cookie <- cookies) yield cookie
+  def cookies: immutable.Seq[HttpCookiePair] = for (case `Cookie`(cookies) <- headers; cookie <- cookies) yield cookie
 
   /**
    * Determines whether this request can be safely retried, which is the case only of the request method is idempotent.

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/NewConnectionPoolSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/NewConnectionPoolSpec.scala
@@ -554,7 +554,8 @@ class NewConnectionPoolSpec extends PekkoSpecWithMaterializer("""
       }
 
       val requestSourceQueuePromise = Promise[SourceQueueWithComplete[_]]()
-      val requestSource = Source.queue(8, OverflowStrategy.fail).mapMaterializedValue(requestSourceQueuePromise.success)
+      val requestSource = Source.queue[HttpEntity.ChunkStreamPart](8, OverflowStrategy.fail)
+        .mapMaterializedValue(requestSourceQueuePromise.success)
       val slowRequestEntity = Chunked(ContentTypes.`text/plain(UTF-8)`, requestSource)
       val request =
         HttpRequest(uri = s"http://$serverHostName:$serverPort/abc?query#fragment", entity = slowRequestEntity)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ContentNegotation.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ContentNegotation.scala
@@ -29,7 +29,7 @@ final class MediaTypeNegotiator(requestHeaders: Seq[HttpHeader]) {
    */
   val acceptedMediaRanges: List[MediaRange] =
     (for {
-      Accept(mediaRanges) <- requestHeaders
+      case Accept(mediaRanges) <- requestHeaders
       range <- mediaRanges
     } yield range).sortBy { // `sortBy` is stable, i.e. upholds the original order on identical weights
       case x if x.isWildcard   => (2, -x.params.size, -x.qValue)
@@ -63,7 +63,7 @@ final class CharsetNegotiator(requestHeaders: Seq[HttpHeader]) {
    */
   val acceptedCharsetRanges: List[HttpCharsetRange] =
     (for {
-      `Accept-Charset`(charsetRanges) <- requestHeaders
+      case `Accept-Charset`(charsetRanges) <- requestHeaders
       range <- charsetRanges
     } yield range).sortBy { // `sortBy` is stable, i.e. upholds the original order on identical keys
       case _: HttpCharsetRange.`*` => 1f // most general, needs to come last
@@ -171,7 +171,7 @@ final class EncodingNegotiator(requestHeaders: Seq[HttpHeader]) {
    */
   val acceptedEncodingRanges: List[HttpEncodingRange] =
     (for {
-      `Accept-Encoding`(encodingRanges) <- requestHeaders
+      case `Accept-Encoding`(encodingRanges) <- requestHeaders
       range <- encodingRanges
     } yield range).sortBy { // `sortBy` is stable, i.e. upholds the original order on identical keys
       case _: HttpEncodingRange.`*` => 1f // most general, needs to come last
@@ -230,7 +230,7 @@ final class LanguageNegotiator(requestHeaders: Seq[HttpHeader]) {
    */
   val acceptedLanguageRanges: List[LanguageRange] =
     (for {
-      `Accept-Language`(languageRanges) <- requestHeaders
+      case `Accept-Language`(languageRanges) <- requestHeaders
       range <- languageRanges
     } yield range).sortBy { // `sortBy` is stable, i.e. upholds the original order on identical keys
       case _: LanguageRange.`*` => 1f // most general, needs to come last


### PR DESCRIPTION
This PR fixes some of the compilation errors found in the Open Community Build for the nightly versions of Scala 3.4.x. 
It would allow the Scala compiler team to track any new regressions found in this project.