### PR TITLE
upgrade sbt plugins on 1.4.x branch

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,7 +25,7 @@ addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.4")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.5")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.13")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.7")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")


### PR DESCRIPTION
Main reason is to upgrade sbt-pekko-build because I need access to recent improvements to support more version flags allowing testing against recent branches of pekko core.

Git Blame on main branch provides some background on changes there (and PRs):
https://github.com/apache/pekko-http/blame/c8738067bf58cb0332b6fd63de9472ac4961385b/project/plugins.sbt 

https://github.com/apache/pekko-http/pull/825 is why sbt-hacker-digest is removed