### PR TITLE
use snapshot version of plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,8 +25,9 @@ addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 // We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
 // only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8
 resolvers += Resolver.ApacheMavenSnapshotsRepo
-addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.0+36-42777ace-SNAPSHOT")
+addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.0+37-5e25566b-SNAPSHOT")
 dependencyOverrides += "org.parboiled" % "parboiled-java" % "1.3.1"
+dependencyOverrides += "com.lightbend.paradox" %% "paradox" % "0.9.2"
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,16 +24,8 @@ addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 
 // We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
 // only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8
-addSbtPlugin(("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.0").excludeAll(
-  "com.lightbend.paradox", "sbt-paradox",
-  "com.lightbend.paradox" % "sbt-paradox-apidoc",
-  "com.lightbend.paradox" % "sbt-paradox-project-info"))
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").force().exclude("com.typesafe.sbt", "sbt-web"))
-addSbtPlugin("com.github.sbt" % "sbt-web" % "1.5.4") // sbt-paradox 0.9.2 depends on old sbt-web 1.4.x, but we want a newer version
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.1.0").excludeAll(
-  "com.lightbend.paradox", "sbt-paradox"))
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1").excludeAll(
-  "com.lightbend.paradox", "sbt-paradox"))
+resolvers += Resolver.ApacheMavenSnapshotsRepo
+addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.0+36-42777ace-SNAPSHOT")
 dependencyOverrides += "org.parboiled" % "parboiled-java" % "1.3.1"
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,9 +25,7 @@ addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 // We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
 // only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8
 resolvers += Resolver.ApacheMavenSnapshotsRepo
-addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.0+37-5e25566b-SNAPSHOT")
-dependencyOverrides += "org.parboiled" % "parboiled-java" % "1.3.1"
-dependencyOverrides += "com.lightbend.paradox" %% "paradox" % "0.9.2"
+addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1-RC1+3-2b1f8708-SNAPSHOT")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")


### PR DESCRIPTION
I think this is a useful test for the prospective new release for pekko-sbt-paradox.

The plugins.sbt changes are based on https://github.com/apache/incubator-pekko-sbt-paradox?tab=readme-ov-file#jdk-18-only