### PR TITLE
pekko-http2-support is part of pekko-http-core

### DIFF
--- a/http-core/src/main/resources/reference.conf
+++ b/http-core/src/main/resources/reference.conf
@@ -23,8 +23,7 @@ pekko.http {
     # "PREVIEW" features that are not yet fully production ready.
     # These flags can change or be removed between patch releases.
     preview {
-      # If this setting is enabled AND the pekko-http2-support is found
-      # on the classpath, `Http().newServerAt(...).bind` and `bindSync`
+      # If this setting is enabled `Http().newServerAt(...).bind` and `bindSync`
       # will be enabled to use HTTP/2.
       #
       # `Http().newServerAt(...).bindFlow` and `connectionSource()` are not supported.


### PR DESCRIPTION
In older versions of Akka, there was a separate jar. This comment makes no sense in Pekko. 