### PR TITLE
Replace getFirst with get

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
@@ -663,7 +663,7 @@ object HttpEntity {
         private var bytesLeft = Long.MaxValue
 
         override def preStart(): Unit = {
-          _attributes.getFirst[SizeLimit] match {
+          _attributes.get[SizeLimit] match {
             case Some(limit: SizeLimit) if limit.isDisabled =>
             // "no limit"
             case Some(SizeLimit(bytes, cl @ Some(contentLength))) =>


### PR DESCRIPTION
So `getFirst` for getting an attribute is deprecated and you are instead meant to use `get` however this does have a different behaviour change (i.e. `getFirst` will get the first found attribute where as `get` will get the most specific attribute).

Since we are now in the 1.1.x branch these kinds of behaviour changes are allowed