### PR TITLE
test with pekko core 1.3.0 (#871)

### DIFF
--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.1.5"
+  override val currentVersion: String = "1.3.0"
 }


### PR DESCRIPTION
* test with pekko core 1.3.0
* main branch is targeted at 2.0.0 so we don't need to test with old versions of pekko