### PR TITLE
add config support for RouteTestTimeout via application.conf

### DIFF
--- a/http-testkit/src/main/resources/reference.conf
+++ b/http-testkit/src/main/resources/reference.conf
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 pekko.http.testkit.marshalling.timeout = 1 s
+pekko.http.testkit.routes.timeout = 1 s

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestTimeout.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestTimeout.scala
@@ -8,7 +8,7 @@
  */
 
 /*
- * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package org.apache.pekko.http.scaladsl.testkit
@@ -17,10 +17,13 @@ import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.actor.ActorSystem
-import pekko.testkit._
+import pekko.http.impl.util.enhanceConfig
 
 case class RouteTestTimeout(duration: FiniteDuration)
 
 object RouteTestTimeout {
-  implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(1.second.dilated)
+  implicit def default(implicit system: ActorSystem): RouteTestTimeout = {
+    val routesTimeout = system.settings.config.getFiniteDuration("pekko.http.testkit.routes.timeout")
+    RouteTestTimeout(routesTimeout)
+  }
 }


### PR DESCRIPTION
This PR add support to changing the RouteTestTimeout with providing the override of the `pekko.http.testkit.routes.timeout` from the typesafe config, in this way we can change the default timeout directly from the configuration instead of overriding the timeout directly from the code.

This is based on https://github.com/akka/akka-http/pull/4239 which is now available under the Apache License.
https://github.com/akka/akka-http/releases/tag/v10.5.1

