### PR TITLE
build with pekko 1.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,7 @@
 
 import ValidatePullRequest._
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
-import com.github.pjfanning.pekkobuild.PekkoDependency
-import PekkoDependency._
+import com.github.pjfanning.pekkobuild._
 import Dependencies.{ h2specExe, h2specName }
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import java.nio.file.Files

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -45,7 +45,7 @@ object VersionGenerator {
 
   def generateVersion(dir: SettingKey[File], locate: File => File, template: String) = Def.task[Seq[File]] {
     val file = locate(dir.value)
-    val content = template.stripMargin.format(version.value, PekkoDependency.pekkoVersion)
+    val content = template.stripMargin.format(version.value, PekkoDependency.minPekkoVersion)
     if (!file.exists || IO.read(file) != content) IO.write(file, content)
     Seq(file)
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -39,7 +39,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.11")
-addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.1.0")
+addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.2.0")
 addSbtPlugin("net.virtual-void" % "sbt-hackers-digest" % "0.1.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 


### PR DESCRIPTION
relates to #380 

* sbt-pekko-build 0.2.0 uses pekko 1.0.2 as the default
* VersionGenerator uses a minPekkoVersion value that is set to 1.0.0
  * this means that the validation mentioned in #380 will allow all versions from Pekko 1.0.0 and up 