### PR TITLE
test with latest pekko snapshots

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         SCALA_VERSION: [2.13, 3]
         JDK: [17, 21, 25]
-        PEKKO_VERSION: ['default']
+        PEKKO_VERSION: ['main']
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
* 'main' finds the latest snapshots while 'default' tests with the latest release
* #954 shows that we have issues in our 1.x snapshots and I think we will find that our 2.x snapshots also have an issue