### PR TITLE
tests the 1.3 dev branch

### DIFF
--- a/.github/workflows/nightly-1.3.yml
+++ b/.github/workflows/nightly-1.3.yml
@@ -12,7 +12,6 @@ on:
   schedule:
     - cron: "30 1 * * *"
   workflow_dispatch:
-  pull_request:
 
 jobs:
   compile-and-test:


### PR DESCRIPTION
We could do with beefing up the CI coverage of the 1.3 dev branch.
This runs a nightly test with the latest pekko core 1.x snapshots.