### PR TITLE
remove conversion to Vector

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
@@ -218,8 +218,7 @@ object Multipart {
 
   private def strictify[BP <: Multipart.BodyPart, BPS <: Multipart.BodyPart.Strict](parts: Source[BP, Any])(
       f: BP => Future[BPS])(implicit fm: Materializer): Future[Seq[BPS]] = {
-    import fm.executionContext
-    parts.mapAsync(Int.MaxValue)(f).runWith(Sink.seq).fast
+    parts.mapAsync(Int.MaxValue)(f).runWith(Sink.seq)
   }
 
   //////////////////////// CONCRETE multipart types /////////////////////////


### PR DESCRIPTION
from the usages, it seems unnecessary to convert to Vector - possibly needed for Scala 2.12 but we don't support that any more