### PR TITLE
Upgrade dependencies to move away from repo.scala-sbt.org

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,8 +28,8 @@ addSbtPlugin(("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.0").excludeAll(
   "com.lightbend.paradox", "sbt-paradox",
   "com.lightbend.paradox" % "sbt-paradox-apidoc",
   "com.lightbend.paradox" % "sbt-paradox-project-info"))
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").force())
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-apidoc" % "0.10.1").force())
+addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox" % "0.10.6").force())
+addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.0.0").force())
 addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-project-info" % "2.0.0").force())
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")


### PR DESCRIPTION
This PR is more a reminder, I don't expect it to be merged.
See 
- https://github.com/apache/incubator-pekko/pull/1061#issuecomment-1913598078