### PR TITLE
use char based startsWith/endsWith

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/ResponseParsing.scala
@@ -19,6 +19,7 @@ import pekko.annotation.InternalApi
 import pekko.http.impl.engine.http2.RequestParsing._
 import pekko.http.impl.engine.parsing.HttpHeaderParser
 import pekko.http.impl.engine.server.HttpAttributes
+import pekko.http.impl.util._
 import pekko.http.scaladsl.model
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.`Tls-Session-Info`
@@ -102,7 +103,7 @@ private[http2] object ResponseParsing {
             rec(remainingHeaders.tail, status, contentType, contentLengthValue, seenRegularHeader, headers)
           } else malformedRequest("HTTP message must not contain more than one content-length header")
 
-        case (name, _) if name.startsWith(":") =>
+        case (name, _) if name.startsWith(':') =>
           malformedRequest(s"Unexpected pseudo-header '$name' in response")
 
         case (_, httpHeader: HttpHeader) =>

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/ContentDispositionHeader.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/ContentDispositionHeader.scala
@@ -16,13 +16,12 @@ package org.apache.pekko.http.impl.model.parser
 import scala.collection.immutable.TreeMap
 
 import org.apache.pekko
-import org.parboiled2.Parser
 import pekko.http.scaladsl.model.headers._
-import pekko.http.impl.util.ISO88591
-import pekko.http.impl.util.UTF8
+import pekko.http.impl.util._
 import pekko.http.impl.model.parser.CharacterClasses.`attr-char`
 import pekko.http.impl.model.parser.CharacterClasses.HEXDIG
 import pekko.http.scaladsl.model.Uri
+import org.parboiled2.Parser
 
 import java.nio.charset.Charset
 
@@ -58,7 +57,7 @@ private[parser] trait ContentDispositionHeader { this: Parser with CommonRules w
     | `ext-token` ~ ws('=') ~ `ext-value`)
 
   def `ext-token` = rule { // token which ends with '*'
-    token ~> (s => test(s.endsWith("*")) ~ push(s))
+    token ~> (s => test(s.endsWith('*')) ~ push(s))
   }
 
   // https://tools.ietf.org/html/rfc5987#section-3.2.1

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
@@ -13,23 +13,23 @@
 
 package org.apache.pekko.http.impl
 
-import language.implicitConversions
 import java.nio.charset.StandardCharsets
 
-import com.typesafe.config.Config
-import org.apache.pekko
-import pekko.stream.scaladsl.Source
-import pekko.stream.stage._
-
+import language.implicitConversions
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future }
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
 import scala.util.matching.Regex
-import pekko.util.ByteString
+
+import com.typesafe.config.Config
+import org.apache.pekko
 import pekko.actor._
 import pekko.http.impl.engine.parsing.ParserOutput.RequestStart
 import pekko.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
+import pekko.stream.scaladsl.Source
+import pekko.stream.stage._
+import pekko.util.ByteString
 
 package object util {
   private[http] val UTF8 = StandardCharsets.UTF_8

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
@@ -472,7 +472,7 @@ final case class `Content-Disposition`(dispositionType: ContentDispositionType, 
       case (k, v) if k == "filename" =>
         r ~~ "; " ~~ k ~~ '=' ~~ '"'
         r.putReplaced(v, keep = safeChars, placeholder = '?') ~~ '"'
-      case (k, v) if k.endsWith("*") =>
+      case (k, v) if k.endsWith('*') =>
         r ~~ "; " ~~ k ~~ '=' ~~ "UTF-8''"
         UriRendering.encode(r, v, UTF8, keep = `attr-char`, replaceSpaces = false)
       case (k, v) => r ~~ "; " ~~ k ~~ '=' ~~#! v

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -107,7 +107,7 @@ trait FileAndResourceDirectives {
    */
   def getFromResource(
       resourceName: String, contentType: ContentType, classLoader: ClassLoader = _defaultClassLoader): Route =
-    if (!resourceName.endsWith("/"))
+    if (!resourceName.endsWith('/'))
       get {
         Option(classLoader.getResource(resourceName)).flatMap(ResourceFile.apply) match {
           case Some(ResourceFile(url, length, lastModified)) =>
@@ -222,7 +222,7 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
     RangeDirectives.withRangeSupport &
     CodingDirectives.withPrecompressedMediaTypeSupport
 
-  private def withTrailingSlash(path: String): String = if (path.endsWith("/")) path else path + '/'
+  private def withTrailingSlash(path: String): String = if (path.endsWith('/')) path else path + '/'
 
   /**
    * Given a base directory and a (Uri) path, returns a path to a location contained in the base directory,


### PR DESCRIPTION
* pekko-http has an implicit that adds char based startsWith/endsWith to String and it is a little faster than the built-in String param version
* jmh used is https://github.com/pjfanning/pekko-bench/blob/main/src/main/scala/example/EndsWithBench.scala