### PR TITLE
fix: nightly YAML multiline run command starts sbt without tasks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,11 +57,11 @@ jobs:
         run: sbt -Dpekko.build.pekko.version=${{ matrix.PEKKO_VERSION }} "++ ${{ matrix.SCALA_VERSION }}" Test/compile
 
       - name: Run all tests JDK ${{ matrix.JDK }}, Scala ${{ matrix.SCALA_VERSION }}, Pekko ${{ matrix.PEKKO_VERSION }}, TLS Engine ${{ matrix.TLS_ENGINE_CONFIG }}
-        run: |
-          sbt -Dpekko.http.parallelExecution=false -Dpekko.test.timefactor=2 
-            -Dpekko.build.pekko.version=${{ matrix.PEKKO_VERSION }}
-            -DTLS_ENGINE_CONFIG=${{ matrix.TLS_ENGINE_CONFIG }}
-            "++ ${{ matrix.SCALA_VERSION }}" mimaReportBinaryIssues test
+        run: >
+          sbt -Dpekko.http.parallelExecution=false -Dpekko.test.timefactor=2
+          -Dpekko.build.pekko.version=${{ matrix.PEKKO_VERSION }}
+          -DTLS_ENGINE_CONFIG=${{ matrix.TLS_ENGINE_CONFIG }}
+          "++ ${{ matrix.SCALA_VERSION }}" mimaReportBinaryIssues test
 
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

After #1030, the nightly job hangs for 5+ hours per matrix entry until canceled (e.g. [run 25588927669](https://github.com/apache/pekko-http/actions/runs/25588927669)).

The `run: |` literal block scalar turns each indented line into a **separate shell command**, so:

1. The first line `sbt -Dpekko.http.parallelExecution=false -Dpekko.test.timefactor=2 ` runs sbt with **no tasks** and drops into the interactive REPL — the job hangs here until the workflow timeout.
2. The following `-Dpekko.build.pekko.version=...`, `-DTLS_ENGINE_CONFIG=...`, and `"++ ..." mimaReportBinaryIssues test` lines are dispatched as separate shell commands and never reach sbt.

The hung-job logs match exactly: `sbt server started` followed by long silence and `[gc] Pause Full (System.gc())`.

## Fix

Switch the block scalar from `|` (literal, preserves newlines) to `>` (folded, joins lines with spaces) so the whole sbt invocation runs as a single command. Also drop the trailing whitespace on the first line.

```yaml
run: >
  sbt -Dpekko.http.parallelExecution=false -Dpekko.test.timefactor=2
  -Dpekko.build.pekko.version=${{ matrix.PEKKO_VERSION }}
  -DTLS_ENGINE_CONFIG=${{ matrix.TLS_ENGINE_CONFIG }}
  "++ ${{ matrix.SCALA_VERSION }}" mimaReportBinaryIssues test
```

Verified locally — the YAML now parses to a single-line command:

```
sbt -Dpekko.http.parallelExecution=false -Dpekko.test.timefactor=2 -Dpekko.build.pekko.version=... -DTLS_ENGINE_CONFIG=... "++ ..." mimaReportBinaryIssues test
```

## Test plan

- [ ] Wait for next nightly run (or trigger manually) and confirm jobs complete in normal time instead of timing out at 6h.