### PR TITLE
chore: don't rely on Pekko Core `ccompat`

### DIFF
--- a/http-core/src/main/scala-2.13+/org/apache/pekko/http/ccompat/package.scala
+++ b/http-core/src/main/scala-2.13+/org/apache/pekko/http/ccompat/package.scala
@@ -19,6 +19,12 @@ package org.apache.pekko.http
 package object ccompat {
 
   type Builder[-A, +To] = scala.collection.mutable.Builder[A, To]
+
+  // When we drop support for 2.12 we can delete this concept
+  // and import scala.jdk.CollectionConverters.Ops._ instead
+  object JavaConverters
+      extends scala.collection.convert.AsJavaExtensions
+      with scala.collection.convert.AsScalaExtensions
 }
 
 /**

--- a/http-core/src/main/scala-2.13-/org/apache/pekko/http/ccompat/package.scala
+++ b/http-core/src/main/scala-2.13-/org/apache/pekko/http/ccompat/package.scala
@@ -53,6 +53,8 @@ package object ccompat {
     // missing in 2.12
     def -=(element: T): Unit = queue.dequeueAll(_ == element)
   }
+
+  object JavaConverters extends scala.collection.convert.DecorateAsJava with scala.collection.convert.DecorateAsScala
 }
 
 /**

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/Http2ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/Http2ServerSettings.scala
@@ -17,8 +17,8 @@ import java.time.Duration
 
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
+import pekko.http.ccompat.JavaConverters._
 import pekko.http.scaladsl
-import pekko.util.ccompat.JavaConverters._
 import com.typesafe.config.Config
 
 import scala.concurrent.duration.DurationLong

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/Http2ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/Http2ServerSettings.scala
@@ -17,9 +17,9 @@ import org.apache.pekko
 import pekko.annotation.ApiMayChange
 import pekko.annotation.DoNotInherit
 import pekko.annotation.InternalApi
+import pekko.http.ccompat.JavaConverters._
 import pekko.http.impl.util._
 import pekko.http.javadsl
-import pekko.util.ccompat.JavaConverters._
 import com.typesafe.config.Config
 
 import scala.concurrent.duration.Duration


### PR DESCRIPTION
ccompat was intentionally never `@InternalStableApi` to allow modules to evolve them more independently