### PR TITLE
Revert "Update sbt-scalafix, scalafix-core to 0.12.0"

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -10,6 +10,7 @@ updates.ignore = [
   { groupId = "com.lightbend.sbt", artifactId = "sbt-java-formatter" }
   # genjavadoc is broken with latest Scala 2.13.13, see https://github.com/lightbend/genjavadoc/issues/347 and https://github.com/scala/bug/issues/12966
   { groupId = "org.scala-lang" }
+  { groupId = "ch.epfl.scala" }
 ]
 
 updates.pin = [

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -38,7 +38,7 @@ dependencyOverrides += "org.parboiled" % "parboiled-java" % "1.3.1"
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.3")


### PR DESCRIPTION
Reverts apache/incubator-pekko-http#499

the downgrade of Scala 2.13 is now leading to failures on dependency graph job - see https://github.com/apache/incubator-pekko-http/actions/runs/8129865838