### PR TITLE
Add -Yfuture-lazy-vals for Scala 3 builds

### DIFF
--- a/http/src/main/mima-filters/2.0.x.backwards.excludes/scala3-future-lazy-vals-clinit.excludes
+++ b/http/src/main/mima-filters/2.0.x.backwards.excludes/scala3-future-lazy-vals-clinit.excludes
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Scala 3's -Yfuture-lazy-vals flag changes the bytecode generated for object
+# lazy vals, removing the synthetic <clinit> methods present in the 1.0.0
+# baseline. These are compiler-internal initialization methods and are not
+# part of the public API, so the change is binary compatible in practice.
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.server.Directives.<clinit>")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.server.PathMatchers.<clinit>")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.server.directives.PathDirectives.<clinit>")

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -34,8 +34,9 @@ object Common extends AutoPlugin {
       // In all other cases, the warning is non-actionable: you get spurious warnings that need to be suppressed
       // verbosely. So, opt out of those in general.
       "-Wconf:cat=other-match-analysis&msg=match may not be exhaustive:s")).value,
-    scalacOptions ++= onlyOnScala3(Seq("-Wconf:cat=deprecation:s")).value,
-    scalacOptions ++= onlyOnScala3(Seq("-Yfuture-lazy-vals")).value,
+    scalacOptions ++= onlyOnScala3(Seq(
+      "-Wconf:cat=deprecation:s",
+      "-Yfuture-lazy-vals")).value,
     javacOptions ++=
       Seq("-encoding", "UTF-8", "--release", javacTarget),
     mimaReportSignatureProblems := true,

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -35,6 +35,7 @@ object Common extends AutoPlugin {
       // verbosely. So, opt out of those in general.
       "-Wconf:cat=other-match-analysis&msg=match may not be exhaustive:s")).value,
     scalacOptions ++= onlyOnScala3(Seq("-Wconf:cat=deprecation:s")).value,
+    scalacOptions ++= onlyOnScala3(Seq("-Yfuture-lazy-vals")).value,
     javacOptions ++=
       Seq("-encoding", "UTF-8", "--release", javacTarget),
     mimaReportSignatureProblems := true,


### PR DESCRIPTION
### Motivation

The Scala 3.3.8 compiler introduced the `-Yfuture-lazy-vals` flag ([scala/scala3-lts#637](https://github.com/scala/scala3-lts/pull/637)) to optionally use `VarHandle` instead of `sun.misc.Unsafe` for lazy val implementation. This prepares libraries for upcoming JDK releases that restrict `sun.misc.Unsafe` access.

### Modification

Add `-Yfuture-lazy-vals` to `Common.scala` scalacOptions using the existing `onlyOnScala3` helper:

```scala
scalacOptions ++= onlyOnScala3(Seq("-Yfuture-lazy-vals")).value,
```

### Result

pekko-http's Scala 3 build uses the future-proof `VarHandle`-based lazy val implementation, compatible with all JDK 9+ versions.

### Tests

- `sbt "++3.3.8; http/compile"` — passed (exit 0, 66s, only pre-existing warnings)

### References

Refs scala/scala3-lts#637