### PR TITLE
HTTP2: Allow frame of type RstStreamFrame when in state HalfClosedLocalWaitingForPeerStream

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
@@ -447,9 +447,9 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
         // We're not planning on sending any data on this stream anymore, so we don't care about window updates.
         this
       case rst@RstStreamFrame(streamId, _) =>
-        //TODO if errorCode is REFUSED_STREAM, we should try to open a new stream
-        val frame = ParsedHeadersFrame(streamId, endStream = true, Seq((":status", "429")), None)
-        dispatchStream(streamId, frame, ByteString.empty, correlationAttributes, _ => Closed)
+        val headers = ParsedHeadersFrame(streamId, endStream = false, Seq((":status", "429")), None)
+        dispatchSubstream(headers, Right(Source.failed(new PeerClosedStreamException(rst.streamId, rst.errorCode))), correlationAttributes)
+        Closed
       case _ =>
         expectIncomingStream(event, Closed, HalfClosedLocal(_), correlationAttributes)
     }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
@@ -40,7 +40,6 @@ import scala.util.control.NoStackTrace
  * Mixed into the Http2ServerDemux graph logic.
  */
 @InternalApi
-//noinspection ConvertibleToMethodValue,ScalaWeakerAccess,ScalaUnusedSymbol
 private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper { self =>
   // required API from demux
   def isServer: Boolean
@@ -446,9 +445,10 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
       case _: WindowUpdateFrame =>
         // We're not planning on sending any data on this stream anymore, so we don't care about window updates.
         this
-      case rst@RstStreamFrame(streamId, _) =>
-        val headers = ParsedHeadersFrame(streamId, endStream = false, Seq((":status", "429")), None)
-        dispatchSubstream(headers, Right(Source.failed(new PeerClosedStreamException(rst.streamId, rst.errorCode))), correlationAttributes)
+      case rst: RstStreamFrame =>
+        val headers = ParsedHeadersFrame(rst.streamId, endStream = false, Seq((":status", "429")), None)
+        dispatchSubstream(headers, Right(Source.failed(new PeerClosedStreamException(rst.streamId, rst.errorCode))),
+          correlationAttributes)
         Closed
       case _ =>
         expectIncomingStream(event, Closed, HalfClosedLocal(_), correlationAttributes)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
@@ -446,6 +446,10 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
       case _: WindowUpdateFrame =>
         // We're not planning on sending any data on this stream anymore, so we don't care about window updates.
         this
+      case rst@RstStreamFrame(streamId, _) =>
+        //TODO if errorCode is REFUSED_STREAM, we should try to open a new stream
+        val frame = ParsedHeadersFrame(streamId, endStream = true, Seq((":status", "429")), None)
+        dispatchStream(streamId, frame, ByteString.empty, correlationAttributes, _ => Closed)
       case _ =>
         expectIncomingStream(event, Closed, HalfClosedLocal(_), correlationAttributes)
     }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
@@ -40,6 +40,7 @@ import scala.util.control.NoStackTrace
  * Mixed into the Http2ServerDemux graph logic.
  */
 @InternalApi
+//noinspection ConvertibleToMethodValue,ScalaWeakerAccess,ScalaUnusedSymbol
 private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper { self =>
   // required API from demux
   def isServer: Boolean

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
@@ -298,7 +298,8 @@ class Http2ClientSpec extends PekkoSpecWithMaterializer("""
 
         network.sendRST_STREAM(TheStreamId, ErrorCode.REFUSED_STREAM)
 
-        expectGracefulCompletion()
+        val response = user.expectResponse()
+        response.status should be(StatusCodes.TooManyRequests)
 
       })
     }


### PR DESCRIPTION
As described in https://github.com/apache/pekko-connectors/pull/830, I got an `"Received unexpected frame of type RstStreamFrame for stream 1 in state HalfClosedLocalWaitingForPeerStream"` which I think is a bug in the http2 client side support.

In this PR I took the approach of returning an `HttpResponse` with status 429, and with an failed source with `PeerClosedStreamException` as entity. I though of several alternatives but I could not implement them:
* transparently retry the request when the error code is `REFUSED_STREAM`, since the spec clearly says the request can be retried.
* return/throw `PeerClosedStreamException`, without having to "wrap" it in a `HttpResponse`