### PR TITLE
Update PEKKO_VERSION to '1.x' in workflow

### DIFF
--- a/.github/workflows/nightly-1.x.yml
+++ b/.github/workflows/nightly-1.x.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         SCALA_VERSION: [2.12, 2.13, 3]
         JDK: [8, 17]
-        PEKKO_VERSION: ['1.4.x']
+        PEKKO_VERSION: ['1.x']
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
* test with latest 1.x snapshot
* means we won't need to change this plan every time we do a minor release for pekko 1.x