### PR TITLE
pekko-http-jackson: upgrade jackson to 2.16

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -14,8 +14,8 @@ updates.ignore = [
 
 updates.pin = [
   # pin to jackson version used in pekko-core 
-  { groupId = "com.fasterxml.jackson.core", version = "2.14." },
-  { groupId = "com.fasterxml.jackson.dataformat", version = "2.14." },
+  { groupId = "com.fasterxml.jackson.core", version = "2.16." },
+  { groupId = "com.fasterxml.jackson.dataformat", version = "2.16." },
   # https://github.com/akka/akka-http/pull/3995#issuecomment-1009951997
   { groupId = "org.scala-lang.modules", artifactId = "scala-xml", version = "1." },
   # https://github.com/akka/akka-http/pull/3996#issuecomment-1009953070

--- a/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
+++ b/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
@@ -94,17 +94,20 @@ public class Jackson {
 
   private static ObjectMapper createMapper() {
     Config config = ConfigFactory.load().getConfig("pekko.http.jackson");
-    StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder()
+    StreamReadConstraints streamReadConstraints =
+        StreamReadConstraints.builder()
             .maxNestingDepth(config.getInt("read.max-nesting-depth"))
             .maxNumberLength(config.getInt("read.max-number-length"))
             .maxStringLength(config.getInt("read.max-string-length"))
             .maxNameLength(config.getInt("read.max-name-length"))
             .maxDocumentLength(config.getLong("read.max-document-length"))
             .build();
-    StreamWriteConstraints streamWriteConstraints = StreamWriteConstraints.builder()
+    StreamWriteConstraints streamWriteConstraints =
+        StreamWriteConstraints.builder()
             .maxNestingDepth(config.getInt("write.max-nesting-depth"))
             .build();
-    JsonFactory jsonFactory = JsonFactory.builder()
+    JsonFactory jsonFactory =
+        JsonFactory.builder()
             .streamReadConstraints(streamReadConstraints)
             .streamWriteConstraints(streamWriteConstraints)
             .build();

--- a/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
+++ b/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class Jackson {
   private static final ObjectMapper defaultObjectMapper =
-      new ObjectMapper().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
+      createMapper().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
 
   /** INTERNAL API */
   public static class JacksonUnmarshallingException extends ExceptionWithErrorInfo {
@@ -90,6 +90,10 @@ public class Jackson {
     } catch (IOException e) {
       throw new JacksonUnmarshallingException(expectedType, e);
     }
+  }
+
+  private static ObjectMapper createMapper() {
+    return createMapper(ConfigFactory.load().getConfig("pekko.http.jackson"));
   }
 
   static ObjectMapper createMapper(final Config config) {

--- a/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
+++ b/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
@@ -93,7 +93,7 @@ public class Jackson {
   }
 
   private static ObjectMapper createMapper() {
-    return createMapper(ConfigFactory.load().getConfig("pekko.http.jackson"));
+    return createMapper(ConfigFactory.load().getConfig("pekko.http.marshallers.jackson"));
   }
 
   static ObjectMapper createMapper(final Config config) {

--- a/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
+++ b/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
@@ -92,8 +92,7 @@ public class Jackson {
     }
   }
 
-  private static ObjectMapper createMapper() {
-    Config config = ConfigFactory.load().getConfig("pekko.http.jackson");
+  static ObjectMapper createMapper(final Config config) {
     StreamReadConstraints streamReadConstraints =
         StreamReadConstraints.builder()
             .maxNestingDepth(config.getInt("read.max-nesting-depth"))

--- a/http-marshallers-java/http-jackson/src/main/resources/reference.conf
+++ b/http-marshallers-java/http-jackson/src/main/resources/reference.conf
@@ -7,7 +7,7 @@
 # This is the reference config file that contains all the default settings.
 # Make your edits/overrides in your application.conf.
 
-pekko.http.jackson {
+pekko.http.marshallers.jackson {
   read {
     # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.1/com/fasterxml/jackson/core/StreamReadConstraints.html
     # these defaults are the same as the defaults in `StreamReadConstraints`
@@ -18,6 +18,7 @@ pekko.http.jackson {
     # max-document-length of -1 means unlimited
     max-document-length = -1
   }
+
   write {
     # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.1/com/fasterxml/jackson/core/StreamWriteConstraints.html
     # these defaults are the same as the defaults in `StreamWriteConstraints`

--- a/http-marshallers-java/http-jackson/src/main/resources/reference.conf
+++ b/http-marshallers-java/http-jackson/src/main/resources/reference.conf
@@ -9,7 +9,7 @@
 
 pekko.http.jackson {
   read {
-    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.0/com/fasterxml/jackson/core/StreamReadConstraints.html
+    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.1/com/fasterxml/jackson/core/StreamReadConstraints.html
     # these defaults are the same as the defaults in `StreamReadConstraints`
     max-nesting-depth = 1000
     max-number-length = 1000
@@ -19,7 +19,7 @@ pekko.http.jackson {
     max-document-length = -1
   }
   write {
-    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.0/com/fasterxml/jackson/core/StreamWriteConstraints.html
+    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.1/com/fasterxml/jackson/core/StreamWriteConstraints.html
     # these defaults are the same as the defaults in `StreamWriteConstraints`
     max-nesting-depth = 1000
   }

--- a/http-marshallers-java/http-jackson/src/main/resources/reference.conf
+++ b/http-marshallers-java/http-jackson/src/main/resources/reference.conf
@@ -15,8 +15,8 @@ pekko.http.jackson {
     max-number-length = 1000
     max-string-length = 20000000
     max-name-length = 50000
-    # max-document-length of 0 means unlimited
-    max-document-length = 0
+    # max-document-length of -1 means unlimited
+    max-document-length = -1
   }
   write {
     # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.0/com/fasterxml/jackson/core/StreamWriteConstraints.html

--- a/http-marshallers-java/http-jackson/src/main/resources/reference.conf
+++ b/http-marshallers-java/http-jackson/src/main/resources/reference.conf
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+##################################
+# Pekko HTTP Jackson Config File #
+##################################
+
+# This is the reference config file that contains all the default settings.
+# Make your edits/overrides in your application.conf.
+
+pekko.http.jackson {
+  read {
+    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.0/com/fasterxml/jackson/core/StreamReadConstraints.html
+    # these defaults are the same as the defaults in `StreamReadConstraints`
+    max-nesting-depth = 1000
+    max-number-length = 1000
+    max-string-length = 20000000
+    max-name-length = 50000
+    # max-document-length of 0 means unlimited
+    max-document-length = 0
+  }
+  write {
+    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.0/com/fasterxml/jackson/core/StreamWriteConstraints.html
+    # these defaults are the same as the defaults in `StreamWriteConstraints`
+    max-nesting-depth = 1000
+  }
+}

--- a/http-marshallers-java/http-jackson/src/test/java/org/apache/pekko/http/javadsl/marshallers/jackson/JacksonTest.java
+++ b/http-marshallers-java/http-jackson/src/test/java/org/apache/pekko/http/javadsl/marshallers/jackson/JacksonTest.java
@@ -109,7 +109,7 @@ public class JacksonTest extends JUnitRouteTest {
             + maxNestingDepth;
     Config config =
         ConfigFactory.parseString(configText)
-            .withFallback(ConfigFactory.load().getConfig("pekko.http.jackson"));
+            .withFallback(ConfigFactory.load().getConfig("pekko.http.marshallers.jackson"));
     ObjectMapper mapper = Jackson.createMapper(config);
     StreamReadConstraints constraints = mapper.getFactory().streamReadConstraints();
     assertEquals(maxNumLen, constraints.getMaxNumberLength());
@@ -125,7 +125,7 @@ public class JacksonTest extends JUnitRouteTest {
     String configText = "write.max-nesting-depth=" + maxNestingDepth;
     Config config =
         ConfigFactory.parseString(configText)
-            .withFallback(ConfigFactory.load().getConfig("pekko.http.jackson"));
+            .withFallback(ConfigFactory.load().getConfig("pekko.http.marshallers.jackson"));
     ObjectMapper mapper = Jackson.createMapper(config);
     StreamWriteConstraints constraints = mapper.getFactory().streamWriteConstraints();
     assertEquals(maxNestingDepth, constraints.getMaxNestingDepth());

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ import scala.language.implicitConversions
 object Dependencies {
   import DependencyHelpers._
 
-  val jacksonDatabindVersion = "2.16.0"
+  val jacksonDatabindVersion = "2.16.1"
   val jacksonXmlVersion = jacksonDatabindVersion
   val junitVersion = "4.13.2"
   val h2specVersion = "2.6.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ import scala.language.implicitConversions
 object Dependencies {
   import DependencyHelpers._
 
-  val jacksonDatabindVersion = "2.14.3"
+  val jacksonDatabindVersion = "2.16.0"
   val jacksonXmlVersion = jacksonDatabindVersion
   val junitVersion = "4.13.2"
   val h2specVersion = "2.6.0"


### PR DESCRIPTION
add config support for setting read and write constraints