### PR TITLE
use Scala FunctionConverter and remove some unused implicits

### DIFF
--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
@@ -19,6 +19,7 @@ import java.util.function.BiFunction
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.jdk.CollectionConverters._
+import scala.jdk.FunctionConverters._
 import scala.jdk.FutureConverters._
 
 import com.github.benmanes.caffeine.cache.{ AsyncCache, Caffeine }
@@ -29,7 +30,6 @@ import pekko.http.caching.LfuCache.toJavaMappingFunction
 import pekko.http.caching.scaladsl.Cache
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.caching.CacheJavaMapping.Implicits._
-import pekko.util.FunctionConverters._
 
 @ApiMayChange
 object LfuCache {

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/EnhancedByteStringTraversableOnce.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/EnhancedByteStringTraversableOnce.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.http.impl.util
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.http.ccompat._
 import pekko.util.ByteString
 
 /**

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.CompletionStage
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
-import pekko.http.ccompat._
 import pekko.http.impl.engine.rendering.BodyPartRenderer
 import pekko.http.impl.util.{ DefaultNoLogging, Util }
 import pekko.http.impl.util.JavaMapping.Implicits._

--- a/http-tests/src/multi-jvm/scala/org/apache/pekko/remote/testkit/MultiNodeConfig.scala
+++ b/http-tests/src/multi-jvm/scala/org/apache/pekko/remote/testkit/MultiNodeConfig.scala
@@ -13,26 +13,23 @@
 
 package org.apache.pekko.remote.testkit
 
-import language.implicitConversions
 import java.net.{ InetAddress, InetSocketAddress }
 
 import com.typesafe.config.{ Config, ConfigFactory, ConfigObject }
 
+import language.implicitConversions
 import scala.concurrent.{ Await, Awaitable }
-import scala.util.control.NonFatal
+import scala.concurrent.duration._
 import scala.collection.immutable
+import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.actor._
-import pekko.util.Timeout
-import pekko.http.ccompat._
-import pekko.remote.testconductor.{ TestConductor, TestConductorExt }
+import pekko.event.{ LogSource, Logging, LoggingAdapter }
+import pekko.remote.testconductor.{ RoleName, TestConductor, TestConductorExt }
 import pekko.testkit._
 import pekko.testkit.TestEvent._
-
-import scala.concurrent.duration._
-import pekko.remote.testconductor.RoleName
-import pekko.actor.RootActorPath
-import pekko.event.{ LogSource, Logging, LoggingAdapter }
+import pekko.util.Timeout
 
 /**
  * Configure the role names and participants of the test, including configuration settings.

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FormFieldDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FormFieldDirectives.scala
@@ -25,7 +25,6 @@ import pekko.http.scaladsl.server.{ Directives => D }
 import pekko.http.scaladsl.server.directives.ParameterDirectives._
 
 import scala.jdk.CollectionConverters._
-import pekko.http.impl.util.JavaMapping.Implicits._
 import scala.jdk.OptionConverters._
 
 abstract class FormFieldDirectives extends FileUploadDirectives {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
@@ -18,8 +18,6 @@ import java.util.{ function => jf }
 
 import org.apache.pekko
 import pekko.actor.ReflectiveDynamicAccess
-
-import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.model.headers.{ HttpOriginRange, HttpOriginRanges }
 import pekko.http.javadsl.model.HttpHeader
 import pekko.http.javadsl.server.Route

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/common/StrictForm.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/common/StrictForm.scala
@@ -19,7 +19,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import org.apache.pekko
 import pekko.stream.Materializer
-import pekko.http.ccompat._
 import pekko.http.scaladsl.unmarshalling._
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.util.FastFuture

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshal.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshal.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.http.scaladsl.marshalling
 
 import scala.concurrent.{ ExecutionContext, Future }
 import org.apache.pekko
-import pekko.http.ccompat._
 import pekko.http.scaladsl.server.ContentNegotiator
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.util.FastFuture._


### PR DESCRIPTION
* some of this is facilitated by removing Scala 2.12 support
* some of the imports may not even have been required before