### PR TITLE
Use sbt-web 1.5.x despite staying on paradox 0.9.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,7 +28,8 @@ addSbtPlugin(("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.0").excludeAll(
   "com.lightbend.paradox", "sbt-paradox",
   "com.lightbend.paradox" % "sbt-paradox-apidoc",
   "com.lightbend.paradox" % "sbt-paradox-project-info"))
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").force())
+addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").force().exclude("com.typesafe.sbt", "sbt-web"))
+addSbtPlugin("com.github.sbt" % "sbt-web" % "1.5.4") // sbt-paradox 0.9.2 depends on old sbt-web 1.4.x, but we want a newer version
 addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.1.0").excludeAll(
   "com.lightbend.paradox", "sbt-paradox"))
 addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1").excludeAll(


### PR DESCRIPTION
I am pretty sure this is safe since I am basically the on who maintains sbt-web and v1.5 is pretty much compatible with v1.4 API wise.
I use the same workaround in https://github.com/sbt/sbt-paradox-material-theme/blob/v0.7.0/project/plugins.sbt#L1-L3 actually

With this change I can `+Test/compile` pekko-http and I am not hitting https://repo.scala-sbt.org/ anymore (since I have blocked it on my machine).

@mdedetrich I am pretty sure this is ok to merge.


See
- https://github.com/apache/incubator-pekko/pull/1135