### PR TITLE
rework symlink test

### DIFF
--- a/http-tests/src/test/resources/dirWithLink/linked-dir
+++ b/http-tests/src/test/resources/dirWithLink/linked-dir
@@ -1,1 +1,0 @@
-../subDirectory

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -210,16 +210,6 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
         headers should contain(`Last-Modified`(DateTime(lastModified)))
       }
     }
-    "not follow symbolic links to find a file" in {
-      EventFilter.warning(pattern = ".* points to a location that is not part of .*", occurrences = 1).intercept {
-        Get("linked-dir/empty.pdf") ~> _getFromDirectory("dirWithLink") ~> check {
-          handled shouldBe false
-          /* TODO: resurrect following links under an option
-          responseAs[String] shouldEqual "123"
-          mediaType shouldEqual `application/pdf`*/
-        }
-      }
-    }
   }
 
   "getFromResource" should {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -16,19 +16,20 @@ package directives
 
 import java.io.File
 
-import org.apache.pekko
-import pekko.http.scaladsl.settings.RoutingSettings
-import pekko.http.scaladsl.testkit.RouteTestTimeout
-
 import scala.concurrent.duration._
 import scala.util.Properties
-import org.scalatest.{ Inside, Inspectors }
-import pekko.http.scaladsl.model.MediaTypes._
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.model.headers._
+
+import org.apache.pekko
 import pekko.http.impl.util._
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.MediaTypes._
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.model.Uri.Path
+import pekko.http.scaladsl.settings.RoutingSettings
+import pekko.http.scaladsl.testkit.RouteTestTimeout
 import pekko.testkit._
+
+import org.scalatest.{ Inside, Inspectors }
 
 class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Inside {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
@@ -39,7 +39,7 @@ class FileAndResourceDirectivesSymlinkSpec extends RoutingSpec
   dirWithLink.mkdir()
   val symlink = Files.createSymbolicLink(
     Paths.get(dirWithLink.getAbsolutePath, "linked-dir"),
-    new File(testRoot, "subDirectory").toPath)
+    new File(testRoot, "subDirectory").toPath.toAbsolutePath)
 
   override def afterAll(): Unit = {
     super.afterAll()
@@ -59,6 +59,7 @@ class FileAndResourceDirectivesSymlinkSpec extends RoutingSpec
     def _getFromDirectory() = getFromDirectory(dirWithLink.getCanonicalPath)
 
     "not follow symbolic links to find a file" in {
+      Files.isSymbolicLink(symlink) shouldBe true
       EventFilter.warning(pattern = ".* points to a location that is not part of .*", occurrences = 1).intercept {
         Get("linked-dir/empty.pdf") ~> _getFromDirectory() ~> check {
           handled shouldBe false

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
@@ -35,17 +35,16 @@ class FileAndResourceDirectivesSymlinkSpec extends RoutingSpec
 
   val tempDir = Files.createTempDirectory("pekko-http-symlink-test")
   tempDir.toFile.deleteOnExit()
+  val dirWithLink = new File(tempDir.toFile, "dirWithLink")
+  dirWithLink.mkdir()
   val symlink = Files.createSymbolicLink(
-    Paths.get(tempDir.toAbsolutePath.toString, "linked-dir"),
+    Paths.get(dirWithLink.getAbsolutePath, "linked-dir"),
     new File(testRoot, "subDirectory").toPath)
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-  }
 
   override def afterAll(): Unit = {
     super.afterAll()
     Files.deleteIfExists(symlink)
+    Files.deleteIfExists(dirWithLink.toPath)
     Files.deleteIfExists(tempDir)
   }
 
@@ -57,7 +56,7 @@ class FileAndResourceDirectivesSymlinkSpec extends RoutingSpec
   """
 
   "getFromDirectory" should {
-    def _getFromDirectory() = getFromDirectory(tempDir.toFile.getCanonicalPath)
+    def _getFromDirectory() = getFromDirectory(dirWithLink.getCanonicalPath)
 
     "not follow symbolic links to find a file" in {
       EventFilter.warning(pattern = ".* points to a location that is not part of .*", occurrences = 1).intercept {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.http.scaladsl.server
+package directives
+
+import java.io.File
+import java.nio.file.{ Files, Paths }
+
+import scala.concurrent.duration._
+
+import org.apache.pekko
+import pekko.http.scaladsl.testkit.RouteTestTimeout
+import pekko.testkit._
+
+import org.scalatest.{ BeforeAndAfterAll, Inside, Inspectors }
+
+class FileAndResourceDirectivesSymlinkSpec extends RoutingSpec
+    with Inspectors with Inside with BeforeAndAfterAll {
+
+  // need to serve from the src directory, when sbt copies the resource directory over to the
+  // target directory it will resolve symlinks in the process
+  val testRoot = new File("http-tests/src/test/resources")
+  require(testRoot.exists(), s"testRoot was not found at ${testRoot.getAbsolutePath}")
+
+  val tempDir = Files.createTempDirectory("pekko-http-symlink-test")
+  tempDir.toFile.deleteOnExit()
+  val symlink = Files.createSymbolicLink(
+    Paths.get(tempDir.toAbsolutePath.toString, "linked-dir"),
+    new File(testRoot, "subDirectory").toPath)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    Files.deleteIfExists(symlink)
+    Files.deleteIfExists(tempDir)
+  }
+
+  // operations touch files, can be randomly hit by slowness
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(3.seconds.dilated)
+
+  override def testConfigSource = super.testConfigSource ++ """
+    pekko.http.routing.range-coalescing-threshold = 1
+  """
+
+  "getFromDirectory" should {
+    def _getFromDirectory() = getFromDirectory(tempDir.toFile.getCanonicalPath)
+
+    "not follow symbolic links to find a file" in {
+      EventFilter.warning(pattern = ".* points to a location that is not part of .*", occurrences = 1).intercept {
+        Get("linked-dir/empty.pdf") ~> _getFromDirectory() ~> check {
+          handled shouldBe false
+          /* TODO: resurrect following links under an option
+          responseAs[String] shouldEqual "123"
+          mediaType shouldEqual `application/pdf`*/
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* rework existing symlink test so that it creates the link itself (and removes it) - in /tmp folder for duration of test
* aim is to get 1.0.x ready for 1.0.1-RC2 - will forward fit after it is merged

#275, #444