### PR TITLE
Use designated Scala methods for converter utils

### DIFF
--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
@@ -99,7 +99,7 @@ private[http] object RoutingJavaMapping {
   //  val javaToScalaResponseEntity extends Inherited[javadsl.model.ResponseEntity, scaladsl.model.ResponseEntity]
 
   implicit final class ConvertCompletionStage[T](val stage: CompletionStage[T]) extends AnyVal {
-    import pekko.util.FutureConverters
-    def asScala = FutureConverters.asScala(stage)
+    import pekko.util.FutureConverters._
+    def asScala = CompletionStageOps(stage).asScala
   }
 }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
@@ -48,7 +48,6 @@ import java.util.function.Predicate
 import pekko.dispatch.ExecutionContexts
 import pekko.event.LoggingAdapter
 import pekko.http.javadsl.server
-import pekko.util.FutureConverters
 import pekko.util.FutureConverters._
 
 import scala.concurrent.duration.FiniteDuration
@@ -98,8 +97,8 @@ abstract class BasicDirectives {
   def mapRouteResultFuture(f: JFunction[CompletionStage[RouteResult], CompletionStage[RouteResult]],
       inner: Supplier[Route]): Route = RouteAdapter {
     D.mapRouteResultFuture(stage =>
-      FutureConverters.asScala(
-        f(stage.fast.map(_.asJava)(ExecutionContexts.parasitic).asJava)).fast.map(_.asScala)(
+      CompletionStageOps(
+        f(stage.fast.map(_.asJava)(ExecutionContexts.parasitic).asJava)).asScala.fast.map(_.asScala)(
         ExecutionContexts.parasitic)) {
       inner.get.delegate
     }
@@ -108,7 +107,7 @@ abstract class BasicDirectives {
   def mapRouteResultWith(f: JFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route =
     RouteAdapter {
       D.mapRouteResultWith(r =>
-        FutureConverters.asScala(f(r.asJava)).fast.map(_.asScala)(ExecutionContexts.parasitic)) {
+        CompletionStageOps(f(r.asJava)).asScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) {
         inner.get.delegate
       }
     }
@@ -116,7 +115,7 @@ abstract class BasicDirectives {
   def mapRouteResultWithPF(
       f: PartialFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
     D.mapRouteResultWith(r =>
-      FutureConverters.asScala(f(r.asJava)).fast.map(_.asScala)(ExecutionContexts.parasitic)) {
+      CompletionStageOps(f(r.asJava)).asScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) {
       inner.get.delegate
     }
   }
@@ -174,7 +173,7 @@ abstract class BasicDirectives {
   def recoverRejectionsWith(
       f: JFunction[JIterable[Rejection], CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
     D.recoverRejectionsWith(rs =>
-      FutureConverters.asScala(f.apply(Util.javaArrayList(rs.map(_.asJava)))).fast.map(_.asScala)(
+      CompletionStageOps(f.apply(Util.javaArrayList(rs.map(_.asJava)))).asScala.fast.map(_.asScala)(
         ExecutionContexts.parasitic)) { inner.get.delegate }
   }
 


### PR DESCRIPTION
This PR is a response to https://github.com/apache/incubator-pekko/pull/894, specifically rather than using the Java designed converter methods within Scala sources we use the Scala ones so that when the project is compiled with Scala 3 it gets inlined.

Note that in the case of `BasicDirectives`, the reason why pekko-http was using the designated Java methods in the first place is due to ambiguous implicit imports which is why `CompletionStageOps` is being used rather than the typical use of extension methods within `implicit class`.