### PR TITLE
Avoid unnecessary ByteString concat for strict HTTP/2 entities

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
@@ -358,7 +358,10 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
       extraInitialWindow: Int) extends ReceivingData {
 
     override protected def onDataFrame(dataFrame: DataFrame): StreamState = {
-      val newData = collectedData ++ dataFrame.payload
+      val newData =
+        if (collectedData.isEmpty) dataFrame.payload
+        else if (dataFrame.payload.isEmpty) collectedData
+        else collectedData ++ dataFrame.payload
 
       if (dataFrame.endStream) {
         totalBufferedData -= newData.length


### PR DESCRIPTION
Motivation:
HTTP/2 DATA aggregation for small strict request entities may concatenate an empty `ByteString` with the incoming payload. That adds unnecessary work and allocation on unary/small-request gRPC-like paths without changing stream semantics.

Modification:
- keep the existing collecting state machine
- avoid `collectedData ++ payload` when either side is empty

Result:
The first DATA frame on the strict collection path now reuses the existing payload reference instead of allocating a concatenated `ByteString`. Non-empty aggregation behavior is unchanged.

Verification:
- `sbt "http-core / scalafmtCheck" "http2-tests / Test / testOnly org.apache.pekko.http.impl.engine.http2.Http2ServerSpec -- -z collect"`

Risk / Boundary:
- HTTP/2 stream state transitions are unchanged
- the change is limited to the empty/non-empty `ByteString` boundary
- existing HTTP/2 collection tests pass