### PR TITLE
Make .splitWhen explicit with SubstreamCancelStrategy.drain

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/WebSocket.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/WebSocket.scala
@@ -177,7 +177,7 @@ private[http] object WebSocket {
     def prepareMessages: Flow[MessagePart, Message, NotUsed] =
       Flow[MessagePart]
         .via(PrepareForUserHandler)
-        .splitAfter(_.isMessageEnd)
+        .splitAfter(SubstreamCancelStrategy.drain)(_.isMessageEnd)
         .collect {
           case m: MessageDataPart => m
         }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
@@ -24,7 +24,7 @@ import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.settings.ParserSettings
 import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import pekko.http.scaladsl.util.FastFuture
-import pekko.stream.ActorMaterializerHelper
+import pekko.stream.{ ActorMaterializerHelper, SubstreamCancelStrategy }
 import pekko.stream.scaladsl._
 
 import scala.collection.immutable
@@ -118,7 +118,7 @@ trait MultipartUnmarshallers {
               case _ =>
                 val bodyParts = entity.dataBytes
                   .via(parser)
-                  .splitWhen(_.isInstanceOf[PartStart])
+                  .splitWhen(SubstreamCancelStrategy.drain)(_.isInstanceOf[PartStart])
                   .prefixAndTail(1)
                   .collect {
                     case (Seq(BodyPartStart(headers, createEntity)), entityParts) =>


### PR DESCRIPTION
The context of this change is https://github.com/apache/incubator-pekko/pull/252. I want to try and get that PR over the finish line for Pekko 1.1.0 and while that PR is not a binary breaking change it is a behaviour breaking change.

What this PR does is it makes any usage of `splitWhen` explicitly use `SubstreamCancelStrategy.drain` (which is the current default) so that if someone uses pekko-http with a future release of pekko 1.1.0 there won't be any behaviour change. Note that I am not entirely sure if this change makes sense or even if its necessary i.e. it may be the case that whatever `SubstreamCancelStrategy` you use it doesn't matter because the various `SubFlow`'s cannot error (in which case this PR is pointless and can be closed) or it could also be that we really should be explicit about which `SubstreamCancelStrategy` to use for correctness reasons (i.e. if hypothetically an error in a `SubFlow` can occur then it should always be either `SubstreamCancelStrategy.drain` or `SubstreamCancelStrategy.propagate`)

@jrudolph @raboof @kerr Pinging you here since you have most of the domain knowledge.