### PR TITLE
use ByteString.toArrayUnsafe where it is safe to do so and improves performance

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
@@ -28,7 +28,7 @@ private[http2] object ByteStringInputStream {
     bs match {
       case cs: ByteString1C =>
         // TODO optimise, ByteString needs to expose InputStream (esp if array backed, nice!)
-        new ByteArrayInputStream(cs.toArray)
+        new ByteArrayInputStream(cs.toArrayUnsafe())
       case _ =>
         // NOTE: We actually measured recently, and compact + use array was pretty good usually
         apply(bs.compact)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DeflateCompressor.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DeflateCompressor.scala
@@ -51,7 +51,7 @@ class DeflateCompressor private[coding] (compressionLevel: Int) extends Compress
 
   protected def compressWithBuffer(input: ByteString, buffer: Array[Byte]): ByteString = {
     require(deflater.needsInput())
-    deflater.setInput(input.toArray)
+    deflater.setInput(input.toArrayUnsafe())
     drainDeflater(deflater, buffer)
   }
   protected def flushWithBuffer(buffer: Array[Byte]): ByteString = {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
@@ -41,7 +41,7 @@ private[coding] class GzipCompressor(compressionLevel: Int) extends DeflateCompr
     header() ++ super.finishWithBuffer(buffer) ++ trailer()
 
   private def updateCrc(input: ByteString): Unit = {
-    checkSum.update(input.toArray)
+    checkSum.update(input.toArrayUnsafe())
     bytesRead += input.length
   }
   private def header(): ByteString =
@@ -117,7 +117,7 @@ private[coding] class GzipDecompressor(
   }
   private def crc16(data: ByteString) = {
     val crc = new CRC32
-    crc.update(data.toArray)
+    crc.update(data.toArrayUnsafe())
     crc.getValue.toInt & 0xFFFF
   }
 }

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2FrameHpackSupport.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2FrameHpackSupport.scala
@@ -58,7 +58,7 @@ trait Http2FrameHpackSupport extends Http2FrameProbeDelegator with Http2FrameSen
   val decoder = new Decoder(Http2Protocol.InitialMaxHeaderListSize, Http2Protocol.InitialMaxHeaderTableSize)
 
   def decodeHeaders(bytes: ByteString): Seq[(String, String)] = {
-    val bis = new ByteArrayInputStream(bytes.toArray)
+    val bis = new ByteArrayInputStream(bytes.toArrayUnsafe())
     val hs = new VectorBuilder[(String, String)]()
 
     decoder.decode(bis,


### PR DESCRIPTION
only safe to use toArrayUnsafe when you know that you are not mutating the array

the advantage is that you safe on having to clone the inner array that the ByteString has

there might be 1 or 2 more places that we could update in pekko-http too