### PR TITLE
Remove apidoc from ignore and pin paradox versions

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,7 +1,4 @@
 updates.ignore = [
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info" },
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-apidoc"},
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox"},
   { groupId = "org.apache.pekko", artifactId = "pekko-actor" },
   { groupId = "org.apache.pekko", artifactId = "pekko-actor-typed" },
   { groupId = "org.apache.pekko", artifactId = "pekko-stream" },
@@ -23,6 +20,9 @@ updates.pin = [
   { groupId = "org.specs2", artifactId = "specs2-core", version = "4.10." },
   # https://github.com/akka/akka-http/pull/4080#issuecomment-1074853622
   { groupId = "com.github.ben-manes.caffeine", artifactId = "caffeine", version = "2.9." },
+  # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info", version = "0.9." },
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
 ]
 
 updatePullRequests = "always"


### PR DESCRIPTION
Pins the sbt-paradox/sbt-paradox-project-info versions since we can use the entire 0.9.x series (it being compiled against JDK 8).

Also removes `sbt-paradox-apidoc` from the ignore list since we are free to update this (note that `sbt-paradox-apidoc` was recently updated to latest version without any issues)