### PR TITLE
Update Scala to 3.3.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
 
   val scala212Version = "2.12.18"
   val scala213Version = "2.13.12"
-  val scala3Version = "3.3.1"
+  val scala3Version = "3.3.2-RC1"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val Versions = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
 
   val scala212Version = "2.12.18"
   val scala213Version = "2.13.12"
-  val scala3Version = "3.3.2-RC1"
+  val scala3Version = "3.3.2-RC2"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val Versions = Seq(


### PR DESCRIPTION
Scala 3.3.2-RC1 just came out so this PR is testing it out to see if the codebase compiles. It will remain in draft until full release of Scala 3.3.2 is out.