### PR TITLE
standardise on specs 4.20

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,13 +78,7 @@ object Dependencies {
     object Test {
       val sprayJson = Compile.sprayJson % "test"
       val junit = Compile.junit % "test"
-      val specs2 = {
-        val specs2 = "org.specs2" %% "specs2-core"
-        ScalaVersionDependentModuleID.versioned {
-          case v if v.startsWith("2.") => specs2 % "4.10.6"
-          case _                       => specs2 % "4.15.0"
-        }
-      }
+      val specs2 = "org.specs2" %% "specs2-core" % "4.20.3"
 
       val scalacheck = "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test"
       val junitIntf = "com.github.sbt" % "junit-interface" % "0.13.3" % "test"


### PR DESCRIPTION
https://mvnrepository.com/artifact/org.specs2/specs2-core

* most recent 4.x release
* simplifies the build - avoids having different versions depending on scala version