### PR TITLE
perf: use VarHandle int view in FrameEventParser.mask with byte-per-byte fallback

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/FrameEventParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/FrameEventParser.scala
@@ -13,6 +13,9 @@
 
 package org.apache.pekko.http.impl.engine.ws
 
+import java.lang.invoke.{ MethodHandles, VarHandle }
+import java.nio.ByteOrder
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.impl.io.ByteStringParser
@@ -50,6 +53,16 @@ import pekko.stream.Attributes
 @InternalApi
 private[http] object FrameEventParser extends ByteStringParser[FrameEvent] {
   import ByteStringParser._
+
+  // VarHandle for reading/writing 4 bytes as a big-endian int in a byte array.
+  // Initialized lazily with a fallback to null if unavailable (e.g. security restrictions).
+  private val intArrayViewHandle: VarHandle = {
+    try {
+      MethodHandles.byteArrayViewVarHandle(classOf[Array[Int]], ByteOrder.BIG_ENDIAN)
+    } catch {
+      case _: Exception => null
+    }
+  }
 
   override def createLogic(attr: Attributes) = new ParsingLogic {
     startWith(ReadFrameHeader)
@@ -130,36 +143,47 @@ private[http] object FrameEventParser extends ByteStringParser[FrameEvent] {
     val m0 = ((mask >> 24) & 0xFF).toByte
     val m1 = ((mask >> 16) & 0xFF).toByte
     val m2 = ((mask >> 8) & 0xFF).toByte
-    val m3 = ((mask >> 0) & 0xFF).toByte
-
-    @tailrec def rec(bytes: Array[Byte], offset: Int, last: Int): Unit =
-      if (offset < last) {
-        // process four bytes each turn
-        bytes(offset + 0) = (bytes(offset + 0) ^ m0).toByte
-        bytes(offset + 1) = (bytes(offset + 1) ^ m1).toByte
-        bytes(offset + 2) = (bytes(offset + 2) ^ m2).toByte
-        bytes(offset + 3) = (bytes(offset + 3) ^ m3).toByte
-
-        rec(bytes, offset + 4, last)
-      } else {
-        val len = bytes.length
-
-        if (last < len) {
-          bytes(last) = (bytes(last) ^ m0).toByte
-
-          if (last + 1 < len) {
-            bytes(last + 1) = (bytes(last + 1) ^ m1).toByte
-
-            if (last + 2 < len)
-              bytes(last + 2) = (bytes(last + 2) ^ m2).toByte
-          }
-        }
-      }
 
     val buffer = bytes.toArray[Byte]
-    rec(buffer, 0, (bytes.length / 4) * 4)
+    val len = buffer.length
+    val aligned = (len / 4) * 4
 
-    val newMask = Integer.rotateLeft(mask, (bytes.length % 4) * 8)
+    if (intArrayViewHandle != null) {
+      // Fast path: read/XOR/write 4 bytes at a time as a single int via VarHandle
+      @tailrec def recFast(offset: Int): Unit =
+        if (offset < aligned) {
+          val chunk = intArrayViewHandle.get(buffer, offset).asInstanceOf[Int]
+          intArrayViewHandle.set(buffer, offset, chunk ^ mask)
+          recFast(offset + 4)
+        }
+      recFast(0)
+    } else {
+      // Fallback: process four bytes each turn
+      val m3 = ((mask >> 0) & 0xFF).toByte
+      @tailrec def rec(offset: Int): Unit =
+        if (offset < aligned) {
+          buffer(offset + 0) = (buffer(offset + 0) ^ m0).toByte
+          buffer(offset + 1) = (buffer(offset + 1) ^ m1).toByte
+          buffer(offset + 2) = (buffer(offset + 2) ^ m2).toByte
+          buffer(offset + 3) = (buffer(offset + 3) ^ m3).toByte
+          rec(offset + 4)
+        }
+      rec(0)
+    }
+
+    // Handle remaining 1-3 bytes beyond the last aligned group
+    if (aligned < len) {
+      buffer(aligned) = (buffer(aligned) ^ m0).toByte
+
+      if (aligned + 1 < len) {
+        buffer(aligned + 1) = (buffer(aligned + 1) ^ m1).toByte
+
+        if (aligned + 2 < len)
+          buffer(aligned + 2) = (buffer(aligned + 2) ^ m2).toByte
+      }
+    }
+
+    val newMask = Integer.rotateLeft(mask, (len % 4) * 8)
     (ByteString.fromArrayUnsafe(buffer), newMask)
   }
 


### PR DESCRIPTION
## Summary

Optimizes the WebSocket frame masking/unmasking loop in `FrameEventParser` by using `MethodHandles.byteArrayViewVarHandle` (available since Java 9, part of the JDK standard library) to process 4 payload bytes as a single big-endian `int` per loop iteration, rather than 4 individual byte reads and writes.

## Changes

**`FrameEventParser.scala`**

- Added `import java.lang.invoke.{ MethodHandles, VarHandle }` and `import java.nio.ByteOrder`.
- Added a `private val intArrayViewHandle: VarHandle` initialized once at object-load time via `MethodHandles.byteArrayViewVarHandle(classOf[Array[Int]], ByteOrder.BIG_ENDIAN)`, wrapped in a `try/catch` that sets the field to `null` if the VarHandle cannot be created (e.g. under a restrictive security policy).
- Refactored `mask(bytes: ByteString, mask: Int)`:
  - **Fast path** (`intArrayViewHandle != null`): reads 4 bytes as one `int`, XORs with the full 32-bit mask in a single operation, then writes the result back — replacing 8 array accesses (4 reads + 4 writes) with 2 VarHandle operations per 4-byte group.
  - **Fallback path** (`intArrayViewHandle == null`): keeps the existing 4-byte-unrolled per-byte loop unchanged.
  - Both paths share the same trailing 1–3 byte remainder logic (XOR with `m0`/`m1`/`m2`).
- `m3` byte is now only computed inside the fallback path where it is actually needed.

## Why `classOf[Array[Int]]` is correct

`byteArrayViewVarHandle(viewArrayClass, byteOrder)` takes the **view** type — i.e. `int[].class` (≡ `classOf[Array[Int]]` in Scala) — because the handle views a `byte[]` *as if* it were an `int[]`. Passing `byte[].class` here would be incorrect and would throw `IllegalArgumentException` at runtime.

## Why plain `get`/`set` rather than `getAndBitwiseXor`

`getAndBitwiseXor` is an *atomic* access mode that inserts full memory barriers. The local mutable `byte[]` buffer is not shared between threads, so atomicity is not needed and its overhead would be counterproductive.
