### PR TITLE
Derive junit-platform-launcher and junit5Version from sbt-jupiter-interface plugin

### DIFF
--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/JUnitRouteTest.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/JUnitRouteTest.scala
@@ -33,6 +33,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
  * A RouteTest that uses JUnit assertions. ActorSystem and Materializer are provided as an [[org.junit.rules.ExternalResource]]
  * and their lifetime is automatically managed.
  */
+@deprecated("Use JUnitJupiterRouteTestBase instead", "2.0.0")
 abstract class JUnitRouteTestBase extends RouteTest {
   protected def systemResource: ActorSystemResource
   implicit def system: ActorSystem = systemResource.system
@@ -64,6 +65,8 @@ abstract class JUnitRouteTestBase extends RouteTest {
       }
     }
 }
+
+@deprecated("Use JUnitJupiterRouteTest instead", "2.0.0")
 abstract class JUnitRouteTest extends JUnitRouteTestBase {
   protected def additionalConfig: Config = ConfigFactory.empty()
 
@@ -72,6 +75,7 @@ abstract class JUnitRouteTest extends JUnitRouteTestBase {
   protected def systemResource: ActorSystemResource = _systemResource
 }
 
+@deprecated("Use ActorSystemExtension (Jupiter Junit support) instead", "2.0.0")
 class ActorSystemResource(name: String, additionalConfig: Config) extends ExternalResource {
   protected def config = additionalConfig.withFallback(ConfigFactory.load())
   protected def createSystem(): ActorSystem = ActorSystem(name, config)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,29 +13,14 @@
 
 import sbt._
 import sbt.Keys._
+import com.github.sbt.junit.jupiter.sbt.Import.JupiterKeys
 import scala.language.implicitConversions
 
 object Dependencies {
   import DependencyHelpers._
 
-  // Versions derived from sbt-jupiter-interface plugin (avoids hardcoding JUnit 5/platform versions)
-  private def readResourceProperty(resource: String, property: String): String = {
-    val props = new java.util.Properties
-    val stream = getClass.getClassLoader.getResourceAsStream(resource)
-    if (stream eq null)
-      throw new RuntimeException(s"Could not find classpath resource '$resource'. Is sbt-jupiter-interface on the plugin classpath?")
-    try props.load(stream)
-    catch { case e: Exception => throw new RuntimeException(s"Failed to load '$resource': ${e.getMessage}", e) }
-    finally stream.close()
-    Option(props.getProperty(property))
-      .getOrElse(throw new RuntimeException(s"Property '$property' not found in '$resource'"))
-  }
-  val jupiterInterfaceVersion: String = readResourceProperty("jupiter-interface.properties", "version")
-  val junit5Version: String = readResourceProperty("jupiter-interface.properties", "junit.jupiter.version")
-  val junitPlatformVersion: String = readResourceProperty("jupiter-interface.properties", "junit.platform.version")
-
   val jacksonDatabindVersion = "2.21.2"
-  val jacksonDatabind3Version = "3.1.1"
+  val jacksonDatabind3Version = "3.1.2"
   val jacksonXmlVersion = jacksonDatabindVersion
   val junitVersion = "4.13.2"
   val h2specVersion = "2.6.0"
@@ -78,7 +63,7 @@ object Dependencies {
     // For pekko-http-jackson3 support
     val jacksonDatabind3 = "tools.jackson.core" % "jackson-databind" % jacksonDatabind3Version
 
-    // For pekko-http-testkit-java
+    // For pekko-http-testkit-java (JUnit 4 support for library users)
     val junit = "junit" % "junit" % junitVersion
 
     val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % "3.2.3"
@@ -98,18 +83,10 @@ object Dependencies {
       val sprayJson = Compile.sprayJson % "test"
       val junit = Compile.junit % "test"
       val specs2 = "org.specs2" %% "specs2-core" % "4.23.0"
-      val munit = "org.scalameta" %% "munit" % "1.2.4"
+      val munit = "org.scalameta" %% "munit" % "1.3.0"
 
       val scalacheck = "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test"
       val junitIntf = "com.github.sbt" % "junit-interface" % "0.13.3" % "test"
-
-      // JUnit 5 (Jupiter) dependencies
-      val jupiterIntf = "com.github.sbt.junit" % "jupiter-interface" % jupiterInterfaceVersion % "test"
-      val junit5Api = "org.junit.jupiter" % "junit-jupiter-api" % junit5Version % "test"
-      val junit5Engine = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % "test"
-      val junit5Params = "org.junit.jupiter" % "junit-jupiter-params" % junit5Version % "test"
-      // Explicitly pin junit-platform-launcher to match the version bundled by sbt-jupiter-interface
-      val junitPlatformLauncher = "org.junit.platform" % "junit-platform-launcher" % junitPlatformVersion % "test"
 
       val scalatest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
       val scalatestplusScalacheck = "org.scalatestplus" %% "scalacheck-1-19" % (scalaTestVersion + ".0") % "test"
@@ -125,14 +102,27 @@ object Dependencies {
 
   lazy val l = libraryDependencies
 
+  // JUnit 5 dependencies — versions derived from the sbt-jupiter-interface plugin settings
+  lazy val junit5TestDeps: Def.Initialize[Seq[ModuleID]] = Def.setting {
+    Seq(
+      "com.github.sbt.junit" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
+      "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % Test,
+      "org.junit.jupiter" % "junit-jupiter-engine" % JupiterKeys.junitJupiterVersion.value % Test,
+      "org.junit.jupiter" % "junit-jupiter-params" % JupiterKeys.junitJupiterVersion.value % Test,
+      "org.junit.platform" % "junit-platform-launcher" % JupiterKeys.junitPlatformVersion.value % Test
+    )
+  }
+
   lazy val parsing = Seq(
     DependencyHelpers.versionDependentDeps(
       Dependencies.Provided.scalaReflect))
 
-  lazy val httpCore = l ++= Seq(
-    parboiled,
-    Test.sprayJson, // for WS Autobahn test metadata
-    Test.scalatest, Test.scalatestplusScalacheck, Test.scalatestplusJUnit, Test.junit)
+  lazy val httpCore = Seq(
+    l ++= Seq(
+      parboiled,
+      Test.sprayJson, // for WS Autobahn test metadata
+      Test.scalatest, Test.scalatestplusScalacheck, Test.scalatestplusJUnit),
+    libraryDependencies ++= junit5TestDeps.value)
 
   lazy val httpCaching = l ++= Seq(
     caffeine,
@@ -143,19 +133,25 @@ object Dependencies {
 
   lazy val http = Seq()
 
-  lazy val http2Tests = l ++= Seq(Test.h2spec)
+  lazy val http2Tests = Seq(
+    l ++= Seq(Test.h2spec),
+    libraryDependencies ++= junit5TestDeps.value)
 
   lazy val httpTestkit = Seq(
     versionDependentDeps(
       Test.specs2 % "provided; test"),
+    libraryDependencies ++= junit5TestDeps.value,
     l ++= Seq(
       Test.junit, Test.junitIntf, Compile.junit % "provided",
-      Test.scalatest.withConfigurations(Some("provided; test"))))
+      Test.scalatest.withConfigurations(Some("provided; test"))),
+    libraryDependencies += "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % Provided)
 
   lazy val httpTestkitMunit =
     l ++= Seq(Test.munit % "provided; test")
 
-  lazy val httpTests = l ++= Seq(Test.junit, Test.scalatest, Test.junitIntf)
+  lazy val httpTests = Seq(
+    l ++= Seq(Test.scalatest, Test.junitIntf),
+    libraryDependencies ++= junit5TestDeps.value)
 
   lazy val httpXml = Seq(
     versionDependentDeps(scalaXml),
@@ -165,11 +161,17 @@ object Dependencies {
     versionDependentDeps(sprayJson),
     libraryDependencies += Test.scalatest)
 
-  lazy val httpJackson = l ++= Seq(jacksonDatabind, Test.scalatestplusJUnit, Test.junit, Test.junitIntf)
+  lazy val httpJackson = Seq(
+    l ++= Seq(jacksonDatabind, Test.scalatestplusJUnit),
+    libraryDependencies ++= junit5TestDeps.value)
 
-  lazy val httpJackson3 = l ++= Seq(jacksonDatabind3, Test.scalatestplusJUnit, Test.junit, Test.junitIntf)
+  lazy val httpJackson3 = Seq(
+    l ++= Seq(jacksonDatabind3, Test.scalatestplusJUnit),
+    libraryDependencies ++= junit5TestDeps.value)
 
-  lazy val docs = l ++= Seq(Docs.sprayJson, Docs.gson, Docs.jacksonXml, Docs.reflections)
+  lazy val docs = Seq(
+    l ++= Seq(Docs.sprayJson, Docs.gson, Docs.jacksonXml, Docs.reflections),
+    libraryDependencies ++= junit5TestDeps.value)
 }
 
 object DependencyHelpers {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   val jacksonDatabindVersion = "2.21.2"
   val jacksonDatabind3Version = "3.1.2"
   val jacksonXmlVersion = jacksonDatabindVersion
-  val junitVersion = "4.13.2"
+  val junit4Version = "4.13.2"
   val h2specVersion = "2.6.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
@@ -78,6 +78,9 @@ object Dependencies {
 
     object Test {
       val sprayJson = Compile.sprayJson % "test"
+
+      // For pekko-http-testkit-java (JUnit 4 support for library users) -- deprecated since 2.0.0
+      val junit4 = "junit" % "junit" % junit4Version
       val specs2 = "org.specs2" %% "specs2-core" % "4.23.0"
       val munit = "org.scalameta" %% "munit" % "1.3.0"
 
@@ -135,6 +138,7 @@ object Dependencies {
 
   lazy val httpTestkit = Seq(
     versionDependentDeps(
+      Test.junit4,
       Test.specs2 % "provided; test"),
     l ++= junitJupiterTestDeps.value ++ Seq(
       "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % "provided",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,9 +63,6 @@ object Dependencies {
     // For pekko-http-jackson3 support
     val jacksonDatabind3 = "tools.jackson.core" % "jackson-databind" % jacksonDatabind3Version
 
-    // For pekko-http-testkit-java (JUnit 4 support for library users)
-    val junit = "junit" % "junit" % junitVersion
-
     val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % "3.2.3"
 
     val scalafix = "ch.epfl.scala" %% "scalafix-core" % Dependencies.scalafixVersion
@@ -81,12 +78,10 @@ object Dependencies {
 
     object Test {
       val sprayJson = Compile.sprayJson % "test"
-      val junit = Compile.junit % "test"
       val specs2 = "org.specs2" %% "specs2-core" % "4.23.0"
       val munit = "org.scalameta" %% "munit" % "1.3.0"
 
       val scalacheck = "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test"
-      val junitIntf = "com.github.sbt" % "junit-interface" % "0.13.3" % "test"
 
       val scalatest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
       val scalatestplusScalacheck = "org.scalatestplus" %% "scalacheck-1-19" % (scalaTestVersion + ".0") % "test"
@@ -96,20 +91,21 @@ object Dependencies {
 
       val h2spec = ("io.github.summerwind" % h2specName % h2specVersion % "test").from(h2specUrl)
     }
+
   }
 
   import Compile._
 
   lazy val l = libraryDependencies
 
-  // JUnit 5 dependencies — versions derived from the sbt-jupiter-interface plugin settings
-  lazy val junit5TestDeps: Def.Initialize[Seq[ModuleID]] = Def.setting {
+  // JUnit Jupiter dependencies — versions derived from the sbt-jupiter-interface plugin settings
+  lazy val junitJupiterTestDeps: Def.Initialize[Seq[ModuleID]] = Def.setting {
     Seq(
-      "com.github.sbt.junit" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
-      "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % Test,
-      "org.junit.jupiter" % "junit-jupiter-engine" % JupiterKeys.junitJupiterVersion.value % Test,
-      "org.junit.jupiter" % "junit-jupiter-params" % JupiterKeys.junitJupiterVersion.value % Test,
-      "org.junit.platform" % "junit-platform-launcher" % JupiterKeys.junitPlatformVersion.value % Test
+      "com.github.sbt.junit" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % "test",
+      "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % "test",
+      "org.junit.jupiter" % "junit-jupiter-engine" % JupiterKeys.junitJupiterVersion.value % "test",
+      "org.junit.jupiter" % "junit-jupiter-params" % JupiterKeys.junitJupiterVersion.value % "test",
+      "org.junit.platform" % "junit-platform-launcher" % JupiterKeys.junitPlatformVersion.value % "test"
     )
   }
 
@@ -122,7 +118,7 @@ object Dependencies {
       parboiled,
       Test.sprayJson, // for WS Autobahn test metadata
       Test.scalatest, Test.scalatestplusScalacheck, Test.scalatestplusJUnit),
-    libraryDependencies ++= junit5TestDeps.value)
+    libraryDependencies ++= junitJupiterTestDeps.value)
 
   lazy val httpCaching = l ++= Seq(
     caffeine,
@@ -135,23 +131,20 @@ object Dependencies {
 
   lazy val http2Tests = Seq(
     l ++= Seq(Test.h2spec),
-    libraryDependencies ++= junit5TestDeps.value)
+    libraryDependencies ++= junitJupiterTestDeps.value)
 
   lazy val httpTestkit = Seq(
     versionDependentDeps(
       Test.specs2 % "provided; test"),
-    libraryDependencies ++= junit5TestDeps.value,
-    l ++= Seq(
-      Test.junit, Test.junitIntf, Compile.junit % "provided",
-      Test.scalatest.withConfigurations(Some("provided; test"))),
-    libraryDependencies += "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % Provided)
+    l ++= junitJupiterTestDeps.value ++ Seq(
+      "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % "provided",
+      Test.scalatest.withConfigurations(Some("provided; test"))))
 
   lazy val httpTestkitMunit =
     l ++= Seq(Test.munit % "provided; test")
 
   lazy val httpTests = Seq(
-    l ++= Seq(Test.scalatest, Test.junitIntf),
-    libraryDependencies ++= junit5TestDeps.value)
+    l ++= junitJupiterTestDeps.value ++ Seq(Test.scalatest))
 
   lazy val httpXml = Seq(
     versionDependentDeps(scalaXml),
@@ -163,15 +156,15 @@ object Dependencies {
 
   lazy val httpJackson = Seq(
     l ++= Seq(jacksonDatabind, Test.scalatestplusJUnit),
-    libraryDependencies ++= junit5TestDeps.value)
+    libraryDependencies ++= junitJupiterTestDeps.value)
 
   lazy val httpJackson3 = Seq(
     l ++= Seq(jacksonDatabind3, Test.scalatestplusJUnit),
-    libraryDependencies ++= junit5TestDeps.value)
+    libraryDependencies ++= junitJupiterTestDeps.value)
 
   lazy val docs = Seq(
     l ++= Seq(Docs.sprayJson, Docs.gson, Docs.jacksonXml, Docs.reflections),
-    libraryDependencies ++= junit5TestDeps.value)
+    libraryDependencies ++= junitJupiterTestDeps.value)
 }
 
 object DependencyHelpers {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,13 +18,26 @@ import scala.language.implicitConversions
 object Dependencies {
   import DependencyHelpers._
 
+  // Versions derived from sbt-jupiter-interface plugin (avoids hardcoding JUnit 5/platform versions)
+  private def readResourceProperty(resource: String, property: String): String = {
+    val props = new java.util.Properties
+    val stream = getClass.getClassLoader.getResourceAsStream(resource)
+    if (stream eq null)
+      throw new RuntimeException(s"Could not find classpath resource '$resource'. Is sbt-jupiter-interface on the plugin classpath?")
+    try props.load(stream)
+    catch { case e: Exception => throw new RuntimeException(s"Failed to load '$resource': ${e.getMessage}", e) }
+    finally stream.close()
+    Option(props.getProperty(property))
+      .getOrElse(throw new RuntimeException(s"Property '$property' not found in '$resource'"))
+  }
+  val jupiterInterfaceVersion: String = readResourceProperty("jupiter-interface.properties", "version")
+  val junit5Version: String = readResourceProperty("jupiter-interface.properties", "junit.jupiter.version")
+  val junitPlatformVersion: String = readResourceProperty("jupiter-interface.properties", "junit.platform.version")
+
   val jacksonDatabindVersion = "2.21.2"
-  val jacksonDatabind3Version = "3.1.2"
+  val jacksonDatabind3Version = "3.1.1"
   val jacksonXmlVersion = jacksonDatabindVersion
   val junitVersion = "4.13.2"
-  // sbt-jupiter-interface 0.11.0 requires JUnit 5.9.x; using 5.9.3 for compatibility
-  val junit5Version = "5.14.3"
-  val junitPlatformVersion = "1.14.3"
   val h2specVersion = "2.6.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
@@ -65,11 +78,8 @@ object Dependencies {
     // For pekko-http-jackson3 support
     val jacksonDatabind3 = "tools.jackson.core" % "jackson-databind" % jacksonDatabind3Version
 
-    // For pekko-http-testkit-java (JUnit 4 support for library users)
+    // For pekko-http-testkit-java
     val junit = "junit" % "junit" % junitVersion
-
-    // For pekko-http-testkit-java (JUnit 5 support for library users)
-    val junit5Api = "org.junit.jupiter" % "junit-jupiter-api" % junit5Version
 
     val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % "3.2.3"
 
@@ -88,19 +98,18 @@ object Dependencies {
       val sprayJson = Compile.sprayJson % "test"
       val junit = Compile.junit % "test"
       val specs2 = "org.specs2" %% "specs2-core" % "4.23.0"
-      val munit = "org.scalameta" %% "munit" % "1.3.0"
+      val munit = "org.scalameta" %% "munit" % "1.2.4"
 
       val scalacheck = "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test"
       val junitIntf = "com.github.sbt" % "junit-interface" % "0.13.3" % "test"
 
-      // JUnit 5 (Jupiter) dependencies for running tests
-      val junit5Api = Compile.junit5Api % "test"
+      // JUnit 5 (Jupiter) dependencies
+      val jupiterIntf = "com.github.sbt.junit" % "jupiter-interface" % jupiterInterfaceVersion % "test"
+      val junit5Api = "org.junit.jupiter" % "junit-jupiter-api" % junit5Version % "test"
       val junit5Engine = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % "test"
       val junit5Params = "org.junit.jupiter" % "junit-jupiter-params" % junit5Version % "test"
-      val jupiterIntf = "net.aichler" % "jupiter-interface" % "0.11.1" % "test"
-      // Override platform-launcher to match our JUnit 5 version (jupiter-interface 0.11.1 pulls 1.9.1)
-      val junitPlatformLauncher =
-        "org.junit.platform" % "junit-platform-launcher" % junitPlatformVersion % "test"
+      // Explicitly pin junit-platform-launcher to match the version bundled by sbt-jupiter-interface
+      val junitPlatformLauncher = "org.junit.platform" % "junit-platform-launcher" % junitPlatformVersion % "test"
 
       val scalatest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
       val scalatestplusScalacheck = "org.scalatestplus" %% "scalacheck-1-19" % (scalaTestVersion + ".0") % "test"
@@ -123,8 +132,7 @@ object Dependencies {
   lazy val httpCore = l ++= Seq(
     parboiled,
     Test.sprayJson, // for WS Autobahn test metadata
-    Test.scalatest, Test.scalatestplusScalacheck, Test.scalatestplusJUnit,
-    Test.junit5Api, Test.junit5Engine, Test.jupiterIntf, Test.junitPlatformLauncher)
+    Test.scalatest, Test.scalatestplusScalacheck, Test.scalatestplusJUnit, Test.junit)
 
   lazy val httpCaching = l ++= Seq(
     caffeine,
@@ -135,22 +143,19 @@ object Dependencies {
 
   lazy val http = Seq()
 
-  lazy val http2Tests = l ++= Seq(Test.h2spec,
-    Test.junit5Api, Test.junit5Engine, Test.jupiterIntf, Test.junitPlatformLauncher)
+  lazy val http2Tests = l ++= Seq(Test.h2spec)
 
   lazy val httpTestkit = Seq(
     versionDependentDeps(
       Test.specs2 % "provided; test"),
     l ++= Seq(
-      Test.junit5Api, Test.junit5Engine, Test.jupiterIntf, Test.junitPlatformLauncher,
-      Test.junit, Test.junitIntf, Compile.junit % "provided", Compile.junit5Api % "provided",
+      Test.junit, Test.junitIntf, Compile.junit % "provided",
       Test.scalatest.withConfigurations(Some("provided; test"))))
 
   lazy val httpTestkitMunit =
     l ++= Seq(Test.munit % "provided; test")
 
-  lazy val httpTests = l ++=
-    Seq(Test.junit5Api, Test.junit5Engine, Test.jupiterIntf, Test.junitPlatformLauncher, Test.scalatest, Test.junitIntf)
+  lazy val httpTests = l ++= Seq(Test.junit, Test.scalatest, Test.junitIntf)
 
   lazy val httpXml = Seq(
     versionDependentDeps(scalaXml),
@@ -160,14 +165,11 @@ object Dependencies {
     versionDependentDeps(sprayJson),
     libraryDependencies += Test.scalatest)
 
-  lazy val httpJackson = l ++= Seq(jacksonDatabind, Test.scalatestplusJUnit,
-    Test.junit5Api, Test.junit5Engine, Test.jupiterIntf, Test.junitPlatformLauncher)
+  lazy val httpJackson = l ++= Seq(jacksonDatabind, Test.scalatestplusJUnit, Test.junit, Test.junitIntf)
 
-  lazy val httpJackson3 = l ++= Seq(jacksonDatabind3, Test.scalatestplusJUnit,
-    Test.junit5Api, Test.junit5Engine, Test.jupiterIntf, Test.junitPlatformLauncher)
+  lazy val httpJackson3 = l ++= Seq(jacksonDatabind3, Test.scalatestplusJUnit, Test.junit, Test.junitIntf)
 
-  lazy val docs = l ++= Seq(Docs.sprayJson, Docs.gson, Docs.jacksonXml, Docs.reflections,
-    Test.junit5Api, Test.junit5Engine, Test.jupiterIntf, Test.junitPlatformLauncher)
+  lazy val docs = l ++= Seq(Docs.sprayJson, Docs.gson, Docs.jacksonXml, Docs.reflections)
 }
 
 object DependencyHelpers {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -120,8 +120,9 @@ object Dependencies {
     l ++= Seq(
       parboiled,
       Test.sprayJson, // for WS Autobahn test metadata
-      Test.scalatest, Test.scalatestplusScalacheck, Test.scalatestplusJUnit),
-    libraryDependencies ++= junitJupiterTestDeps.value)
+      Test.scalatest,
+      Test.scalatestplusScalacheck,
+      Test.scalatestplusJUnit) ++ junitJupiterTestDeps.value)
 
   lazy val httpCaching = l ++= Seq(
     caffeine,
@@ -133,16 +134,15 @@ object Dependencies {
   lazy val http = Seq()
 
   lazy val http2Tests = Seq(
-    l ++= Seq(Test.h2spec),
-    libraryDependencies ++= junitJupiterTestDeps.value)
+    l ++= Seq(Test.h2spec) ++ junitJupiterTestDeps.value)
 
   lazy val httpTestkit = Seq(
     versionDependentDeps(
       Test.junit4,
       Test.specs2 % "provided; test"),
-    l ++= junitJupiterTestDeps.value ++ Seq(
+    l ++= Seq(
       "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % "provided",
-      Test.scalatest.withConfigurations(Some("provided; test"))))
+      Test.scalatest.withConfigurations(Some("provided; test"))) ++ junitJupiterTestDeps.value)
 
   lazy val httpTestkitMunit =
     l ++= Seq(Test.munit % "provided; test")
@@ -159,16 +159,17 @@ object Dependencies {
     libraryDependencies += Test.scalatest)
 
   lazy val httpJackson = Seq(
-    l ++= Seq(jacksonDatabind, Test.scalatestplusJUnit),
-    libraryDependencies ++= junitJupiterTestDeps.value)
+    l ++= Seq(jacksonDatabind, Test.scalatestplusJUnit) ++ junitJupiterTestDeps.value)
 
   lazy val httpJackson3 = Seq(
-    l ++= Seq(jacksonDatabind3, Test.scalatestplusJUnit),
-    libraryDependencies ++= junitJupiterTestDeps.value)
+    l ++= Seq(jacksonDatabind3, Test.scalatestplusJUnit) ++ junitJupiterTestDeps.value)
 
   lazy val docs = Seq(
-    l ++= Seq(Docs.sprayJson, Docs.gson, Docs.jacksonXml, Docs.reflections),
-    libraryDependencies ++= junitJupiterTestDeps.value)
+    l ++= Seq(
+      Docs.sprayJson,
+      Docs.gson,
+      Docs.jacksonXml,
+      Docs.reflections) ++ junitJupiterTestDeps.value)
 }
 
 object DependencyHelpers {


### PR DESCRIPTION
## Summary

Removes the hardcoded version numbers for `junit-platform-launcher` and `junit5Version` from `project/Dependencies.scala`. Instead, both are now derived at build time via the `SettingKey`s that the `sbt-jupiter-interface` plugin already exposes — ensuring they always stay in sync with the plugin.

Deprecates Junit 4 supporting classes.

## Changes

### `project/Dependencies.scala`
- Import `JupiterKeys` from `com.github.sbt.junit.jupiter.sbt.Import` (available on the meta-build classpath via `addSbtPlugin`)
- Add `lazy val junit5TestDeps: Def.Initialize[Seq[ModuleID]] = Def.setting { ... }` that reads versions from the plugin's own `SettingKey`s: `JupiterKeys.jupiterVersion`, `JupiterKeys.junitJupiterVersion`, and `JupiterKeys.junitPlatformVersion`
- Replace old `net.aichler:jupiter-interface:0.11.1` with `com.github.sbt.junit:jupiter-interface` (current artifact coordinates), version also derived from the plugin
- Update all subproject dependency settings (`httpCore`, `http2Tests`, `httpTestkit`, `httpTests`, `httpJackson`, `httpJackson3`, `docs`) to use `libraryDependencies ++= junit5TestDeps.value`

## How it works

`JupiterPlugin` exposes the JUnit versions it was built against as SBT `SettingKey`s (see [`JupiterPlugin.scala` line 37](https://github.com/sbt/sbt-jupiter-interface/blob/7391c5ae6ef7b6a9610fd7d628999c98cc5ea022/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala#L37)):

```scala
junitPlatformVersion := readResourceProperty("jupiter-interface.properties", "junit.platform.version"),
junitJupiterVersion  := readResourceProperty("jupiter-interface.properties", "junit.jupiter.version"),
jupiterVersion       := readResourceProperty("jupiter-interface.properties", "version"),
```

Since the plugin is on the meta-build classpath, `project/Dependencies.scala` can import `JupiterKeys` and use those settings directly inside a `Def.setting { }` block — the same way SBT's own setting graph works — rather than duplicating the resource-reading logic.