### PR TITLE
Change vote duration to at least 72 hours

### DIFF
--- a/.github/workflows/stage-release-candidate.yml
+++ b/.github/workflows/stage-release-candidate.yml
@@ -300,7 +300,7 @@ jobs:
           The VOTE will pass if we have more positive votes than negative votes
           and there must be a minimum of 3 approvals from Pekko PMC members.
           Anyone voting in favour of the release, could you please provide a list of the checks you have done?
-          The vote will be left open until [VOTE_ENDS_UTC].
+          The vote will be left open for at least 72hrs.
           
           [ ] +1 approve
           [ ] +0 no opinion


### PR DESCRIPTION
`[VOTE_ENDS_UTC]` was not token substituted in emails. - example: https://lists.apache.org/thread/mcwbc3bqy2hvd9cgxvd6hr7yt3y1hogs