### PR TITLE
Update .scala-steward.conf to remove version pins

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,10 +11,6 @@ updates.ignore = [
 ]
 
 updates.pin = [
-  # specs2 v5 needs newer java version
-  { groupId = "org.specs2", artifactId = "specs2-core", version = "4." },
-  # https://github.com/akka/akka-http/pull/4080#issuecomment-1074853622
-  { groupId = "com.github.ben-manes.caffeine", artifactId = "caffeine", version = "2.9." },
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]


### PR DESCRIPTION
Removed pinned versions for specs2 and caffeine.

Should hopefully work with Java 17