### PR TITLE
Replace Scala string interpolation in log calls with lazy {} placeholder format

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientDecodingExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientDecodingExampleSpec.scala
@@ -50,7 +50,7 @@ class HttpClientDecodingExampleSpec extends PekkoSpec with CompileOnlySpec with 
         case HttpEncodings.identity =>
           Coders.NoCoding
         case other =>
-          log.warning(s"Unknown encoding [$other], not decoding")
+          log.warning("Unknown encoding [{}], not decoding", other)
           Coders.NoCoding
       }
 
@@ -61,7 +61,7 @@ class HttpClientDecodingExampleSpec extends PekkoSpec with CompileOnlySpec with 
       Future.traverse(requests)(http.singleRequest(_).map(decodeResponse))
 
     futureResponses.futureValue.foreach { resp =>
-      system.log.info(s"response is ${resp.toStrict(1.second).futureValue}")
+      system.log.info("response is {}", resp.toStrict(1.second).futureValue)
     }
 
     system.terminate()

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorInteraction.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorInteraction.scala
@@ -45,7 +45,7 @@ object HttpServerWithActorInteraction {
 
     def apply(bids: List[Bid]): Behaviors.Receive[Message] = Behaviors.receive {
       case (ctx, bid @ Bid(userId, offer)) =>
-        ctx.log.info(s"Bid complete: $userId, $offer")
+        ctx.log.info("Bid complete: {}, {}", userId, offer)
         apply(bids :+ bid)
       case (_, GetBids(replyTo)) =>
         replyTo ! Bids(bids)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/HttpsProxyGraphStage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/HttpsProxyGraphStage.scala
@@ -150,7 +150,7 @@ private final class HttpsProxyGraphStage(
                     }
                     parser.onUpstreamFinish()
 
-                    log.debug(s"HTTP(S) proxy connection to {}:{} established. Now forwarding data.", targetHostName,
+                    log.debug("HTTP(S) proxy connection to {}:{} established. Now forwarding data.", targetHostName,
                       targetPort)
 
                     state = Connected

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -107,7 +107,7 @@ private[http] object OutgoingConnectionBlueprint {
       val terminationFanout = b.add(Broadcast[HttpResponse](2))
 
       val logger =
-        b.add(Flow[ByteString].mapError { case t => log.debug(s"Outgoing request stream error {}", t); t }.named(
+        b.add(Flow[ByteString].mapError { case t => log.debug("Outgoing request stream error {}", t); t }.named(
           "errorLogger"))
       val wrapTls = b.add(Flow[ByteString].map(SendBytes(_)))
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -629,7 +629,7 @@ private[client] object NewHostConnectionPool {
         }
         override def postStop(): Unit = {
           slots.foreach(_.shutdown())
-          log.debug(s"Pool stopped")
+          log.debug("Pool stopped")
         }
 
         private def willClose(response: HttpResponse): Boolean =

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
@@ -154,8 +154,8 @@ private[http2] object PersistentConnection {
             } else {
               setHandler(requestIn, Unconnected)
               if (baseEmbargo == Duration.Zero) {
-                log.info(s"Connection attempt failed: ${cause.getMessage}. Trying to connect again${connectsLeft.map(
-                    n => s" ($n attempts left)").getOrElse("")}.")
+                log.info("Connection attempt failed: {}. Trying to connect again{}.", cause.getMessage,
+                    connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
                 connect(connectsLeft, Duration.Zero)
               } else {
                 val embargo = lastEmbargo match {
@@ -165,9 +165,9 @@ private[http2] object PersistentConnection {
                 val minMillis = embargo.toMillis
                 val maxMillis = minMillis * 2
                 val backoff = ThreadLocalRandom.current().nextLong(minMillis, maxMillis).millis
-                log.info(
-                  s"Connection attempt failed: ${cause.getMessage}. Trying to connect again after backoff ${PrettyDuration.format(
-                      backoff)} ${connectsLeft.map(n => s" ($n attempts left)").getOrElse("")}.")
+                log.info("Connection attempt failed: {}. Trying to connect again after backoff {} {}.",
+                    cause.getMessage, PrettyDuration.format(backoff),
+                    connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
                 scheduleOnce(EmbargoEnded(connectsLeft, embargo), backoff)
               }
             }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
@@ -154,8 +154,9 @@ private[http2] object PersistentConnection {
             } else {
               setHandler(requestIn, Unconnected)
               if (baseEmbargo == Duration.Zero) {
-                log.info("Connection attempt failed: {}. Trying to connect again{}.", cause.getMessage,
-                    connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
+                if (log.isInfoEnabled)
+                  log.info("Connection attempt failed: {}. Trying to connect again{}.", cause.getMessage,
+                      connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
                 connect(connectsLeft, Duration.Zero)
               } else {
                 val embargo = lastEmbargo match {
@@ -165,9 +166,10 @@ private[http2] object PersistentConnection {
                 val minMillis = embargo.toMillis
                 val maxMillis = minMillis * 2
                 val backoff = ThreadLocalRandom.current().nextLong(minMillis, maxMillis).millis
-                log.info("Connection attempt failed: {}. Trying to connect again after backoff {} {}.",
-                    cause.getMessage, PrettyDuration.format(backoff),
-                    connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
+                if (log.isInfoEnabled)
+                  log.info("Connection attempt failed: {}. Trying to connect again after backoff {} {}.",
+                      cause.getMessage, PrettyDuration.format(backoff),
+                      connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
                 scheduleOnce(EmbargoEnded(connectsLeft, embargo), backoff)
               }
             }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
@@ -156,7 +156,7 @@ private[http2] object PersistentConnection {
               if (baseEmbargo == Duration.Zero) {
                 if (log.isInfoEnabled)
                   log.info("Connection attempt failed: {}. Trying to connect again{}.", cause.getMessage,
-                      connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
+                    connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
                 connect(connectsLeft, Duration.Zero)
               } else {
                 val embargo = lastEmbargo match {
@@ -168,8 +168,8 @@ private[http2] object PersistentConnection {
                 val backoff = ThreadLocalRandom.current().nextLong(minMillis, maxMillis).millis
                 if (log.isInfoEnabled)
                   log.info("Connection attempt failed: {}. Trying to connect again after backoff {} {}.",
-                      cause.getMessage, PrettyDuration.format(backoff),
-                      connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
+                    cause.getMessage, PrettyDuration.format(backoff),
+                    connectsLeft.map(n => s" ($n attempts left)").getOrElse(""))
                 scheduleOnce(EmbargoEnded(connectsLeft, embargo), backoff)
               }
             }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -189,7 +189,7 @@ private[engine] final class HttpHeaderParser private (
         case (c, IllegalResponseHeaderNameProcessingMode.Error) =>
           fail(s"Illegal character '${escape(c)}' in header name")
         case (c, IllegalResponseHeaderNameProcessingMode.Warn) =>
-          log.warning(s"Header key contains illegal character '${escape(c)}'")
+          log.warning("Header key contains illegal character '{}'", escape(c))
           scanHeaderNameAndReturnIndexOfColon(input, start, limit)(ix + 1)
         case (c, IllegalResponseHeaderNameProcessingMode.Ignore) =>
           scanHeaderNameAndReturnIndexOfColon(input, start, limit)(ix + 1)
@@ -649,7 +649,7 @@ private[http] object HttpHeaderParser {
                   fail(s"Illegal character '${escape(c)}' in header value")
                 case IllegalResponseHeaderValueProcessingMode.Warn =>
                   // ignore the illegal character and log a warning message
-                  log.warning(s"Illegal character '${escape(c)}' in header value")
+                  log.warning("Illegal character '{}' in header value", escape(c))
                   sb
                 case IllegalResponseHeaderValueProcessingMode.Ignore =>
                   // just ignore the illegal character

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -228,10 +228,10 @@ private[http] object StreamUtils {
         override def onDownstreamFinish(cause: Throwable): Unit = {
           cancelAfter match {
             case finite: FiniteDuration =>
-              log.debug(s"Delaying cancellation for $finite")
+              log.debug("Delaying cancellation for {}", finite)
               timeout = OptionVal.Some {
                 scheduleOnce(finite) {
-                  log.debug(s"Stage was canceled after delay of $cancelAfter")
+                  log.debug("Stage was canceled after delay of {}", cancelAfter)
                   timeout = OptionVal.None
                   completeStage()
                 }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
@@ -176,7 +176,7 @@ package util {
       new Receive {
         def isDefinedAt(x: Any): Boolean = r.isDefinedAt(x)
         def apply(x: Any): Unit = {
-          log.debug(s"[$mark] received: $x")
+          log.debug("[{}] received: {}", mark, x)
           r(x)
         }
       }

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -880,7 +880,7 @@ class HostConnectionPoolSpec extends PekkoSpecWithMaterializer(
             connectionProbe.ref ! serverConnection
           })
           .run().awaitResult(3.seconds)
-      system.log.debug(s"Server bound to [${serverBinding.localAddress}]")
+      system.log.debug("Server bound to [{}]", serverBinding.localAddress)
 
       // needs to be an involved two step process:
       //   1. setup client flow and proxies on the server side to be able to return that flow immediately

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
@@ -643,7 +643,7 @@ abstract class ClientServerSpecBase(http2: Boolean) extends PekkoSpecWithMateria
         Http().singleRequest(request(i), settings = clientSettings).futureValue
           .entity.dataBytes.runFold(ByteString.empty) { (prev, cur) =>
             val res = prev ++ cur
-            system.log.debug(s"Received ${res.size} of [${res.take(1).utf8String}]")
+            system.log.debug("Received {} of [{}]", res.size, res.take(1).utf8String)
             res
           }.futureValue
           .size shouldBe responseSize

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/GracefulTerminationSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/GracefulTerminationSpec.scala
@@ -232,7 +232,7 @@ class GracefulTerminationSpec
                   conn.onComplete {
                     case Success(s)  => result.trySuccess(s)
                     case Failure(ex) =>
-                      log.debug(s"Delaying failure ${ex.getMessage}")
+                      log.debug("Delaying failure {}", ex.getMessage)
                       system.scheduler.scheduleOnce(100.millis)(result.tryFailure(ex))
                   }
                   result.future

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -84,11 +84,11 @@ abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String
   private def handleResponse(httpResp: Try[HttpResponse], id: Int): Unit = {
     httpResp match {
       case Success(httpRes) =>
-        system.log.error(s"$id: OK: (${httpRes.status.intValue}")
+        system.log.error("{}: OK: ({}", id, httpRes.status.intValue)
         httpRes.entity.dataBytes.runWith(Sink.ignore)
 
       case Failure(ex) =>
-        system.log.debug(s"$id: FAIL $ex") // this is what we expect
+        system.log.debug("{}: FAIL {}", id, ex) // this is what we expect
     }
   }
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -271,8 +271,8 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
     val canonicalFinalPath = finalFile.getCanonicalPath
 
     if (!canonicalFinalPath.startsWith(baseFile.getCanonicalPath)) {
-      log.warning(s"[$finalFile] points to a location that is not part of [$baseFile]. This might be a directory " +
-        "traversal attempt.")
+      log.warning("[{}] points to a location that is not part of [{}]. This might be a directory traversal attempt.",
+        finalFile, baseFile)
       ""
     } else canonicalFinalPath
   }

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -311,7 +311,7 @@ class H2SpecIntegrationSpec extends PekkoFreeSpec(
           "-j", junitOutput.getPath) ++
         specSectionNumber.toList.map(number => s"http2/$number")
 
-      log.debug(s"Executing h2spec: $command")
+      log.debug("Executing h2spec: {}", command)
       val aggregateTckLogs = ProcessLogger(
         out => {
           if (out.contains("All tests passed")) ()


### PR DESCRIPTION
and other changes to make the interpolation lazy