### PR TITLE
chore: Rewrite to scala3 syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version                                  = 3.11.1
-runner.dialect                           = scala213
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -73,3 +73,13 @@ rewriteTokens          = {
 }
 project.excludeFilters = []
 project.layout         = StandardConvention
+
+rewrite.scala3.convertToNewSyntax = true
+runner {
+  dialectOverride {
+    allowSignificantIndentation = false
+    allowAsForImportRename = false
+    allowStarWildcardImport = false
+    allowPostfixStarVarargSplices = false
+  }
+}

--- a/docs/src/test/scala/docs/ApiMayChangeDocCheckerSpec.scala
+++ b/docs/src/test/scala/docs/ApiMayChangeDocCheckerSpec.scala
@@ -29,7 +29,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class ApiMayChangeDocCheckerSpec extends AnyWordSpec with Matchers {
 
-  def prettifyName(clazz: Class[_]): String = {
+  def prettifyName(clazz: Class[?]): String = {
     clazz.getCanonicalName.replaceAll("\\$minus", "-").split("\\$")(0)
   }
 
@@ -65,7 +65,7 @@ class ApiMayChangeDocCheckerSpec extends AnyWordSpec with Matchers {
     try {
       val docPage = source.getLines().toList
       "contain all ApiMayChange references in classes" in {
-        val classes: mutable.Set[Class[_]] = reflections.getTypesAnnotatedWith(classOf[ApiMayChange], true).asScala
+        val classes: mutable.Set[Class[?]] = reflections.getTypesAnnotatedWith(classOf[ApiMayChange], true).asScala
         val missing = classes
           .map(prettifyName)
           .foldLeft(Set.empty[String])(collectMissing(docPage))

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorsSample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorsSample.scala
@@ -103,7 +103,7 @@ object HttpServerWithActorsSample {
   import scala.concurrent.Future
 
   class JobRoutes(buildJobRepository: ActorRef[JobRepository.Command])(
-      implicit system: ActorSystem[_]) extends JsonSupport {
+      implicit system: ActorSystem[?]) extends JsonSupport {
 
     import pekko.actor.typed.scaladsl.AskPattern.schedulerFromActorSystem
     import pekko.actor.typed.scaladsl.AskPattern.Askable

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExample.scala
@@ -34,7 +34,7 @@ import scala.io.StdIn
 object SprayJsonExample {
 
   // needed to run the route
-  implicit val system: ActorSystem[_] = ActorSystem(Behaviors.empty, "SprayExample")
+  implicit val system: ActorSystem[?] = ActorSystem(Behaviors.empty, "SprayExample")
   // needed for the future map/flatmap in the end and future in fetchItem and saveOrder
   implicit val executionContext: ExecutionContext = system.executionContext
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/TestKitWithActorSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/TestKitWithActorSpec.scala
@@ -46,7 +46,7 @@ class TestKitWithActorSpec extends AnyWordSpec with Matchers with ScalatestRoute
   // This test does not use the classic APIs,
   // so it needs to adapt the system:
   import pekko.actor.typed.scaladsl.adapter._
-  implicit val typedSystem: ActorSystem[_] = system.toTyped
+  implicit val typedSystem: ActorSystem[?] = system.toTyped
   implicit val timeout: Timeout = Timeout(500.milliseconds)
   implicit val scheduler: untyped.Scheduler = system.scheduler
 

--- a/http-caching/src/test/scala/org/apache/pekko/http/caching/ExpiringLfuCacheSpec.scala
+++ b/http-caching/src/test/scala/org/apache/pekko/http/caching/ExpiringLfuCacheSpec.scala
@@ -174,7 +174,7 @@ class ExpiringLfuCacheSpec extends AnyWordSpec with Matchers with BeforeAndAfter
       }
     }
     "be created with the same ttl and tti" in {
-      lfuCache[Int](timeToLive = 5.seconds, timeToIdle = 5.seconds) shouldBe a[LfuCache[_, _]]
+      lfuCache[Int](timeToLive = 5.seconds, timeToIdle = 5.seconds) shouldBe a[LfuCache[?, ?]]
     }
   }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
@@ -257,6 +257,6 @@ private[http] object PoolInterface {
       }
       override def genString(poolId: PoolId, system: ActorSystem): String = s"${system.name}/${genString(poolId)}"
 
-      override def getClazz(t: PoolId): Class[_] = classOf[PoolId]
+      override def getClazz(t: PoolId): Class[?] = classOf[PoolId]
     }
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
@@ -304,7 +304,7 @@ private[http] object Http2 extends ExtensionId[Http2Ext] with ExtensionIdProvide
   override def get(system: ClassicActorSystemProvider): Http2Ext = super.get(system)
   def apply()(implicit system: ClassicActorSystemProvider): Http2Ext = super.apply(system)
   override def apply(system: ActorSystem): Http2Ext = super.apply(system)
-  def lookup: ExtensionId[_ <: Extension] = Http2
+  def lookup: ExtensionId[? <: Extension] = Http2
   def createExtension(system: ExtendedActorSystem): Http2Ext = new Http2Ext()(system)
 
   private[http] type HttpImplementation = Flow[SslTlsInbound, SslTlsOutbound, ServerTerminator]

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2Blueprint.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2Blueprint.scala
@@ -56,11 +56,11 @@ private[http2] case class Http2SubStream(
     // or streaming as the LastChunk of a chunked data stream
     trailingHeaders: OptionVal[ParsedHeadersFrame],
     data: Either[ByteString, Source[Any /* ByteString | HttpEntity.ChunkStreamPart */, Any]],
-    correlationAttributes: Map[AttributeKey[_], _]) {
+    correlationAttributes: Map[AttributeKey[?], ?]) {
   def streamId: Int = initialHeaders.streamId
   def hasEntity: Boolean = !initialHeaders.endStream
 
-  def withCorrelationAttributes(newAttributes: Map[AttributeKey[_], _]): Http2SubStream =
+  def withCorrelationAttributes(newAttributes: Map[AttributeKey[?], ?]): Http2SubStream =
     copy(correlationAttributes = newAttributes)
 
   /**
@@ -91,7 +91,7 @@ private[http2] case class Http2SubStream(
 @InternalApi
 private[http2] object Http2SubStream {
   def apply(entity: HttpEntity, headers: ParsedHeadersFrame, trailingHeaders: OptionVal[ParsedHeadersFrame],
-      correlationAttributes: Map[AttributeKey[_], _] = Map.empty): Http2SubStream = {
+      correlationAttributes: Map[AttributeKey[?], ?] = Map.empty): Http2SubStream = {
     val data =
       entity match {
         case HttpEntity.Chunked(_, chunks) => Right(chunks)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2Demux.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2Demux.scala
@@ -248,7 +248,7 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings,
 
       override def isUpgraded: Boolean = upgraded
 
-      override protected def logSource: Class[_] =
+      override protected def logSource: Class[?] =
         if (isServer) classOf[Http2ServerDemux] else classOf[Http2ClientDemux]
 
       // cache debug state at the beginning to avoid that this has to be queried all the time
@@ -422,7 +422,7 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings,
       //        after a while or buffer only a limited amount?
       val bufferedSubStreamOutput = new BufferedOutlet[Http2SubStream](fromOutlet(substreamOut))
       override def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Either[ByteString, Source[Any, Any]],
-          correlationAttributes: Map[AttributeKey[_], _]): Unit =
+          correlationAttributes: Map[AttributeKey[?], ?]): Unit =
         bufferedSubStreamOutput.push(Http2SubStream(initialHeaders, OptionVal.None, data, correlationAttributes))
 
       // -----------------------------------------------------------------

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2StreamHandling.scala
@@ -47,7 +47,7 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
   def settings: Http2CommonSettings
   def pushGOAWAY(errorCode: ErrorCode, debug: String): Unit
   def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Either[ByteString, Source[Any, Any]],
-      correlationAttributes: Map[AttributeKey[_], _]): Unit
+      correlationAttributes: Map[AttributeKey[?], ?]): Unit
   def isUpgraded: Boolean
 
   def wrapTrailingHeaders(headers: ParsedHeadersFrame): Option[HttpEntity.ChunkStreamPart]
@@ -263,14 +263,14 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
     def stateName: String = productPrefix
 
     /** Called when we receive a user-created stream (that is open for more data) */
-    def handleOutgoingCreated(outStream: OutStream, correlationAttributes: Map[AttributeKey[_], _]): StreamState = {
+    def handleOutgoingCreated(outStream: OutStream, correlationAttributes: Map[AttributeKey[?], ?]): StreamState = {
       warning(
         s"handleOutgoingCreated received unexpectedly in state $stateName. This indicates a bug in Pekko HTTP, please report it to the issue tracker.")
       this
     }
 
     /** Called when we receive a user-created stream that is already closed */
-    def handleOutgoingCreatedAndFinished(correlationAttributes: Map[AttributeKey[_], _]): StreamState = {
+    def handleOutgoingCreatedAndFinished(correlationAttributes: Map[AttributeKey[?], ?]): StreamState = {
       warning(
         s"handleOutgoingCreatedAndFinished received unexpectedly in state $stateName. This indicates a bug in Pekko HTTP, please report it to the issue tracker.")
       this
@@ -297,7 +297,7 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
         event: StreamFrameEvent,
         nextStateEmpty: StreamState,
         nextStateStream: IncomingStreamBuffer => StreamState,
-        correlationAttributes: Map[AttributeKey[_], _] = Map.empty): StreamState =
+        correlationAttributes: Map[AttributeKey[?], ?] = Map.empty): StreamState =
       event match {
         case frame @ ParsedHeadersFrame(streamId, endStream, _, _, _) =>
           if (endStream) {
@@ -315,7 +315,7 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
         streamId: Int,
         headers: ParsedHeadersFrame,
         initialData: ByteString,
-        correlationAttributes: Map[AttributeKey[_], _],
+        correlationAttributes: Map[AttributeKey[?], ?],
         nextStateStream: IncomingStreamBuffer => StreamState): StreamState = {
       val subSource = new SubSourceOutlet[Any](s"substream-out-$streamId")
       val buffer = new IncomingStreamBuffer(streamId, subSource)
@@ -344,16 +344,16 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
         expectIncomingStream(event, HalfClosedRemoteWaitingForOutgoingStream(0), OpenReceivingDataFirst(_, 0))
 
     override def handleOutgoingCreated(
-        outStream: OutStream, correlationAttributes: Map[AttributeKey[_], _]): StreamState =
+        outStream: OutStream, correlationAttributes: Map[AttributeKey[?], ?]): StreamState =
       OpenSendingData(outStream, correlationAttributes)
-    override def handleOutgoingCreatedAndFinished(correlationAttributes: Map[AttributeKey[_], _]): StreamState =
+    override def handleOutgoingCreatedAndFinished(correlationAttributes: Map[AttributeKey[?], ?]): StreamState =
       HalfClosedLocalWaitingForPeerStream(correlationAttributes)
   }
 
   /** Special state that allows collecting some incoming data before dispatching it either as strict or streamed entity */
   case class CollectingIncomingData(
       headers: ParsedHeadersFrame,
-      correlationAttributes: Map[AttributeKey[_], _],
+      correlationAttributes: Map[AttributeKey[?], ?],
       collectedData: ByteString,
       extraInitialWindow: Int) extends ReceivingData {
 
@@ -379,11 +379,11 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
   case class OpenReceivingDataFirst(buffer: IncomingStreamBuffer, extraInitialWindow: Int = 0)
       extends ReceivingDataWithBuffer(HalfClosedRemoteWaitingForOutgoingStream(extraInitialWindow)) {
     override def handleOutgoingCreated(
-        outStream: OutStream, correlationAttributes: Map[AttributeKey[_], _]): StreamState = {
+        outStream: OutStream, correlationAttributes: Map[AttributeKey[?], ?]): StreamState = {
       outStream.increaseWindow(extraInitialWindow)
       Open(buffer, outStream)
     }
-    override def handleOutgoingCreatedAndFinished(correlationAttributes: Map[AttributeKey[_], _]): StreamState =
+    override def handleOutgoingCreatedAndFinished(correlationAttributes: Map[AttributeKey[?], ?]): StreamState =
       HalfClosedLocal(buffer)
     override def handleOutgoingEnded(): StreamState = Closed
 
@@ -426,7 +426,7 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
     }
   }
 
-  case class OpenSendingData(outStream: OutStream, correlationAttributes: Map[AttributeKey[_], _]) extends StreamState
+  case class OpenSendingData(outStream: OutStream, correlationAttributes: Map[AttributeKey[?], ?]) extends StreamState
       with Sending {
     override def handle(event: StreamFrameEvent): StreamState = event match {
       case _: ParsedHeadersFrame =>
@@ -443,7 +443,7 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
 
     override def handleOutgoingEnded(): StreamState = HalfClosedLocalWaitingForPeerStream(correlationAttributes)
   }
-  case class HalfClosedLocalWaitingForPeerStream(correlationAttributes: Map[AttributeKey[_], _]) extends StreamState {
+  case class HalfClosedLocalWaitingForPeerStream(correlationAttributes: Map[AttributeKey[?], ?]) extends StreamState {
     override def handle(event: StreamFrameEvent): StreamState = event match {
       case _: WindowUpdateFrame =>
         // We're not planning on sending any data on this stream anymore, so we don't care about window updates.
@@ -552,11 +552,11 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
     }
 
     override def handleOutgoingCreated(
-        outStream: OutStream, correlationAttributes: Map[AttributeKey[_], _]): StreamState = {
+        outStream: OutStream, correlationAttributes: Map[AttributeKey[?], ?]): StreamState = {
       outStream.increaseWindow(extraInitialWindow)
       HalfClosedRemoteSendingData(outStream)
     }
-    override def handleOutgoingCreatedAndFinished(correlationAttributes: Map[AttributeKey[_], _]): StreamState = Closed
+    override def handleOutgoingCreatedAndFinished(correlationAttributes: Map[AttributeKey[?], ?]): StreamState = Closed
   }
 
   /**
@@ -723,10 +723,10 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
   }
   final class OutStreamImpl(
       val streamId: Int,
-      private var maybeInlet: OptionVal[SubSinkInlet[_]],
+      private var maybeInlet: OptionVal[SubSinkInlet[?]],
       var outboundWindowLeft: Int,
       var trailer: OptionVal[ParsedHeadersFrame]) extends InHandler with OutStream {
-    private def inlet: SubSinkInlet[_] = maybeInlet.get
+    private def inlet: SubSinkInlet[?] = maybeInlet.get
 
     private var buffer: ByteString = ByteString.empty
     private var upstreamClosed: Boolean = false
@@ -743,7 +743,7 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
         enqueueOutStream(streamId)
       }
 
-    def registerIncomingData(inlet: SubSinkInlet[_]): Unit = {
+    def registerIncomingData(inlet: SubSinkInlet[?]): Unit = {
       require(!maybeInlet.isDefined)
 
       this.maybeInlet = OptionVal.Some(inlet)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/RequestParsing.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/RequestParsing.scala
@@ -61,7 +61,7 @@ private[http2] object RequestParsing {
         None
 
     val baseAttributes = {
-      var map = Map.empty[AttributeKey[_], Any]
+      var map = Map.empty[AttributeKey[?], Any]
       map = sslSessionAttribute match {
         case Some(sslSession) => map.updated(AttributeKeys.sslSession, SslSessionInfo(sslSession))
         case None             => map

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
@@ -187,7 +187,7 @@ private[http2] object PersistentConnection {
         class Connected(
             requestOut: SubSourceOutlet[HttpRequest],
             responseIn: SubSinkInlet[HttpResponse]) extends State {
-          private var ongoingRequests: Map[AssociationTag, Map[AttributeKey[_], RequestResponseAssociation]] = Map.empty
+          private var ongoingRequests: Map[AssociationTag, Map[AttributeKey[?], RequestResponseAssociation]] = Map.empty
           responseIn.pull()
 
           requestOut.setHandler(new OutHandler {
@@ -234,7 +234,7 @@ private[http2] object PersistentConnection {
             ongoingRequests = ongoingRequests.updated(tag,
               req.attributes.collect({
                 case (key, value: RequestResponseAssociation) => key -> value
-              }: PartialFunction[(AttributeKey[_], Any), (AttributeKey[_], RequestResponseAssociation)]))
+              }: PartialFunction[(AttributeKey[?], Any), (AttributeKey[?], RequestResponseAssociation)]))
             requestOut.push(req.addAttribute(associationTagKey, tag))
           }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpRequestParser.scala
@@ -199,7 +199,7 @@ private[http] final class HttpRequestParser(
                 `Raw-Request-URI`(uriBytes.decodeString(HttpCharsets.`US-ASCII`.nioCharset)) :: headers
               else headers
 
-            val attributes: Map[AttributeKey[_], Any] =
+            val attributes: Map[AttributeKey[?], Any] =
               if (settings.includeSslSessionAttribute) Map(AttributeKeys.sslSession -> SslSessionInfo(sslSession))
               else Map.empty
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpResponseParser.scala
@@ -147,7 +147,7 @@ private[http] class HttpResponseParser(protected val settings: ParserSettings,
         createEntity: EntityCreator[ResponseOutput, ResponseEntity],
         headers: List[HttpHeader] = headers) = {
 
-      val attributes: Map[AttributeKey[_], Any] =
+      val attributes: Map[AttributeKey[?], Any] =
         if (settings.includeSslSessionAttribute) Map(AttributeKeys.sslSession -> SslSessionInfo(sslSession))
         else Map.empty
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/ParserOutput.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/ParserOutput.scala
@@ -42,7 +42,7 @@ private[http] object ParserOutput {
       method: HttpMethod,
       uri: Uri,
       protocol: HttpProtocol,
-      attributes: Map[AttributeKey[_], _],
+      attributes: Map[AttributeKey[?], ?],
       headers: List[HttpHeader],
       createEntity: EntityCreator[RequestOutput, RequestEntity],
       expect100Continue: Boolean,
@@ -51,7 +51,7 @@ private[http] object ParserOutput {
   final case class ResponseStart(
       statusCode: StatusCode,
       protocol: HttpProtocol,
-      attributes: Map[AttributeKey[_], _],
+      attributes: Map[AttributeKey[?], ?],
       headers: List[HttpHeader],
       createEntity: EntityCreator[ResponseOutput, ResponseEntity],
       closeRequested: Boolean) extends MessageStart with ResponseOutput

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
@@ -447,7 +447,7 @@ private[http] object HttpServerBluePrint {
               grab(requestParsingIn) match {
                 case r: RequestStart =>
                   openRequests = openRequests.enqueue(r)
-                  messageEndPending = r.createEntity.isInstanceOf[StreamedEntityCreator[_, _]]
+                  messageEndPending = r.createEntity.isInstanceOf[StreamedEntityCreator[?, ?]]
                   val rs = if (r.expect100Continue) {
                     r.createEntity match {
                       case StrictEntityCreator(HttpEntity.Strict(_, _)) =>

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/ServerTerminator.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/ServerTerminator.scala
@@ -208,7 +208,7 @@ private[http] final class GracefulTerminatorStage(settings: ServerSettings)
     val selfTerminator = new ConnectionTerminator(triggerTermination)
 
     val logic = new TimerGraphStageLogic(shape) with StageLogging {
-      override protected def logSource: Class[_] = classOf[GracefulTerminatorStage]
+      override protected def logSource: Class[?] = classOf[GracefulTerminatorStage]
 
       // this promise will be completed once our termination is complete;
       // e.g. we replied with "go away" to pending requests, and no new ones were incoming etc

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/MessageToFrameRenderer.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/MessageToFrameRenderer.scala
@@ -31,7 +31,7 @@ import pekko.http.scaladsl.model.ws._
 @InternalApi
 private[http] object MessageToFrameRenderer {
   def create(serverSide: Boolean): Flow[Message, FrameStart, NotUsed] = {
-    def strictFrames(opcode: Opcode, data: ByteString): Source[FrameStart, _] =
+    def strictFrames(opcode: Opcode, data: ByteString): Source[FrameStart, ?] =
       // FIXME: fragment?
       Source.single(FrameEvent.fullFrame(opcode, None, data, fin = true))
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/JavaMapping.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/JavaMapping.scala
@@ -52,7 +52,7 @@ private[http] trait J2SMapping[J] {
 /** INTERNAL API */
 @InternalApi
 private[http] object J2SMapping {
-  implicit def fromJavaMapping[J](implicit mapping: JavaMapping[J, _]): J2SMapping[J] { type S = mapping.S } = mapping
+  implicit def fromJavaMapping[J](implicit mapping: JavaMapping[J, ?]): J2SMapping[J] { type S = mapping.S } = mapping
 
   implicit def fromJavaSeqMapping[J](
       implicit mapping: J2SMapping[J]): J2SMapping[Seq[J]] { type S = immutable.Seq[mapping.S] } =
@@ -72,7 +72,7 @@ private[http] trait S2JMapping[S] {
 /** INTERNAL API */
 @InternalApi
 private[http] object S2JMapping {
-  implicit def fromScalaMapping[S](implicit mapping: JavaMapping[_, S]): S2JMapping[S] { type J = mapping.J } = mapping
+  implicit def fromScalaMapping[S](implicit mapping: JavaMapping[?, S]): S2JMapping[S] { type J = mapping.J } = mapping
 }
 
 /** INTERNAL API */
@@ -256,8 +256,8 @@ private[http] object JavaMapping {
   implicit object InetSocketAddress extends Identity[java.net.InetSocketAddress]
   implicit object ByteString extends Identity[pekko.util.ByteString]
 
-  implicit val AttributeKey: Inherited[jm.AttributeKey[_], sm.AttributeKey[_]] =
-    new Inherited[jm.AttributeKey[_], sm.AttributeKey[_]]
+  implicit val AttributeKey: Inherited[jm.AttributeKey[?], sm.AttributeKey[?]] =
+    new Inherited[jm.AttributeKey[?], sm.AttributeKey[?]]
   implicit def attributeKey[T]: Inherited[jm.AttributeKey[T], sm.AttributeKey[T]] =
     AttributeKey.asInstanceOf[Inherited[jm.AttributeKey[T], sm.AttributeKey[T]]]
   implicit object ContentType extends Inherited[jm.ContentType, sm.ContentType]

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StageLoggingWithOverride.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StageLoggingWithOverride.scala
@@ -33,7 +33,7 @@ private[pekko] trait StageLoggingWithOverride extends GraphStageLogic {
 
   private var _log: LoggingAdapter = null
 
-  protected def logSource: Class[_] = this.getClass
+  protected def logSource: Class[?] = this.getClass
 
   def log: LoggingAdapter = {
     // only used in StageLogic, i.e. thread safe

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -287,7 +287,7 @@ private[http] object StreamUtils {
   /**
    * Tries to guess whether a source needs to cancelled and how. In the best case no materialization should be needed.
    */
-  def cancelSource(source: Source[_, _])(implicit materializer: Materializer): Unit = source match {
+  def cancelSource(source: Source[?, ?])(implicit materializer: Materializer): Unit = source match {
     case EmptySource => // nothing to do with empty source
     case x           =>
       val mat =

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
@@ -57,7 +57,7 @@ package object util {
     new EnhancedByteStringSource(byteStrings)
 
   private[this] var eventStreamLogger: ActorRef = _
-  private[http] def installEventStreamLoggerFor(channel: Class[_])(implicit system: ActorSystem): Unit = {
+  private[http] def installEventStreamLoggerFor(channel: Class[?])(implicit system: ActorSystem): Unit = {
     synchronized {
       if (eventStreamLogger == null)
         eventStreamLogger =

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
@@ -114,7 +114,7 @@ trait ServerBuilder {
    * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    */
-  def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): CompletionStage[ServerBinding]
+  def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, ?]): CompletionStage[ServerBinding]
 
   /**
    * Creates a [[pekko.stream.javadsl.Source]] of [[pekko.http.javadsl.IncomingConnection]] instances which represents a prospective HTTP server binding
@@ -185,9 +185,9 @@ object ServerBuilder {
         interface, port, context.asScala, settings.asScala, parallelism = 0, log)(materializer)
         .map(new ServerBinding(_)).asJava
 
-    def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): CompletionStage[ServerBinding] =
+    def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, ?]): CompletionStage[ServerBinding] =
       http.bindAndHandleImpl(
-        handlerFlow.asInstanceOf[Flow[sm.HttpRequest, sm.HttpResponse, _]].asScala,
+        handlerFlow.asInstanceOf[Flow[sm.HttpRequest, sm.HttpResponse, ?]].asScala,
         interface, port, context.asScala, settings.asScala, log)(materializer)
         .map(new ServerBinding(_)).asJava
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/Message.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/Message.scala
@@ -71,7 +71,7 @@ abstract class TextMessage extends Message {
   /**
    * Returns a source of the text message data.
    */
-  def getStreamedText: Source[String, _]
+  def getStreamedText: Source[String, ?]
 
   /**
    * Returns the strict message text if this message is strict, throws otherwise.
@@ -95,7 +95,7 @@ object TextMessage {
   def create(text: String): TextMessage =
     new TextMessage {
       def isStrict: Boolean = true
-      def getStreamedText: Source[String, _] = Source.single(text)
+      def getStreamedText: Source[String, ?] = Source.single(text)
       def getStrictText: String = text
 
       def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.TextMessage.Strict] = asScala
@@ -108,11 +108,11 @@ object TextMessage {
   /**
    * Creates a streamed text message.
    */
-  def create(textStream: Source[String, _]): TextMessage =
+  def create(textStream: Source[String, ?]): TextMessage =
     new TextMessage {
       def isStrict: Boolean = false
       def getStrictText: String = throw new IllegalStateException("Cannot get strict text for streamed message.")
-      def getStreamedText: Source[String, _] = textStream
+      def getStreamedText: Source[String, ?] = textStream
 
       def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.TextMessage.Strict] = asScala
         .toStrict(timeoutMillis.millis)(materializer)
@@ -137,7 +137,7 @@ abstract class BinaryMessage extends Message {
   /**
    * Returns a source of the binary message data.
    */
-  def getStreamedData: Source[ByteString, _]
+  def getStreamedData: Source[ByteString, ?]
 
   /**
    * Returns the strict message data if this message is strict, throws otherwise.
@@ -159,7 +159,7 @@ object BinaryMessage {
   def create(data: ByteString): BinaryMessage =
     new BinaryMessage {
       def isStrict: Boolean = true
-      def getStreamedData: Source[ByteString, _] = Source.single(data)
+      def getStreamedData: Source[ByteString, ?] = Source.single(data)
       def getStrictData: ByteString = data
 
       def toStrict(
@@ -173,11 +173,11 @@ object BinaryMessage {
   /**
    * Creates a streamed binary message.
    */
-  def create(dataStream: Source[ByteString, _]): BinaryMessage =
+  def create(dataStream: Source[ByteString, ?]): BinaryMessage =
     new BinaryMessage {
       def isStrict: Boolean = false
       def getStrictData: ByteString = throw new IllegalStateException("Cannot get strict data for streamed message.")
-      def getStreamedData: Source[ByteString, _] = dataStream
+      def getStreamedData: Source[ByteString, ?] = dataStream
 
       def toStrict(
           timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.BinaryMessage.Strict] = asScala

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/WebSocket.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/WebSocket.scala
@@ -25,7 +25,7 @@ object WebSocket {
    * handle the WebSocket message stream. If the request wasn't a WebSocket request a response with status code 400 is
    * returned.
    */
-  def handleWebSocketRequestWith(request: HttpRequest, handler: Flow[Message, Message, _]): HttpResponse =
+  def handleWebSocketRequestWith(request: HttpRequest, handler: Flow[Message, Message, ?]): HttpResponse =
     request.asScala.attribute(AttributeKeys.webSocketUpgrade) match {
       case Some(header) => header.handleMessagesWith(handler)
       case None         => HttpResponse.create().withStatus(StatusCodes.BAD_REQUEST).withEntity("Expected WebSocket request")

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/WebSocketUpgrade.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/WebSocketUpgrade.scala
@@ -39,21 +39,21 @@ trait WebSocketUpgrade {
    * Returns a response that can be used to answer a WebSocket handshake request. The connection will afterwards
    * use the given handlerFlow to handle WebSocket messages from the client.
    */
-  def handleMessagesWith(handlerFlow: Graph[FlowShape[Message, Message], _ <: Any]): HttpResponse
+  def handleMessagesWith(handlerFlow: Graph[FlowShape[Message, Message], ? <: Any]): HttpResponse
 
   /**
    * Returns a response that can be used to answer a WebSocket handshake request. The connection will afterwards
    * use the given handlerFlow to handle WebSocket messages from the client. The given subprotocol must be one
    * of the ones offered by the client.
    */
-  def handleMessagesWith(handlerFlow: Graph[FlowShape[Message, Message], _ <: Any], subprotocol: String): HttpResponse
+  def handleMessagesWith(handlerFlow: Graph[FlowShape[Message, Message], ? <: Any], subprotocol: String): HttpResponse
 
   /**
    * Returns a response that can be used to answer a WebSocket handshake request. The connection will afterwards
    * use the given inSink to handle WebSocket messages from the client and the given outSource to send messages to the client.
    */
   def handleMessagesWith(
-      inSink: Graph[SinkShape[Message], _ <: Any], outSource: Graph[SourceShape[Message], _ <: Any]): HttpResponse
+      inSink: Graph[SinkShape[Message], ? <: Any], outSource: Graph[SourceShape[Message], ? <: Any]): HttpResponse
 
   /**
    * Returns a response that can be used to answer a WebSocket handshake request. The connection will afterwards
@@ -61,6 +61,6 @@ trait WebSocketUpgrade {
    *
    * The given subprotocol must be one of the ones offered by the client.
    */
-  def handleMessagesWith(inSink: Graph[SinkShape[Message], _ <: Any], outSource: Graph[SourceShape[Message], _ <: Any],
+  def handleMessagesWith(inSink: Graph[SinkShape[Message], ? <: Any], outSource: Graph[SourceShape[Message], ? <: Any],
       subprotocol: String): HttpResponse
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ServerBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ServerBuilder.scala
@@ -96,7 +96,7 @@ trait ServerBuilder {
    * the `pekko.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
    * information about what kind of guarantees to expect.
    */
-  def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): Future[ServerBinding]
+  def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, ?]): Future[ServerBinding]
 
   /**
    * Creates a [[pekko.stream.scaladsl.Source]] of [[pekko.http.scaladsl.Http.IncomingConnection]] instances which represents a prospective HTTP server binding
@@ -153,7 +153,7 @@ private[http] object ServerBuilder {
     def connectionSource(): Source[Http.IncomingConnection, Future[ServerBinding]] =
       http.bindImpl(interface, port, context, settings, log)
 
-    def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): Future[ServerBinding] =
+    def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, ?]): Future[ServerBinding] =
       http.bindAndHandleImpl(handlerFlow, interface, port, context, settings, log)(materializer)
 
     def bind(handler: HttpRequest => Future[HttpResponse]): Future[ServerBinding] =

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/AttributeKey.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/AttributeKey.scala
@@ -17,7 +17,7 @@ import org.apache.pekko.http.javadsl.{ model => jm }
 
 import scala.reflect.ClassTag
 
-case class AttributeKey[T](name: String, private val clazz: Class[_]) extends jm.AttributeKey[T]
+case class AttributeKey[T](name: String, private val clazz: Class[?]) extends jm.AttributeKey[T]
 
 object AttributeKey {
   def apply[T: ClassTag](name: String): AttributeKey[T] =

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
@@ -49,7 +49,7 @@ sealed trait HttpMessage extends jm.HttpMessage {
   def isResponse: Boolean
 
   def headers: immutable.Seq[HttpHeader]
-  def attributes: Map[AttributeKey[_], _]
+  def attributes: Map[AttributeKey[?], ?]
   def entity: ResponseEntity
   def protocol: HttpProtocol
 
@@ -104,7 +104,7 @@ sealed trait HttpMessage extends jm.HttpMessage {
     }
 
   /** Returns a copy of this message with the attributes set to the given ones. */
-  def withAttributes(headers: Map[AttributeKey[_], _]): Self
+  def withAttributes(headers: Map[AttributeKey[?], ?]): Self
 
   /** Returns a copy of this message with the entity set to the given one. */
   def withEntity(entity: MessageEntity): Self
@@ -124,7 +124,7 @@ sealed trait HttpMessage extends jm.HttpMessage {
   def mapHeaders(f: immutable.Seq[HttpHeader] => immutable.Seq[HttpHeader]): Self = withHeaders(f(headers))
 
   /** Returns a copy of this message with the attributes transformed by the given function */
-  def mapAttributes(f: Map[AttributeKey[_], _] => Map[AttributeKey[_], _]): Self = withAttributes(f(attributes))
+  def mapAttributes(f: Map[AttributeKey[?], ?] => Map[AttributeKey[?], ?]): Self = withAttributes(f(attributes))
 
   /**
    * The content encoding as specified by the Content-Encoding header. If no Content-Encoding header is present the
@@ -177,8 +177,8 @@ sealed trait HttpMessage extends jm.HttpMessage {
     withHeaders(headers.filterNot(_.is(lowerHeaderName)))
   }
 
-  def removeAttribute(key: jm.AttributeKey[_]): Self = {
-    val ev = implicitly[JavaMapping[jm.AttributeKey[_], AttributeKey[_]]]
+  def removeAttribute(key: jm.AttributeKey[?]): Self = {
+    val ev = implicitly[JavaMapping[jm.AttributeKey[?], AttributeKey[?]]]
     mapAttributes(_ - ev.toScala(key))
   }
 
@@ -319,7 +319,7 @@ final class HttpRequest(
     val method: HttpMethod,
     val uri: Uri,
     val headers: immutable.Seq[HttpHeader],
-    val attributes: Map[AttributeKey[_], _],
+    val attributes: Map[AttributeKey[?], ?],
     val entity: RequestEntity,
     val protocol: HttpProtocol)
     extends jm.HttpRequest with HttpMessage {
@@ -367,7 +367,7 @@ final class HttpRequest(
   override def withHeaders(headers: immutable.Seq[HttpHeader]): HttpRequest =
     if (headers eq this.headers) this else copyImpl(headers = headers)
 
-  override def withAttributes(attributes: Map[AttributeKey[_], _]): HttpRequest =
+  override def withAttributes(attributes: Map[AttributeKey[?], ?]): HttpRequest =
     if (attributes eq this.attributes) this else copyImpl(attributes = attributes)
 
   override def withHeadersAndEntity(headers: immutable.Seq[HttpHeader], entity: RequestEntity): HttpRequest =
@@ -401,7 +401,7 @@ final class HttpRequest(
       method: HttpMethod = method,
       uri: Uri = uri,
       headers: immutable.Seq[HttpHeader] = headers,
-      attributes: Map[AttributeKey[_], _] = attributes,
+      attributes: Map[AttributeKey[?], ?] = attributes,
       entity: RequestEntity = entity,
       protocol: HttpProtocol = protocol) = new HttpRequest(method, uri, headers, attributes, entity, protocol)
 
@@ -520,7 +520,7 @@ object HttpRequest {
 final class HttpResponse(
     val status: StatusCode,
     val headers: immutable.Seq[HttpHeader],
-    val attributes: Map[AttributeKey[_], _],
+    val attributes: Map[AttributeKey[?], ?],
     val entity: ResponseEntity,
     val protocol: HttpProtocol)
     extends jm.HttpResponse with HttpMessage {
@@ -539,7 +539,7 @@ final class HttpResponse(
   override def withHeaders(headers: immutable.Seq[HttpHeader]): HttpResponse =
     if (headers eq this.headers) this else copyImpl(headers = headers)
 
-  def withAttributes(attributes: Map[AttributeKey[_], _]): HttpResponse =
+  def withAttributes(attributes: Map[AttributeKey[?], ?]): HttpResponse =
     if (attributes eq this.attributes) this else copyImpl(attributes = attributes)
 
   override def withProtocol(protocol: pekko.http.javadsl.model.HttpProtocol): pekko.http.javadsl.model.HttpResponse =
@@ -566,7 +566,7 @@ final class HttpResponse(
   private def copyImpl(
       status: StatusCode = status,
       headers: immutable.Seq[HttpHeader] = headers,
-      attributes: Map[AttributeKey[_], _] = attributes,
+      attributes: Map[AttributeKey[?], ?] = attributes,
       entity: ResponseEntity = entity,
       protocol: HttpProtocol = protocol) = new HttpResponse(status, headers, attributes, entity, protocol)
 

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
@@ -92,11 +92,11 @@ sealed trait Multipart extends jm.Multipart {
   def getMediaType: jm.MediaType.Multipart = mediaType
 
   /** Java API */
-  def getParts: JSource[_ <: jm.Multipart.BodyPart, AnyRef] =
+  def getParts: JSource[? <: jm.Multipart.BodyPart, AnyRef] =
     JSource.fromGraph(parts.asInstanceOf[Source[Multipart.BodyPart, AnyRef]])
 
   /** Java API */
-  def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[_ <: jm.Multipart.Strict] =
+  def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[? <: jm.Multipart.Strict] =
     toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).asJava
 }
 
@@ -134,11 +134,11 @@ object Multipart {
     override def toEntity: HttpEntity.Strict = toEntity(BodyPartRenderer.randomBoundary(), DefaultNoLogging)
 
     /** Java API */
-    override def getParts: JSource[_ <: jm.Multipart.BodyPart.Strict, AnyRef] =
-      super.getParts.asInstanceOf[JSource[_ <: jm.Multipart.BodyPart.Strict, AnyRef]]
+    override def getParts: JSource[? <: jm.Multipart.BodyPart.Strict, AnyRef] =
+      super.getParts.asInstanceOf[JSource[? <: jm.Multipart.BodyPart.Strict, AnyRef]]
 
     /** Java API */
-    override def getStrictParts: java.lang.Iterable[_ <: jm.Multipart.BodyPart.Strict] =
+    override def getStrictParts: java.lang.Iterable[? <: jm.Multipart.BodyPart.Strict] =
       (strictParts: immutable.Seq[jm.Multipart.BodyPart.Strict]).asJava
   }
 
@@ -198,7 +198,7 @@ object Multipart {
     def getDispositionType: Optional[jm.headers.ContentDispositionType] = OptionalUtil.convertOption(dispositionType)
 
     /** Java API */
-    def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[_ <: jm.Multipart.BodyPart.Strict] =
+    def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[? <: jm.Multipart.BodyPart.Strict] =
       toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).asJava
   }
 
@@ -235,8 +235,8 @@ object Multipart {
     }
 
     /** Java API */
-    override def getParts: JSource[_ <: jm.Multipart.General.BodyPart, AnyRef] =
-      super.getParts.asInstanceOf[JSource[_ <: jm.Multipart.General.BodyPart, AnyRef]]
+    override def getParts: JSource[? <: jm.Multipart.General.BodyPart, AnyRef] =
+      super.getParts.asInstanceOf[JSource[? <: jm.Multipart.General.BodyPart, AnyRef]]
 
     /** Java API */
     override def toStrict(
@@ -354,8 +354,8 @@ object Multipart {
     }
 
     /** Java API */
-    override def getParts: JSource[_ <: jm.Multipart.FormData.BodyPart, AnyRef] =
-      super.getParts.asInstanceOf[JSource[_ <: jm.Multipart.FormData.BodyPart, AnyRef]]
+    override def getParts: JSource[? <: jm.Multipart.FormData.BodyPart, AnyRef] =
+      super.getParts.asInstanceOf[JSource[? <: jm.Multipart.FormData.BodyPart, AnyRef]]
 
     /** Java API */
     override def toStrict(
@@ -392,7 +392,7 @@ object Multipart {
     /** INTERNAL API */
     @InternalApi
     private[pekko] def createSource(
-        parts: Source[pekko.http.javadsl.model.Multipart.FormData.BodyPart, _]): Multipart.FormData = {
+        parts: Source[pekko.http.javadsl.model.Multipart.FormData.BodyPart, ?]): Multipart.FormData = {
       apply(parts.asInstanceOf[Source[Multipart.FormData.BodyPart, Any]])
     }
 
@@ -576,8 +576,8 @@ object Multipart {
     }
 
     /** Java API */
-    override def getParts: JSource[_ <: jm.Multipart.ByteRanges.BodyPart, AnyRef] =
-      super.getParts.asInstanceOf[JSource[_ <: jm.Multipart.ByteRanges.BodyPart, AnyRef]]
+    override def getParts: JSource[? <: jm.Multipart.ByteRanges.BodyPart, AnyRef] =
+      super.getParts.asInstanceOf[JSource[? <: jm.Multipart.ByteRanges.BodyPart, AnyRef]]
 
     /** Java API */
     override def toStrict(

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
@@ -79,7 +79,7 @@ sealed trait ModeledHeader extends HttpHeader with Serializable {
   def lowercaseName: String = companion.lowercaseName
   final def render[R <: Rendering](r: R): r.type = renderValue(companion.render(r))
   protected[http] def renderValue[R <: Rendering](r: R): r.type
-  protected def companion: ModeledCompanion[_]
+  protected def companion: ModeledCompanion[?]
 }
 
 private[headers] sealed trait RequestHeader extends ModeledHeader { override def renderInRequests = true }

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/Message.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/Message.scala
@@ -40,7 +40,7 @@ sealed trait TextMessage extends pekko.http.javadsl.model.ws.TextMessage with Me
   /**
    * The contents of this message as a stream.
    */
-  def textStream: Source[String, _]
+  def textStream: Source[String, ?]
 
   /**
    * Collects all possible parts and returns a potentially future Strict Message for easier processing.
@@ -57,7 +57,7 @@ sealed trait TextMessage extends pekko.http.javadsl.model.ws.TextMessage with Me
     }
 
   /** Java API */
-  override def getStreamedText: javadsl.Source[String, _] = textStream.asJava
+  override def getStreamedText: javadsl.Source[String, ?] = textStream.asJava
   override def asScala: TextMessage = this
   override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[TextMessage.Strict] =
     toStrict(timeoutMillis.millis)(materializer).asJava
@@ -72,7 +72,7 @@ object TextMessage {
    * A strict [[TextMessage]] that contains the complete data as a [[String]].
    */
   final case class Strict(text: String) extends TextMessage {
-    def textStream: Source[String, _] = Source.single(text)
+    def textStream: Source[String, ?] = Source.single(text)
     override def toString: String = s"TextMessage.Strict($text)"
 
     /** Java API */
@@ -80,7 +80,7 @@ object TextMessage {
     override def isStrict: Boolean = true
   }
 
-  final case class Streamed(textStream: Source[String, _]) extends TextMessage {
+  final case class Streamed(textStream: Source[String, ?]) extends TextMessage {
     override def toString: String = s"TextMessage.Streamed($textStream)"
 
     /** Java API */
@@ -100,7 +100,7 @@ sealed trait BinaryMessage extends pekko.http.javadsl.model.ws.BinaryMessage wit
   /**
    * The contents of this message as a stream.
    */
-  def dataStream: Source[ByteString, _]
+  def dataStream: Source[ByteString, ?]
 
   /**
    * Collects all possible parts and returns a potentially future Strict Message for easier processing.
@@ -117,7 +117,7 @@ sealed trait BinaryMessage extends pekko.http.javadsl.model.ws.BinaryMessage wit
     }
 
   /** Java API */
-  override def getStreamedData: javadsl.Source[ByteString, _] = dataStream.asJava
+  override def getStreamedData: javadsl.Source[ByteString, ?] = dataStream.asJava
   override def asScala: BinaryMessage = this
   override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[BinaryMessage.Strict] =
     toStrict(timeoutMillis.millis)(materializer).asJava
@@ -132,14 +132,14 @@ object BinaryMessage {
    * A strict [[BinaryMessage]] that contains the complete data as a [[pekko.util.ByteString]].
    */
   final case class Strict(data: ByteString) extends BinaryMessage {
-    def dataStream: Source[ByteString, _] = Source.single(data)
+    def dataStream: Source[ByteString, ?] = Source.single(data)
     override def toString: String = s"BinaryMessage.Strict($data)"
 
     /** Java API */
     override def getStrictData: ByteString = data
     override def isStrict: Boolean = true
   }
-  final case class Streamed(dataStream: Source[ByteString, _]) extends BinaryMessage {
+  final case class Streamed(dataStream: Source[ByteString, ?]) extends BinaryMessage {
     override def toString: String = s"BinaryMessage.Streamed($dataStream)"
 
     /** Java API */

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/WebSocketUpgrade.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/WebSocketUpgrade.scala
@@ -78,34 +78,34 @@ trait WebSocketUpgrade extends jm.ws.WebSocketUpgrade {
   /**
    * Java API
    */
-  def handleMessagesWith(handlerFlow: Graph[FlowShape[jm.ws.Message, jm.ws.Message], _ <: Any]): HttpResponse =
+  def handleMessagesWith(handlerFlow: Graph[FlowShape[jm.ws.Message, jm.ws.Message], ? <: Any]): HttpResponse =
     handleMessages(JavaMapping.toScala(handlerFlow))
 
   /**
    * Java API
    */
   def handleMessagesWith(
-      handlerFlow: Graph[FlowShape[jm.ws.Message, jm.ws.Message], _ <: Any], subprotocol: String): HttpResponse =
+      handlerFlow: Graph[FlowShape[jm.ws.Message, jm.ws.Message], ? <: Any], subprotocol: String): HttpResponse =
     handleMessages(JavaMapping.toScala(handlerFlow), subprotocol = Some(subprotocol))
 
   /**
    * Java API
    */
-  def handleMessagesWith(inSink: Graph[SinkShape[jm.ws.Message], _ <: Any],
-      outSource: Graph[SourceShape[jm.ws.Message], _ <: Any]): HttpResponse =
+  def handleMessagesWith(inSink: Graph[SinkShape[jm.ws.Message], ? <: Any],
+      outSource: Graph[SourceShape[jm.ws.Message], ? <: Any]): HttpResponse =
     handleMessages(createScalaFlow(inSink, outSource))
 
   /**
    * Java API
    */
   def handleMessagesWith(
-      inSink: Graph[SinkShape[jm.ws.Message], _ <: Any],
-      outSource: Graph[SourceShape[jm.ws.Message], _ <: Any],
+      inSink: Graph[SinkShape[jm.ws.Message], ? <: Any],
+      outSource: Graph[SourceShape[jm.ws.Message], ? <: Any],
       subprotocol: String): HttpResponse =
     handleMessages(createScalaFlow(inSink, outSource), subprotocol = Some(subprotocol))
 
-  private[this] def createScalaFlow(inSink: Graph[SinkShape[jm.ws.Message], _ <: Any],
-      outSource: Graph[SourceShape[jm.ws.Message], _ <: Any]): Graph[FlowShape[Message, Message], NotUsed] =
+  private[this] def createScalaFlow(inSink: Graph[SinkShape[jm.ws.Message], ? <: Any],
+      outSource: Graph[SourceShape[jm.ws.Message], ? <: Any]): Graph[FlowShape[Message, Message], NotUsed] =
     JavaMapping.toScala(scaladsl.Flow.fromSinkAndSourceMat(inSink, outSource)(scaladsl.Keep.none): Graph[FlowShape[
         jm.ws.Message, jm.ws.Message], NotUsed])
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/util/FastFuture.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/util/FastFuture.scala
@@ -113,7 +113,7 @@ object FastFuture {
     def fast: FastFuture[T] = new FastFuture[T](future)
   }
 
-  def sequence[T, M[_] <: IterableOnce[_]](in: M[Future[T]])(implicit cbf: BuildFrom[M[Future[T]], T, M[T]],
+  def sequence[T, M[_] <: IterableOnce[?]](in: M[Future[T]])(implicit cbf: BuildFrom[M[Future[T]], T, M[T]],
       executor: ExecutionContext): Future[M[T]] =
     in.iterator.foldLeft(successful(cbf.newBuilder(in))) {
       (fr, fa) => for (r <- fr.fast; a <- fa.asInstanceOf[Future[T]].fast) yield r += a
@@ -129,7 +129,7 @@ object FastFuture {
     else sequence(futures).fast.map(_ reduceLeft op)
    */
 
-  def traverse[A, B, M[_] <: IterableOnce[_]](in: M[A])(fn: A => Future[B])(implicit cbf: BuildFrom[M[A], B, M[B]],
+  def traverse[A, B, M[_] <: IterableOnce[?]](in: M[A])(fn: A => Future[B])(implicit cbf: BuildFrom[M[A], B, M[B]],
       executor: ExecutionContext): Future[M[B]] =
     in.iterator.foldLeft(successful(cbf.newBuilder(in))) { (fr, a) =>
       val fb = fn(a.asInstanceOf[A])

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/NewConnectionPoolSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/NewConnectionPoolSpec.scala
@@ -554,7 +554,7 @@ class NewConnectionPoolSpec extends PekkoSpecWithMaterializer("""
               Source.queue(8, OverflowStrategy.fail).mapMaterializedValue(responseSourceQueuePromise.success)))
       }
 
-      val requestSourceQueuePromise = Promise[SourceQueueWithComplete[_]]()
+      val requestSourceQueuePromise = Promise[SourceQueueWithComplete[?]]()
       val requestSource = Source.queue[HttpEntity.ChunkStreamPart](8, OverflowStrategy.fail)
         .mapMaterializedValue(requestSourceQueuePromise.success)
       val slowRequestEntity = Chunked(ContentTypes.`text/plain(UTF-8)`, requestSource)

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/ByteStringSinkProbe.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/ByteStringSinkProbe.scala
@@ -120,7 +120,7 @@ private[http] object ByteStringSinkProbe {
       def within[T](max: FiniteDuration)(f: => T): T = probe.within(max)(f)
     }
 
-  def apply(source: Source[ByteString, _])(implicit system: ClassicActorSystemProvider): ByteStringSinkProbe = {
+  def apply(source: Source[ByteString, ?])(implicit system: ClassicActorSystemProvider): ByteStringSinkProbe = {
     val probe = ByteStringSinkProbe()(system.classicSystem)
     source.runWith(probe.sink)
     probe.ensureSubscription()

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/SerializabilitySpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/SerializabilitySpec.scala
@@ -93,7 +93,7 @@ class SerializabilitySpec extends AnyWordSpec with Matchers {
     // make sure to use correct class loader
     val loader = classOf[HttpRequest].getClassLoader
     val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray)) {
-      override def resolveClass(desc: ObjectStreamClass): Class[_] =
+      override def resolveClass(desc: ObjectStreamClass): Class[?] =
         Class.forName(desc.getName, false, loader)
     }
 

--- a/http-core/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
@@ -55,7 +55,7 @@ object PekkoSpec {
     ConfigFactory.parseMap(map.asJava)
   }
 
-  def getCallerName(clazz: Class[_]): String = {
+  def getCallerName(clazz: Class[?]): String = {
     val s = Thread.currentThread.getStackTrace.map(_.getClassName).drop(1)
       .dropWhile(_.matches("(java.lang.Thread|.*PekkoSpec.?$|.*StreamSpec.?$)"))
     val reduced = s.lastIndexWhere(_ == clazz.getName) match {
@@ -75,7 +75,7 @@ abstract class PekkoSpec(_system: ActorSystem) extends PekkoBaseSpec(_system) wi
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 
-  def this(configMap: Map[String, _]) = this(PekkoSpec.mapToConfig(configMap))
+  def this(configMap: Map[String, ?]) = this(PekkoSpec.mapToConfig(configMap))
 
   def this() = this(ActorSystem(PekkoSpec.getCallerName(getClass), PekkoSpec.testConf))
 
@@ -103,7 +103,7 @@ abstract class PekkoFreeSpec(_system: ActorSystem) extends PekkoBaseSpec(_system
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 
-  def this(configMap: Map[String, _]) = this(PekkoSpec.mapToConfig(configMap))
+  def this(configMap: Map[String, ?]) = this(PekkoSpec.mapToConfig(configMap))
 
   def this() = this(ActorSystem(PekkoSpec.getCallerName(getClass), PekkoSpec.testConf))
 
@@ -134,7 +134,7 @@ abstract class PekkoBaseSpec(_system: ActorSystem)
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 
-  def this(configMap: Map[String, _]) = this(PekkoSpec.mapToConfig(configMap))
+  def this(configMap: Map[String, ?]) = this(PekkoSpec.mapToConfig(configMap))
 
   def this() = this(ActorSystem(PekkoSpec.getCallerName(getClass), PekkoSpec.testConf))
 
@@ -151,9 +151,9 @@ abstract class PekkoBaseSpec(_system: ActorSystem)
 
   override def expectedTestDuration: FiniteDuration = 60.seconds
 
-  def muteDeadLetters(messageClasses: Class[_]*)(sys: ActorSystem = system): Unit =
+  def muteDeadLetters(messageClasses: Class[?]*)(sys: ActorSystem = system): Unit =
     if (!sys.log.isDebugEnabled) {
-      def mute(clazz: Class[_]): Unit =
+      def mute(clazz: Class[?]): Unit =
         sys.eventStream.publish(Mute(DeadLettersFilter(clazz)(occurrences = Int.MaxValue)))
       if (messageClasses.isEmpty) mute(classOf[AnyRef])
       else messageClasses.foreach(mute)
@@ -165,7 +165,7 @@ abstract class PekkoBaseSpec(_system: ActorSystem)
       def areEqual(a: Class[A], b: Class[B]) = a == b
     }
 
-  implicit def setEqualityConstraint[A, T <: Set[_ <: A]]: CanEqual[Set[A], T] =
+  implicit def setEqualityConstraint[A, T <: Set[? <: A]]: CanEqual[Set[A], T] =
     new CanEqual[Set[A], T] {
       def areEqual(a: Set[A], b: T) = a == b
     }

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTest.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTest.scala
@@ -47,7 +47,7 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
   protected def createActorSystem(): ActorSystem =
     ActorSystem(actorSystemNameFrom(getClass), testConfig)
 
-  def actorSystemNameFrom(clazz: Class[_]) =
+  def actorSystemNameFrom(clazz: Class[?]) =
     clazz.getName
       .replace('.', '-')
       .replace('_', '-')

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestResultComponent.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestResultComponent.scala
@@ -118,7 +118,7 @@ trait RouteTestResultComponent {
     private def failNeitherCompletedNorRejected(): Nothing =
       failTest("Request was neither completed nor rejected within " + timeout)
 
-    private def awaitAllElements[T](data: Source[T, _]): immutable.Seq[T] =
+    private def awaitAllElements[T](data: Source[T, ?]): immutable.Seq[T] =
       data.limit(100000).runWith(Sink.seq).awaitResult(timeout)
   }
 }

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestUtils.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestUtils.scala
@@ -31,7 +31,7 @@ trait ScalatestUtils extends MarshallingTestUtils {
   def evaluateTo[T](value: T): Matcher[Future[T]] =
     equal(value).matcher[T].compose(x => Await.result(x, marshallingTimeout))
 
-  def haveFailedWith(t: Throwable): Matcher[Future[_]] =
+  def haveFailedWith(t: Throwable): Matcher[Future[?]] =
     equal(t).matcher[Throwable].compose(x => Await.result(x.failed, marshallingTimeout))
 
   def unmarshalToValue[T: FromEntityUnmarshaller](value: T)(

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/Specs2Utils.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/Specs2Utils.scala
@@ -32,7 +32,7 @@ trait Specs2Utils extends MarshallingTestUtils {
   def evaluateTo[T](value: T)(implicit ee: ExecutionEnv): Matcher[Future[T]] =
     beEqualTo(value).await
 
-  def haveFailedWith(t: Throwable)(implicit ee: ExecutionEnv): Matcher[Future[_]] =
+  def haveFailedWith(t: Throwable)(implicit ee: ExecutionEnv): Matcher[Future[?]] =
     throwA(t).await
 
   def unmarshalToValue[T: FromEntityUnmarshaller](value: T)(

--- a/http-tests/src/multi-jvm/scala/org/apache/pekko/remote/testkit/MultiNodeConfig.scala
+++ b/http-tests/src/multi-jvm/scala/org/apache/pekko/remote/testkit/MultiNodeConfig.scala
@@ -244,7 +244,7 @@ object MultiNodeSpec {
     ConfigFactory.parseMap(map.asJava)
   }
 
-  private def getCallerName(clazz: Class[_]): String = {
+  private def getCallerName(clazz: Class[?]): String = {
     val s = Thread.currentThread.getStackTrace.map(_.getClassName).drop(1).dropWhile(_.matches(".*MultiNodeSpec.?$"))
     val reduced = s.lastIndexWhere(_ == clazz.getName) match {
       case -1 => s
@@ -385,9 +385,9 @@ abstract class MultiNodeSpec(val myself: RoleName, _system: ActorSystem, _roles:
    */
   def node(role: RoleName): ActorPath = RootActorPath(testConductor.getAddressFor(role).await)
 
-  def muteDeadLetters(messageClasses: Class[_]*)(sys: ActorSystem = system): Unit =
+  def muteDeadLetters(messageClasses: Class[?]*)(sys: ActorSystem = system): Unit =
     if (!sys.log.isDebugEnabled) {
-      def mute(clazz: Class[_]): Unit =
+      def mute(clazz: Class[?]): Unit =
         sys.eventStream.publish(Mute(DeadLettersFilter(clazz)(occurrences = Int.MaxValue)))
       if (messageClasses.isEmpty) mute(classOf[AnyRef])
       else messageClasses.foreach(mute)

--- a/http-tests/src/test/scala/org/apache/pekko/http/javadsl/DirectivesConsistencySpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/javadsl/DirectivesConsistencySpec.scala
@@ -91,7 +91,7 @@ class DirectivesConsistencySpec extends AnyWordSpec with Matchers {
       case _                   => Right(m.getName)
     }
 
-  val allowMissing: Map[Class[_], Set[String]] = Map(
+  val allowMissing: Map[Class[?], Set[String]] = Map(
     scalaDirectivesClazz -> Set(
       "route", "request",
       "completeOK", // solved by raw complete() in Scala
@@ -119,7 +119,7 @@ class DirectivesConsistencySpec extends AnyWordSpec with Matchers {
       "authenticateOAuth2PF", "authenticateOAuth2PFAsync",
       "authenticateBasicPF", "authenticateBasicPFAsync"))
 
-  def assertHasMethod(c: Class[_], name: String, alternativeName: String): Unit = {
+  def assertHasMethod(c: Class[?], name: String, alternativeName: String): Unit = {
     // include class name to get better error message
     if (!allowMissing.getOrElse(c, Set.empty).exists(n => n == name || n == alternativeName)) {
       val methods = c.getMethods.collect { case m if !ignore(m.getName) => c.getName + "." + m.getName }
@@ -142,8 +142,8 @@ class DirectivesConsistencySpec extends AnyWordSpec with Matchers {
           case `scalaDirectivesClazz` =>
             val all = javaDirectivesClazz
 
-            var is = List.empty[Class[_]]
-            var c: Class[_] = all
+            var is = List.empty[Class[?]]
+            var c: Class[?] = all
             while (c != classOf[java.lang.Object]) {
               is = c :: is
               c = c.getSuperclass

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/EntityStreamingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/EntityStreamingSpec.scala
@@ -357,7 +357,7 @@ class EntityStreamingSpec extends RoutingSpec with ScalaFutures {
       case ex: java.lang.RuntimeException if ex.getCause != null =>
         val cause = ex.getCause
         cause.getClass should ===(
-          classOf[pekko.http.scaladsl.marshalling.NoStrictlyCompatibleElementMarshallingAvailableException[_]])
+          classOf[pekko.http.scaladsl.marshalling.NoStrictlyCompatibleElementMarshallingAvailableException[?]])
         cause.getMessage should include("Please provide an implicit `Marshaller[java.lang.String, HttpEntity]")
         cause.getMessage should include("that can render java.lang.String as [application/json]")
     }
@@ -420,7 +420,7 @@ class EntityStreamingSpec extends RoutingSpec with ScalaFutures {
       case ex: java.lang.RuntimeException if ex.getCause != null =>
         val cause = ex.getCause
         cause.getClass should ===(
-          classOf[pekko.http.scaladsl.marshalling.NoStrictlyCompatibleElementMarshallingAvailableException[_]])
+          classOf[pekko.http.scaladsl.marshalling.NoStrictlyCompatibleElementMarshallingAvailableException[?]])
         cause.getMessage should include("Please provide an implicit `Marshaller[java.lang.String, HttpEntity]")
         cause.getMessage should include("that can render java.lang.String as [application/json]")
     }

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -500,14 +500,14 @@ class MockFailingWritePath extends java.nio.file.Path { selfPath =>
     new FileSystem {
       override def provider(): FileSystemProvider = new FileSystemProvider {
         override def getScheme: String = ???
-        override def newFileSystem(uri: URI, env: util.Map[String, _]): FileSystem = ???
+        override def newFileSystem(uri: URI, env: util.Map[String, ?]): FileSystem = ???
         override def getFileSystem(uri: URI): FileSystem = ???
         override def getPath(uri: URI): Path = ???
         override def newByteChannel(
-            path: Path, options: util.Set[_ <: OpenOption], attrs: FileAttribute[_]*): SeekableByteChannel = ???
-        override def newDirectoryStream(dir: Path, filter: DirectoryStream.Filter[_ >: Path]): DirectoryStream[Path] =
+            path: Path, options: util.Set[? <: OpenOption], attrs: FileAttribute[?]*): SeekableByteChannel = ???
+        override def newDirectoryStream(dir: Path, filter: DirectoryStream.Filter[? >: Path]): DirectoryStream[Path] =
           ???
-        override def createDirectory(dir: Path, attrs: FileAttribute[_]*): Unit = ???
+        override def createDirectory(dir: Path, attrs: FileAttribute[?]*): Unit = ???
         override def delete(path: Path): Unit = ()
         override def copy(source: Path, target: Path, options: CopyOption*): Unit = ???
         override def move(source: Path, target: Path, options: CopyOption*): Unit = ???
@@ -523,7 +523,7 @@ class MockFailingWritePath extends java.nio.file.Path { selfPath =>
           ???
         override def setAttribute(path: Path, attribute: String, value: Any, options: LinkOption*): Unit = ???
         override def newFileChannel(
-            path: Path, options: util.Set[_ <: OpenOption], attrs: FileAttribute[_]*): FileChannel =
+            path: Path, options: util.Set[? <: OpenOption], attrs: FileAttribute[?]*): FileChannel =
           new FileChannel {
             override def read(dst: ByteBuffer): Int = ???
             override def read(dsts: Array[ByteBuffer], offset: Int, length: Int): Long = ???
@@ -580,8 +580,8 @@ class MockFailingWritePath extends java.nio.file.Path { selfPath =>
     override def toPath: Path = selfPath
   }
   override def register(
-      watcher: WatchService, events: Array[WatchEvent.Kind[_]], modifiers: WatchEvent.Modifier*): WatchKey = ???
-  override def register(watcher: WatchService, events: WatchEvent.Kind[_]*): WatchKey = ???
+      watcher: WatchService, events: Array[WatchEvent.Kind[?]], modifiers: WatchEvent.Modifier*): WatchKey = ???
+  override def register(watcher: WatchService, events: WatchEvent.Kind[?]*): WatchKey = ???
   override def iterator(): util.Iterator[Path] = ???
   override def compareTo(other: Path): Int = ???
 }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/Marshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/Marshaller.scala
@@ -89,7 +89,7 @@ object Marshaller {
     fromScala(scalaMarshaller.wrap(mediaType.asScala)((in: C) => f.apply(in))(ContentTypeOverrider.forEntity))
   }
 
-  def entityToOKResponse[A](m: Marshaller[A, _ <: RequestEntity]): Marshaller[A, HttpResponse] = {
+  def entityToOKResponse[A](m: Marshaller[A, ? <: RequestEntity]): Marshaller[A, HttpResponse] = {
     fromScala(marshalling.Marshaller.fromToEntityMarshaller[A]()(m.asScalaCastOutput))
   }
 
@@ -98,12 +98,12 @@ object Marshaller {
   }
 
   def entityToResponse[A](status: StatusCode, headers: java.lang.Iterable[HttpHeader],
-      m: Marshaller[A, _ <: RequestEntity]): Marshaller[A, HttpResponse] = {
+      m: Marshaller[A, ? <: RequestEntity]): Marshaller[A, HttpResponse] = {
     fromScala(marshalling.Marshaller.fromToEntityMarshaller[A](status.asScala, headers.asScala)(m.asScalaCastOutput))
   }
 
   def entityToOKResponse[A](
-      headers: java.lang.Iterable[HttpHeader], m: Marshaller[A, _ <: RequestEntity]): Marshaller[A, HttpResponse] = {
+      headers: java.lang.Iterable[HttpHeader], m: Marshaller[A, ? <: RequestEntity]): Marshaller[A, HttpResponse] = {
     fromScala(marshalling.Marshaller.fromToEntityMarshaller[A](headers = headers.asScala)(m.asScalaCastOutput))
   }
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
@@ -159,8 +159,8 @@ abstract class BasicDirectives {
    * Adds a TransformationRejection cancelling all rejections of one of the given classes
    * to the list of rejections potentially coming back from the inner route.
    */
-  def cancelRejections(classes: JIterable[Class[_]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.cancelRejections(convertIterable[Class[_], Class[_]](classes): _*) { inner.get.delegate }
+  def cancelRejections(classes: JIterable[Class[?]], inner: Supplier[Route]): Route = RouteAdapter {
+    D.cancelRejections(convertIterable[Class[?], Class[?]](classes): _*) { inner.get.delegate }
   }
 
   /**

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
@@ -91,7 +91,7 @@ abstract class HeaderDirectives extends FutureDirectives {
     def magnetForModeledCustomHeader(clazz: Class[T]): HeaderMagnet[T] = {
       // figure out the modeled header companion and use that to parse the header
       val refl = new ReflectiveDynamicAccess(getClass.getClassLoader)
-      refl.getObjectFor[ModeledCustomHeaderCompanion[_]](t.getName) match {
+      refl.getObjectFor[ModeledCustomHeaderCompanion[?]](t.getName) match {
         case Success(companion) =>
           new HeaderMagnet[T] {
             override def classTag = ClassTag(t)
@@ -106,7 +106,7 @@ abstract class HeaderDirectives extends FutureDirectives {
     }
 
     val magnet: HeaderMagnet[T] =
-      if (classOf[ModeledCustomHeader[_]].isAssignableFrom(t)) magnetForModeledCustomHeader(t)
+      if (classOf[ModeledCustomHeader[?]].isAssignableFrom(t)) magnetForModeledCustomHeader(t)
       else HeaderMagnet.fromClassNormalJavaHeader(t)
 
     D.headerValueByType(magnet) { value =>

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/MarshallingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/MarshallingDirectives.scala
@@ -28,7 +28,7 @@ abstract class MarshallingDirectives extends HostDirectives {
    * produced by the unmarshaller.
    */
   def request[T](
-      unmarshaller: Unmarshaller[_ >: HttpRequest, T],
+      unmarshaller: Unmarshaller[? >: HttpRequest, T],
       inner: java.util.function.Function[T, Route]): Route = RouteAdapter {
     D.entity(unmarshaller.asScala) { value =>
       inner.apply(value).delegate
@@ -41,7 +41,7 @@ abstract class MarshallingDirectives extends HostDirectives {
    * produced by the unmarshaller.
    */
   def entity[T](
-      unmarshaller: Unmarshaller[_ >: HttpEntity, T],
+      unmarshaller: Unmarshaller[? >: HttpEntity, T],
       inner: java.util.function.Function[T, Route]): Route = RouteAdapter {
     D.entity(Unmarshaller.requestToEntity.flatMap(unmarshaller).asScala) { value =>
       inner.apply(value).delegate
@@ -54,7 +54,7 @@ abstract class MarshallingDirectives extends HostDirectives {
    * You can use it do decouple marshaller resolution from request completion.
    */
   def completeWith[T](
-      marshaller: Marshaller[T, _ <: HttpResponse],
+      marshaller: Marshaller[T, ? <: HttpResponse],
       inner: java.util.function.Consumer[java.util.function.Consumer[T]]): Route = RouteAdapter {
     D.completeWith[T](marshaller) { f =>
       inner.accept(new java.util.function.Consumer[T]() {
@@ -68,8 +68,8 @@ abstract class MarshallingDirectives extends HostDirectives {
    * entity unmarshaller and the result value of the function is marshalled with the in-scope marshaller.
    */
   def handleWith[T, R](
-      unmarshaller: Unmarshaller[_ >: HttpEntity, T],
-      marshaller: Marshaller[R, _ <: HttpResponse],
+      unmarshaller: Unmarshaller[? >: HttpEntity, T],
+      marshaller: Marshaller[R, ? <: HttpResponse],
       inner: java.util.function.Function[T, R]): Route = RouteAdapter {
     D.handleWith[T, R] { entity =>
       inner.apply(entity)

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -210,7 +210,7 @@ abstract class Unmarshaller[-A, B] extends UnmarshallerBase[A, B] {
   def flatMap[C](f: java.util.function.Function[B, CompletionStage[C]]): Unmarshaller[A, C] =
     asScala.flatMap { ctx => mat => b => f.apply(b).asScala }
 
-  def flatMap[C](u: Unmarshaller[_ >: B, C]): Unmarshaller[A, C] =
+  def flatMap[C](u: Unmarshaller[? >: B, C]): Unmarshaller[A, C] =
     asScala.flatMap { ctx => mat => b => u.asScala.apply(b)(ctx, mat) }
 
   // TODO not exposed for Java yet

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/client/RequestBuilding.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/client/RequestBuilding.scala
@@ -94,7 +94,7 @@ trait RequestBuilding extends TransformerPipelineSupport {
   def removeHeader[T <: HttpHeader: ClassTag]: RequestTransformer =
     removeHeader(implicitly[ClassTag[T]].runtimeClass)
 
-  def removeHeader(clazz: Class[_]): RequestTransformer =
+  def removeHeader(clazz: Class[?]): RequestTransformer =
     _.mapHeaders(_.filterNot(clazz.isInstance))
 
   def removeHeaders(names: String*): RequestTransformer =

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DataMapper.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DataMapper.scala
@@ -20,17 +20,17 @@ import pekko.util.ByteString
 
 /** An abstraction to transform data bytes of HttpMessages or HttpEntities */
 sealed trait DataMapper[T] {
-  def transformDataBytes(t: T, transformer: Flow[ByteString, ByteString, _]): T
+  def transformDataBytes(t: T, transformer: Flow[ByteString, ByteString, ?]): T
 }
 object DataMapper {
   implicit val mapRequestEntity: DataMapper[RequestEntity] =
     new DataMapper[RequestEntity] {
-      def transformDataBytes(t: RequestEntity, transformer: Flow[ByteString, ByteString, _]): RequestEntity =
+      def transformDataBytes(t: RequestEntity, transformer: Flow[ByteString, ByteString, ?]): RequestEntity =
         t.transformDataBytes(transformer)
     }
   implicit val mapResponseEntity: DataMapper[ResponseEntity] =
     new DataMapper[ResponseEntity] {
-      def transformDataBytes(t: ResponseEntity, transformer: Flow[ByteString, ByteString, _]): ResponseEntity =
+      def transformDataBytes(t: ResponseEntity, transformer: Flow[ByteString, ByteString, ?]): ResponseEntity =
         t.transformDataBytes(transformer)
     }
 
@@ -40,7 +40,7 @@ object DataMapper {
 
   def mapMessage[T, E](entityMapper: DataMapper[E])(mapEntity: (T, E => E) => T): DataMapper[T] =
     new DataMapper[T] {
-      def transformDataBytes(t: T, transformer: Flow[ByteString, ByteString, _]): T =
+      def transformDataBytes(t: T, transformer: Flow[ByteString, ByteString, ?]): T =
         mapEntity(t, entityMapper.transformDataBytes(_, transformer))
     }
 }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
@@ -108,7 +108,7 @@ trait LowPriorityToResponseMarshallerImplicits {
     fromEntityStreamingSupportAndByteStringSourceMarshaller[T, M](s, m.map(_.dataBytes))
 
   private[marshalling] def fromEntityStreamingSupportAndByteStringSourceMarshaller[T: ClassTag, M](
-      s: EntityStreamingSupport, m: Marshaller[T, Source[ByteString, _]]): ToResponseMarshaller[Source[T, M]] = {
+      s: EntityStreamingSupport, m: Marshaller[T, Source[ByteString, ?]]): ToResponseMarshaller[Source[T, M]] = {
     Marshaller[Source[T, M], HttpResponse] { implicit ec => source =>
       FastFuture.successful {
         Marshalling.WithFixedContentType(s.contentType,
@@ -161,7 +161,7 @@ object PredefinedToResponseMarshallers extends PredefinedToResponseMarshallers {
 
 final class NoStrictlyCompatibleElementMarshallingAvailableException[T](
     streamContentType: ContentType,
-    availableMarshallings: List[Marshalling[_]])(implicit tag: ClassTag[T])
+    availableMarshallings: List[Marshalling[?]])(implicit tag: ClassTag[T])
     extends RuntimeException(
       s"None of the available marshallings ($availableMarshallings) directly " +
       s"match the ContentType requested by the top-level streamed entity ($streamContentType). " +

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/PathMatcher.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/PathMatcher.scala
@@ -44,9 +44,9 @@ abstract class PathMatcher[L](implicit val ev: Tuple[L]) extends (Path => PathMa
     this ~ PathMatchers.Slash ~ other
 
   /** Alias for [[or]]. */
-  def |[R >: L: Tuple](other: PathMatcher[_ <: R]): PathMatcher[R] = or(other)
+  def |[R >: L: Tuple](other: PathMatcher[? <: R]): PathMatcher[R] = or(other)
 
-  def or[R >: L: Tuple](other: PathMatcher[_ <: R]): PathMatcher[R] =
+  def or[R >: L: Tuple](other: PathMatcher[? <: R]): PathMatcher[R] =
     new PathMatcher[R] {
       def apply(path: Path) = self(path).orElse(other(path))
     }
@@ -346,7 +346,7 @@ trait ImplicitPathMatcherConstruction {
 trait PathMatchers {
   import PathMatcher._
 
-  def not(self: PathMatcher[_]): PathMatcher0 =
+  def not(self: PathMatcher[?]): PathMatcher0 =
     new PathMatcher[Unit] {
       def apply(path: Path) = if (self(path) eq Unmatched) Matched(path, ()) else Unmatched
     }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RejectionHandler.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RejectionHandler.scala
@@ -126,7 +126,7 @@ object RejectionHandler {
     }
   }
   private final case class TypeHandler[T <: Rejection](
-      runtimeClass: Class[_], f: immutable.Seq[T] => Route) extends Handler with PartialFunction[Rejection, T] {
+      runtimeClass: Class[?], f: immutable.Seq[T] => Route) extends Handler with PartialFunction[Rejection, T] {
     def isDefinedAt(rejection: Rejection): Boolean = runtimeClass.isInstance(rejection)
     def apply(rejection: Rejection): T = rejection.asInstanceOf[T]
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectives.scala
@@ -186,7 +186,7 @@ trait BasicDirectives {
    *
    * @group basic
    */
-  def cancelRejections(classes: Class[_]*): Directive0 =
+  def cancelRejections(classes: Class[?]*): Directive0 =
     cancelRejections(r => classes.exists(_.isInstance(r)))
 
   /**

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshaller.scala
@@ -154,8 +154,8 @@ object Unmarshaller
 
   /** Order of parameters (`right` first, `left` second) is intentional, since that's the order we evaluate them in. */
   final case class EitherUnmarshallingException(
-      rightClass: Class[_], right: Throwable,
-      leftClass: Class[_], left: Throwable)
+      rightClass: Class[?], right: Throwable,
+      leftClass: Class[?], left: Throwable)
       extends RuntimeException(
         s"Failed to unmarshal Either[${Logging.simpleName(leftClass)}, ${Logging.simpleName(
             rightClass)}] (attempted ${Logging.simpleName(rightClass)} first). " +

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
@@ -904,11 +904,11 @@ class Http2ServerSpec extends Http2SpecWithMaterializer("""
            * Loop that checks for a while that publisherProbe has outstanding demand and runs body to fulfill it
            * Will fail if there's still demand after the timeout.
            */
-          def fulfillDemandWithin(publisherProbe: TestPublisher.Probe[_], timeout: FiniteDuration)(
+          def fulfillDemandWithin(publisherProbe: TestPublisher.Probe[?], timeout: FiniteDuration)(
               body: => Unit): Unit = {
             // HACK to support `expectRequest` with a timeout
-            def within[T](publisherProbe: TestPublisher.Probe[_], dur: FiniteDuration)(t: => T): T = {
-              val field = classOf[ManualProbe[_]].getDeclaredField("probe")
+            def within[T](publisherProbe: TestPublisher.Probe[?], dur: FiniteDuration)(t: => T): T = {
+              val field = classOf[ManualProbe[?]].getDeclaredField("probe")
               field.setAccessible(true)
               field.get(publisherProbe).asInstanceOf[TestProbe].within(dur)(t)
             }

--- a/parsing/src/main/scala-3/org/apache/pekko/macros/LogHelperMacro.scala
+++ b/parsing/src/main/scala-3/org/apache/pekko/macros/LogHelperMacro.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.macros
 
 import org.apache.pekko.annotation.InternalApi
 
-import scala.quoted._
+import scala.quoted.*
 
 /** INTERNAL API */
 @InternalApi
@@ -31,5 +31,5 @@ private[pekko] trait LogHelperMacro { self: LogHelper =>
 /** INTERNAL API */
 @InternalApi
 private[pekko] object LogHelperMacro {
-  def guard(isEnabled: Expr[Boolean], log: Expr[Unit])(using Quotes): Expr[Unit] = '{ if ($isEnabled) $log }
+  def guard(isEnabled: Expr[Boolean], log: Expr[Unit])(using Quotes): Expr[Unit] = '{ if $isEnabled then $log }
 }

--- a/project/NoScala3.scala
+++ b/project/NoScala3.scala
@@ -11,6 +11,6 @@ import sbt.{ Def, _ }
 import Keys._
 
 object NoScala3 extends AutoPlugin {
-  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+  override def projectSettings: Seq[Def.Setting[?]] = Seq(
     crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("3.")))
 }

--- a/project/SbtInternalAccess.scala
+++ b/project/SbtInternalAccess.scala
@@ -23,6 +23,6 @@ package sbt {
     }
     def AggregationShowRun[T](complete: sbt.internal.Aggregation.Complete[T],
         show: sbt.internal.Aggregation.ShowConfig)(
-        implicit display: Show[ScopedKey[_]]): Unit = showRunMethod.invoke(Aggregation, complete, show, display)
+        implicit display: Show[ScopedKey[?]]): Unit = showRunMethod.invoke(Aggregation, complete, show, display)
   }
 }

--- a/project/ScalaFixExtraRulesPlugin.scala
+++ b/project/ScalaFixExtraRulesPlugin.scala
@@ -21,7 +21,7 @@ object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport {
 
   import sbt._
   import scalafix.sbt.ScalafixPlugin.autoImport.scalafixDependencies
-  override lazy val projectSettings: Seq[Def.Setting[_]] = super.projectSettings ++ {
+  override lazy val projectSettings: Seq[Def.Setting[?]] = super.projectSettings ++ {
     ThisBuild / scalafixDependencies ++= Seq(
       "com.nequissimus" %% "sort-imports" % "0.6.1")
   }

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -43,7 +43,7 @@ object ValidatePullRequest extends AutoPlugin {
   override def requires = plugins.JvmPlugin
 
   sealed trait BuildMode {
-    def task: Option[TaskKey[_]]
+    def task: Option[TaskKey[?]]
     def log(projectName: String, l: Logger): Unit
   }
 
@@ -106,7 +106,7 @@ object ValidatePullRequest extends AutoPlugin {
   // running validation
   val validatePullRequest = taskKey[Unit]("Validate pull request and report aggregated results")
   val executePullRequestValidation = taskKey[Seq[KeyValue[Result[Any]]]]("Run pull request per project")
-  val additionalTasks = settingKey[Seq[TaskKey[_]]]("Additional tasks for pull request validation")
+  val additionalTasks = settingKey[Seq[TaskKey[?]]]("Additional tasks for pull request validation")
 
   // The set of (top-level) files or directories to watch for build changes.
   val BuildFilesAndDirectories = Set("project", "build.sbt", ".github")
@@ -331,7 +331,7 @@ object AggregatePRValidation extends AutoPlugin {
 
       def runTasks[T](s: State, structure: BuildStructure, ts: Seq[sbt.internal.Aggregation.KeyValue[Task[T]]],
           extra: DummyTaskMap, show: ShowConfig)(
-          implicit display: Show[ScopedKey[_]]): (State, Result[Seq[KeyValue[Result[T]]]]) = {
+          implicit display: Show[ScopedKey[?]]): (State, Result[Seq[KeyValue[Result[T]]]]) = {
         val complete = timedRun[T](s, ts, extra)
         sbt.access.AggregationShowRun(complete, show)
         val newState =
@@ -402,7 +402,7 @@ object AggregatePRValidation extends AutoPlugin {
         write("## Pull request validation report")
         write("")
 
-        def showKey(key: ScopedKey[_]): String = Project.showContextKey2(extracted.session).show(key)
+        def showKey(key: ScopedKey[?]): String = Project.showContextKey2(extracted.session).show(key)
 
         def totalCount(suiteResult: SuiteResult): Int = {
           import suiteResult._
@@ -464,8 +464,8 @@ object AggregatePRValidation extends AutoPlugin {
               Incomplete.linearize(inc).filter(x => x.message.isDefined || x.directCause.isDefined)
                 .map { case i @ Incomplete(node, tpe, message, causes, directCause) =>
                   def nodeName: String = node match {
-                    case Some(key: ScopedKey[_]) => showKey(key)
-                    case Some(t: Task[_])        =>
+                    case Some(key: ScopedKey[?]) => showKey(key)
+                    case Some(t: Task[?])        =>
                       t.info.name
                         .orElse(t.info.attributes.get(taskDefinitionKey).map(showKey))
                         .getOrElse(t.info.toString)

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -19,7 +19,7 @@ import sbt.Keys._
  */
 object VersionGenerator {
 
-  def versionSettings: Seq[Setting[_]] = inConfig(Compile)(Seq(
+  def versionSettings: Seq[Setting[?]] = inConfig(Compile)(Seq(
     resourceGenerators += generateVersion(resourceManaged, _ / "pekko-http-version.conf",
       """|pekko.http.version = "%s"
          |"""),


### PR DESCRIPTION
### Motivation
Let Scala 3 Community build compile pekko-http.

### Modification
Update `.scalafmt.conf` dialect to `scala213source3` and enable Scala 3 syntax rewrite rules (`rewrite.scala3.convertToNewSyntax`), then reformat all sources. Key changes:
- Wildcard type `_` → `?` (e.g. `Class[_]` → `Class[?]`)

### Result
Code is compatible with Scala 3 compiler when built with the community build.

### Tests
Not run - formatting only

### References
Refs apache/pekko#3048