### PR TITLE
there is no index.html to link to

### DIFF
--- a/docs/src/main/paradox/reference.md
+++ b/docs/src/main/paradox/reference.md
@@ -2,7 +2,7 @@
 
 ## API Documentation
 
- * @scaladoc:[Scaladoc](org.apache.pekko.http.scaladsl.index)
+ * @scaladoc:[Scaladoc](org.apache.pekko.http.scaladsl.package-summary)
  * @javadoc:[Javadoc](org.apache.pekko.http.javadsl.package-summary)
 
 ## Directives


### PR DESCRIPTION
relates to #493 

we will also need to changes to our .htaccess because the snapshot part of the URL is not currently supported either - see https://github.com/apache/incubator-pekko-site/pull/92 for that bit