### PR TITLE
Revert to scala 2.13.12 due to regression with genjavadoc + Scala 2.13.13

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -8,6 +8,8 @@ updates.ignore = [
   { groupId = "org.apache.pekko", artifactId = "pekko-multi-node-testkit" },
   { groupId = "org.apache.pekko", artifactId = "pekko-http" },
   { groupId = "com.lightbend.sbt", artifactId = "sbt-java-formatter" }
+  # genjavadoc is broken with latest Scala 2.13.13, see https://github.com/lightbend/genjavadoc/issues/347 and https://github.com/scala/bug/issues/12966
+  { groupId = "org.scala-lang" }
 ]
 
 updates.pin = [

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   val scalafixVersion = _root_.scalafix.sbt.BuildInfo.scalafixVersion // grab from plugin
 
   val scala212Version = "2.12.19"
-  val scala213Version = "2.13.13"
+  val scala213Version = "2.13.12"
   val scala3Version = "3.3.1"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 


### PR DESCRIPTION
Latest Scala 2.13.13 breaks genjavadoc with means our doc publishing is broken, see https://github.com/lightbend/genjavadoc/issues/347, https://github.com/scala/bug/issues/12966 and https://github.com/apache/incubator-pekko-http/actions/runs/8126952015 for the CI failing