### PR TITLE
Replace ExecutionContexts.sameThreadExecutionContext with parasitic

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolMasterActor.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolMasterActor.scala
@@ -191,7 +191,7 @@ private[http] final class PoolMasterActor extends Actor with ActorLogging {
           // has completed.
           val completed = pool.shutdown()(context.dispatcher)
           shutdownCompletedPromise.tryCompleteWith(
-            completed.map(_ => Done)(ExecutionContexts.sameThreadExecutionContext))
+            completed.map(_ => Done)(ExecutionContexts.parasitic))
           statusById += poolId -> PoolInterfaceShuttingDown(shutdownCompletedPromise)
         case Some(PoolInterfaceShuttingDown(formerPromise)) =>
           // Pool is already shutting down, mirror the existing promise.

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -469,7 +469,7 @@ private[client] object NewHostConnectionPool {
                   entityComplete.onComplete(safely {
                     case Success(_)     => withSlot(_.onRequestEntityCompleted())
                     case Failure(cause) => withSlot(_.onRequestEntityFailed(cause))
-                  })(ExecutionContexts.sameThreadExecutionContext)
+                  })(ExecutionContexts.parasitic)
                   request.withEntity(newEntity)
               }
 
@@ -524,9 +524,9 @@ private[client] object NewHostConnectionPool {
                       ongoingResponseEntity = None
                       ongoingResponseEntityKillSwitch = None
                     }
-                  }(ExecutionContexts.sameThreadExecutionContext)
+                  }(ExecutionContexts.parasitic)
                 case Failure(_) => throw new IllegalStateException("Should never fail")
-              })(ExecutionContexts.sameThreadExecutionContext)
+              })(ExecutionContexts.parasitic)
 
               withSlot(_.onResponseReceived(response.withEntity(newEntity)))
             }
@@ -609,7 +609,7 @@ private[client] object NewHostConnectionPool {
                 onConnectionAttemptFailed(currentEmbargoLevel)
                 sl.onConnectionAttemptFailed(cause)
               }
-          })(ExecutionContexts.sameThreadExecutionContext)
+          })(ExecutionContexts.parasitic)
 
           slotCon
         }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
@@ -125,7 +125,7 @@ private[http] final class Http2Ext(implicit val system: ActorSystem)
                 // See https://github.com/akka/akka/issues/17992
                 case NonFatal(ex) =>
                   Done
-              }(ExecutionContexts.sameThreadExecutionContext)
+              }(ExecutionContexts.parasitic)
           } catch {
             case NonFatal(e) =>
               log.error(e, "Could not materialize handling flow for {}", incoming)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
@@ -503,7 +503,7 @@ private[http] object HttpServerBluePrint {
                       log.error(ex,
                         s"Response stream for [${requestStart.debugString}] failed with '${ex.getMessage}'. Aborting connection.")
                     case _ => // ignore
-                  }(ExecutionContexts.sameThreadExecutionContext)
+                  }(ExecutionContexts.parasitic)
                   newEntity
                 }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -89,7 +89,7 @@ private[http] object StreamUtils {
             killResult.future.value match {
               case Some(res) => handleKill(res)
               case None =>
-                killResult.future.onComplete(killCallback.invoke)(ExecutionContexts.sameThreadExecutionContext)
+                killResult.future.onComplete(killCallback.invoke)(ExecutionContexts.parasitic)
             }
           }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -47,7 +47,7 @@ object Http extends ExtensionId[Http] with ExtensionIdProvider {
 }
 
 class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
-  import pekko.dispatch.ExecutionContexts.{ sameThreadExecutionContext => ec }
+  import pekko.dispatch.ExecutionContexts.{ parasitic => ec }
 
   import language.implicitConversions
   private implicit def completionStageCovariant[T, U >: T](in: CompletionStage[T]): CompletionStage[U] =

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
@@ -89,7 +89,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
 
   def terminate(hardDeadline: java.time.Duration): CompletionStage[HttpTerminated] = {
     delegate.terminate(FiniteDuration.apply(hardDeadline.toMillis, TimeUnit.MILLISECONDS))
-      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.sameThreadExecutionContext)
+      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.parasitic)
       .asJava
   }
 
@@ -103,7 +103,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
    */
   def whenTerminationSignalIssued: CompletionStage[java.time.Duration] =
     delegate.whenTerminationSignalIssued
-      .map(deadline => deadline.time.asJava)(ExecutionContexts.sameThreadExecutionContext)
+      .map(deadline => deadline.time.asJava)(ExecutionContexts.parasitic)
       .asJava
 
   /**
@@ -120,7 +120,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
    */
   def whenTerminated: CompletionStage[HttpTerminated] =
     delegate.whenTerminated
-      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.sameThreadExecutionContext)
+      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.parasitic)
       .asJava
 
   /**

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
@@ -195,6 +195,6 @@ object ServerBuilder {
     def connectionSource(): Source[IncomingConnection, CompletionStage[ServerBinding]] =
       http.bindImpl(interface, port, context.asScala, settings.asScala, log)
         .map(new IncomingConnection(_))
-        .mapMaterializedValue(_.map(new ServerBinding(_))(ExecutionContexts.sameThreadExecutionContext).asJava).asJava
+        .mapMaterializedValue(_.map(new ServerBinding(_))(ExecutionContexts.parasitic).asJava).asJava
   }
 }

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketIntegrationSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketIntegrationSpec.scala
@@ -100,7 +100,7 @@ class WebSocketIntegrationSpec extends PekkoSpecWithMaterializer(
 
               override def preStart(): Unit = {
                 promise.future.foreach(_ => getAsyncCallback[Done](_ => complete(shape.out)).invoke(Done))(
-                  pekko.dispatch.ExecutionContexts.sameThreadExecutionContext)
+                  pekko.dispatch.ExecutionContexts.parasitic)
               }
 
               setHandlers(shape.in, shape.out, this)

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RequestContext.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RequestContext.scala
@@ -60,18 +60,18 @@ class RequestContext private (val delegate: scaladsl.server.RequestContext) {
 
   def complete[T](value: T, marshaller: Marshaller[T, HttpResponse]): CompletionStage[RouteResult] = {
     delegate.complete(ToResponseMarshallable(value)(marshaller))
-      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).asJava
+      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.parasitic).asJava
   }
 
   def completeWith(response: HttpResponse): CompletionStage[RouteResult] = {
     delegate.complete(response.asScala)
-      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).asJava
+      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.parasitic).asJava
   }
 
   @varargs def reject(rejections: Rejection*): CompletionStage[RouteResult] = {
     val scalaRejections = rejections.map(_.asScala)
     delegate.reject(scalaRejections: _*)
-      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).asJava
+      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.parasitic).asJava
   }
 
   def redirect(uri: Uri, redirectionType: StatusCode): CompletionStage[RouteResult] = {
@@ -80,7 +80,7 @@ class RequestContext private (val delegate: scaladsl.server.RequestContext) {
 
   def fail(error: Throwable): CompletionStage[RouteResult] =
     delegate.fail(error)
-      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.sameThreadExecutionContext).asJava
+      .fast.map(r => r: RouteResult)(pekko.dispatch.ExecutionContexts.parasitic).asJava
 
   def withRequest(req: HttpRequest): RequestContext = wrap(delegate.withRequest(req.asScala))
   def withExecutionContext(ec: ExecutionContextExecutor): RequestContext = wrap(delegate.withExecutionContext(ec))

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
@@ -99,8 +99,8 @@ abstract class BasicDirectives {
       inner: Supplier[Route]): Route = RouteAdapter {
     D.mapRouteResultFuture(stage =>
       FutureConverters.asScala(
-        f(stage.fast.map(_.asJava)(ExecutionContexts.sameThreadExecutionContext).asJava)).fast.map(_.asScala)(
-        ExecutionContexts.sameThreadExecutionContext)) {
+        f(stage.fast.map(_.asJava)(ExecutionContexts.parasitic).asJava)).fast.map(_.asScala)(
+        ExecutionContexts.parasitic)) {
       inner.get.delegate
     }
   }
@@ -108,7 +108,7 @@ abstract class BasicDirectives {
   def mapRouteResultWith(f: JFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route =
     RouteAdapter {
       D.mapRouteResultWith(r =>
-        FutureConverters.asScala(f(r.asJava)).fast.map(_.asScala)(ExecutionContexts.sameThreadExecutionContext)) {
+        FutureConverters.asScala(f(r.asJava)).fast.map(_.asScala)(ExecutionContexts.parasitic)) {
         inner.get.delegate
       }
     }
@@ -116,7 +116,7 @@ abstract class BasicDirectives {
   def mapRouteResultWithPF(
       f: PartialFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
     D.mapRouteResultWith(r =>
-      FutureConverters.asScala(f(r.asJava)).fast.map(_.asScala)(ExecutionContexts.sameThreadExecutionContext)) {
+      FutureConverters.asScala(f(r.asJava)).fast.map(_.asScala)(ExecutionContexts.parasitic)) {
       inner.get.delegate
     }
   }
@@ -175,7 +175,7 @@ abstract class BasicDirectives {
       f: JFunction[JIterable[Rejection], CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
     D.recoverRejectionsWith(rs =>
       FutureConverters.asScala(f.apply(Util.javaArrayList(rs.map(_.asJava)))).fast.map(_.asScala)(
-        ExecutionContexts.sameThreadExecutionContext)) { inner.get.delegate }
+        ExecutionContexts.parasitic)) { inner.get.delegate }
   }
 
   /**

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteDirectives.scala
@@ -46,7 +46,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
   import RoutingJavaMapping.Implicits._
 
   // Don't try this at home – we only use it here for the java -> scala conversions
-  private implicit val conversionExecutionContext: ExecutionContext = ExecutionContexts.sameThreadExecutionContext
+  private implicit val conversionExecutionContext: ExecutionContext = ExecutionContexts.parasitic
 
   /**
    * Java-specific call added so you can chain together multiple alternate routes using comma,


### PR DESCRIPTION
`ExecutionContexts.sameThreadExecutionContext` is deprecated and `ExecutionContexts.parasitic` should be used instead (one is an alias for the other).