### PR TITLE
TestSource/TestSink probe deprecated

### DIFF
--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HttpsProxyGraphStageSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HttpsProxyGraphStageSpec.scala
@@ -208,9 +208,9 @@ class HttpsProxyGraphStageSpec extends PekkoSpecWithMaterializer {
 
         val flowUnderTest = proxyGraphStage.join(proxyFlow)
 
-        val (source, sink) = TestSource.probe[ByteString]
+        val (source, sink) = TestSource[ByteString]()
           .via(flowUnderTest)
-          .toMat(TestSink.probe)(Keep.both)
+          .toMat(TestSink())(Keep.both)
           .run()
 
         fn(source, flowInProbe, flowOutProbe, sink)

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketIntegrationSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketIntegrationSpec.scala
@@ -59,7 +59,7 @@ class WebSocketIntegrationSpec extends PekkoSpecWithMaterializer(
 
       val (response, sink) = Http().singleWebSocketRequest(
         WebSocketRequest("ws://127.0.0.1:" + myPort),
-        Flow.fromSinkAndSourceMat(TestSink.probe[Message], Source.empty)(Keep.left))
+        Flow.fromSinkAndSourceMat(TestSink[Message](), Source.empty)(Keep.left))
 
       response.futureValue.response.status.isSuccess should ===(true)
       sink
@@ -119,7 +119,7 @@ class WebSocketIntegrationSpec extends PekkoSpecWithMaterializer(
                 Tcp(system).outgoingConnection(new InetSocketAddress("localhost", myPort), halfClose = true)))(
                 Keep.both)
           }(Keep.right)
-          .toMat(TestSink.probe[Message])(Keep.both)
+          .toMat(TestSink[Message]())(Keep.both)
           .run()
 
       response.futureValue.response.status.isSuccess should ===(true)

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/GracefulTerminationSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/GracefulTerminationSpec.scala
@@ -101,7 +101,7 @@ class GracefulTerminationSpec
             // start reading the response
             val responseEntity = r1.futureValue.entity.dataBytes
               .via(Framing.delimiter(ByteString(","), 20))
-              .runWith(TestSink.probe[ByteString])(SystemMaterializer(clientSystem).materializer)
+              .runWith(TestSink[ByteString]())(SystemMaterializer(clientSystem).materializer)
             responseEntity.requestNext().utf8String should ===("reply1")
 
             val termination = serverBinding.terminate(hardDeadline = 1.second)
@@ -132,7 +132,7 @@ class GracefulTerminationSpec
       // start reading the response
       val response = r1.futureValue.entity.dataBytes
         .via(Framing.delimiter(ByteString(","), 20))
-        .runWith(TestSink.probe[ByteString])
+        .runWith(TestSink[ByteString]())
       response.requestNext().utf8String should ===("reply1")
 
       try {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
@@ -426,7 +426,7 @@ class Http2ClientSpec extends PekkoSpecWithMaterializer("""
         val chunksIn =
           user.expectResponse()
             .entity.asInstanceOf[Chunked]
-            .chunks.runWith(TestSink.probe[ChunkStreamPart](system.classicSystem))
+            .chunks.runWith(TestSink[ChunkStreamPart]()(system.classicSystem))
         val data1 = ByteString("abcdef")
         network.sendDATA(TheStreamId, endStream = false, data1)
         chunksIn.request(2)

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDemuxSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDemuxSpec.scala
@@ -40,10 +40,10 @@ class Http2ServerDemuxSpec extends PekkoSpecWithMaterializer("""
         (SettingIdentifier.SETTINGS_ENABLE_PUSH, 0))
       val bidi = BidiFlow.fromGraph(new Http2ServerDemux(settings, initialRemoteSettings, upgraded = true))
 
-      val ((substreamProducer, (frameConsumer, frameProducer)), substreamConsumer) = TestSource.probe[Http2SubStream]
-        .viaMat(bidi.joinMat(Flow.fromSinkAndSourceMat(TestSink.probe[FrameEvent], TestSource.probe[FrameEvent])(
+      val ((substreamProducer, (frameConsumer, frameProducer)), substreamConsumer) = TestSource[Http2SubStream]()
+        .viaMat(bidi.joinMat(Flow.fromSinkAndSourceMat(TestSink[FrameEvent](), TestSource[FrameEvent]())(
           Keep.both))(Keep.right))(Keep.both)
-        .toMat(TestSink.probe[Http2SubStream])(Keep.both)
+        .toMat(TestSink[Http2SubStream]())(Keep.both)
         .run()
 
       frameConsumer.request(1000)


### PR DESCRIPTION
Removed in Pekko 2.
Good to not use deprecated code that is slated for removal.