### PR TITLE
fix api/japi links in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -442,8 +442,8 @@ lazy val docs = project("docs")
       "javadoc.org.apache.pekko.link_style" -> "direct",
       "scaladoc.org.apache.pekko.base_url" -> s"https://pekko.apache.org/api/pekko/${PekkoCoreDependency.default.link}",
       "scaladoc.org.apache.pekko.link_style" -> "direct",
-      "javadoc.org.apache.pekko.http.base_url" -> s"https://pekko.apache.org/api/pekko-http/${projectInfoVersion.value}",
-      "scaladoc.org.apache.pekko.http.base_url" -> s"https://pekko.apache.org/japi/pekko-http/${projectInfoVersion.value}",
+      "javadoc.org.apache.pekko.http.base_url" -> s"https://pekko.apache.org/japi/pekko-http/${projectInfoVersion.value}",
+      "scaladoc.org.apache.pekko.http.base_url" -> s"https://pekko.apache.org/api/pekko-http/${projectInfoVersion.value}",
       "github.base_url" -> GitHub.url(version.value, isSnapshot.value)),
     apidocRootPackage := "org.apache.pekko",
     ValidatePR / additionalTasks += Compile / paradox)

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -64,6 +64,7 @@ site-link-validator {
     "http://localhost:8080"
     # broken URL in license report
     "http://pholser.github.com/"
+    "http://specs2.org/"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
japi is for javadoc - api is for scaladoc - we have them the wrong way around in build.sbt

relates to https://github.com/apache/incubator-pekko-http/issues/493