### PR TITLE
Fix dependency-submission with invalid module

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: scalacenter/sbt-dependency-submission@v2
+        with:
+          modules-ignore: pekko-http-tests_3


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-http/issues/433 , see https://github.com/scalacenter/sbt-dependency-submission/issues/156#issuecomment-1903956426