### PR TITLE
fix: replace private[this] with private and =_ with explicit defaults

### DIFF
--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/cors/CorsBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/cors/CorsBenchmark.scala
@@ -49,10 +49,10 @@ class CorsBenchmark extends Directives with CorsDirectives {
   private val http = Http()
   private val corsSettings = CorsSettings.default
 
-  private var binding: ServerBinding = _
-  private var request: HttpRequest = _
-  private var requestCors: HttpRequest = _
-  private var requestPreflight: HttpRequest = _
+  private var binding: ServerBinding = null
+  private var request: HttpRequest = null
+  private var requestCors: HttpRequest = null
+  private var requestPreflight: HttpRequest = null
 
   @Setup
   def setup(): Unit = {

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
@@ -40,12 +40,12 @@ class ConnectionPoolBenchmark extends CommonBenchmark {
   import ConnectionPoolBenchmark._
 
   @Param(Array("1", "10", "100", "1000", "10000"))
-  var maxConnections: String = _
+  var maxConnections: String = null
 
-  implicit var system: ActorSystem = _
+  implicit var system: ActorSystem = null
   implicit def ec: ExecutionContext = system.dispatcher
 
-  private var poolSettings: ConnectionPoolSettings = _
+  private var poolSettings: ConnectionPoolSettings = null
 
   val request = HttpRequest(uri = "http://localhost:8080")
 

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HeaderParserBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HeaderParserBenchmark.scala
@@ -38,7 +38,7 @@ private[engine] class HeaderParserBenchmark {
   @Param(Array("no", "yes"))
   var withCustomMediaTypes = "no"
 
-  var parser: HttpHeaderParser = _
+  var parser: HttpHeaderParser = null
 
   val request = """GET / HTTP/1.1
       |

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HttpEntityBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HttpEntityBenchmark.scala
@@ -30,11 +30,11 @@ import com.typesafe.config.ConfigFactory
 
 class HttpEntityBenchmark extends CommonBenchmark {
   @Param(Array("strict", "default"))
-  var entityType: String = _
+  var entityType: String = null
 
-  implicit var system: ActorSystem = _
+  implicit var system: ActorSystem = null
 
-  var entity: HttpEntity = _
+  var entity: HttpEntity = null
 
   @Benchmark
   def discardBytes(): Unit = {

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ServerProcessingBenchmark.scala
@@ -37,8 +37,8 @@ class ServerProcessingBenchmark extends CommonBenchmark {
   val request = ByteString("GET / HTTP/1.1\r\nHost: localhost\r\nUser-Agent: test\r\n\r\n")
   val response = HttpResponse()
 
-  var httpFlow: Flow[ByteString, ByteString, Any] = _
-  implicit var system: ActorSystem = _
+  var httpFlow: Flow[ByteString, ByteString, Any] = null
+  implicit var system: ActorSystem = null
 
   @Benchmark
   @OperationsPerInvocation(10000)

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/StreamServerProcessingBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/StreamServerProcessingBenchmark.scala
@@ -46,19 +46,19 @@ class StreamServerProcessingBenchmark extends CommonBenchmark {
   val totalBytes: String = "1000000"
 
   @Param(Array("10", "100", "1000"))
-  var numChunks: String = _
+  var numChunks: String = null
 
-  var totalExpectedBytes: Long = _
+  var totalExpectedBytes: Long = 0L
 
   // @Param(Array("100")) -- not a param any more
   var numRequestsPerConnection: String = "100"
 
   @Param(Array("strict", "default", "chunked"))
-  var entityType: String = _
+  var entityType: String = null
 
-  var httpFlow: Flow[ByteString, ByteString, Any] = _
+  var httpFlow: Flow[ByteString, ByteString, Any] = null
 
-  implicit var system: ActorSystem = _
+  implicit var system: ActorSystem = null
 
   @Benchmark
   def benchRequestProcessing(): Unit = {

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2ClientServerBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2ClientServerBenchmark.scala
@@ -39,13 +39,13 @@ import com.typesafe.config.ConfigFactory
  * for the response. Does not include the network.
  */
 class H2ClientServerBenchmark extends CommonBenchmark with H2RequestResponseBenchmark {
-  var httpFlow: Flow[HttpRequest, HttpResponse, Any] = _
-  implicit var system: ActorSystem = _
+  var httpFlow: Flow[HttpRequest, HttpResponse, Any] = null
+  implicit var system: ActorSystem = null
 
   val numRequests = 1000
 
   @Param(Array("[]", "[\"reset\"]"))
-  var frameTypeThrottleFrameTypes: String = _
+  var frameTypeThrottleFrameTypes: String = null
 
   @Benchmark
   @OperationsPerInvocation(1000) // should be same as numRequest

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2RequestResponseBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2RequestResponseBenchmark.scala
@@ -36,15 +36,15 @@ import com.typesafe.config.ConfigFactory
 
 trait H2RequestResponseBenchmark extends HPackEncodingSupport {
   @Param(Array("1"))
-  var minStrictEntitySize: String = _
+  var minStrictEntitySize: String = null
 
   @Param(Array("empty", "singleframe"))
-  var requestbody: String = _
+  var requestbody: String = null
 
   @Param(Array("strict", "closedelimited" /* Not enable by default:, "chunked", "empty"*/ ))
-  var responsetype: String = _
+  var responsetype: String = null
 
-  protected var response: HttpResponse = _
+  protected var response: HttpResponse = null
 
   private val requestBytes = ByteString("abcde")
   private def requestWithoutBody(streamId: Int): ByteString =
@@ -53,15 +53,15 @@ trait H2RequestResponseBenchmark extends HPackEncodingSupport {
     FrameRenderer.render(HeadersFrame(streamId, endStream = false, endHeaders = true, headerBlock(streamId), None)) ++
     FrameRenderer.render(DataFrame(streamId, endStream = true, requestBytes))
 
-  private var firstRequestHeaderBlock: ByteString = _
+  private var firstRequestHeaderBlock: ByteString = null
   // use header compression for subsequent requests
-  private var subsequentRequestHeaderBlock: ByteString = _
+  private var subsequentRequestHeaderBlock: ByteString = null
   private def headerBlock(streamId: Int): ByteString =
     if (streamId == 1) firstRequestHeaderBlock
     else subsequentRequestHeaderBlock
 
-  protected var requestDataCreator: Int => ByteString = _
-  protected var request: HttpRequest = _
+  protected var requestDataCreator: Int => ByteString = null
+  protected var request: HttpRequest = null
 
   def numRequests: Int
   lazy val config =

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
@@ -32,8 +32,8 @@ import pekko.util.ByteString
 
 class H2ServerProcessingBenchmark extends CommonBenchmark with H2RequestResponseBenchmark {
 
-  var httpFlow: Flow[ByteString, ByteString, Any] = _
-  implicit var system: ActorSystem = _
+  var httpFlow: Flow[ByteString, ByteString, Any] = null
+  implicit var system: ActorSystem = null
 
   val packedResponse = ByteString(1, 5, 0, 0) // a HEADERS frame with end_stream == true
 

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
@@ -55,8 +55,8 @@ class LineParserBenchmark {
 
   lazy val line = ByteString("x" * lineSize + "\n")
 
-  var parserGraph: RunnableGraph[Future[Done]] = _
-  var tempFile: Path = _
+  var parserGraph: RunnableGraph[Future[Done]] = null
+  var tempFile: Path = null
 
   @Setup
   def setup(): Unit = {

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -185,7 +185,7 @@ private[http] object OutgoingConnectionBlueprint {
 
     override def createLogic(effectiveAttributes: Attributes) =
       new GraphStageLogic(shape) with InHandler with OutHandler {
-        private var entitySource: SubSourceOutlet[ResponseOutput] = _
+        private var entitySource: SubSourceOutlet[ResponseOutput] = null
         private def entitySubstreamStarted = entitySource ne null
         private def idle = this
         private var completionDeferred = false

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolId.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolId.scala
@@ -49,6 +49,6 @@ private[http] object PoolId {
     def name: String = s"#$id"
   }
 
-  private[this] val uniquePoolId = new AtomicLong(0)
+  private val uniquePoolId = new AtomicLong(0)
   def newUniquePool() = UniquePool(uniquePoolId.incrementAndGet())
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
@@ -104,7 +104,7 @@ private[http] object PoolInterface {
       requestOut: Outlet[RequestContext], responseIn: Inlet[ResponseContext], bufferSize: Int,
       val log: LoggingAdapter)(implicit executionContext: ExecutionContext) extends TimerGraphStageLogic(shape)
       with PoolInterface with InHandler with OutHandler with LogHelper {
-    private[this] val PoolOverflowException = new BufferOverflowException( // stack trace cannot be prevented here because `BufferOverflowException` is final
+    private val PoolOverflowException = new BufferOverflowException( // stack trace cannot be prevented here because `BufferOverflowException` is final
       s"Exceeded configured max-open-requests value of [${poolId.hcps.setup.settings.maxOpenRequests}]. This means that the request queue of this pool (${poolId.hcps}) " +
       s"has completely filled up because the pool currently does not process requests fast enough to handle the incoming request load. " +
       "Please retry the request later. See https://pekko.apache.org/docs/pekko-http/current/scala/http/client-side/pool-overflow.html for " +

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolMasterActor.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolMasterActor.scala
@@ -126,12 +126,12 @@ private[http] object PoolMaster {
  */
 @InternalApi
 private[http] final class PoolMasterActor extends Actor with ActorLogging {
-  private[this] val thisMaster: PoolMaster = new PoolMaster(self)
+  private val thisMaster: PoolMaster = new PoolMaster(self)
 
   import PoolMasterActor._
 
-  private[this] var statusById = Map[PoolId, PoolInterfaceStatus]()
-  private[this] var idByPool = Map[PoolInterface, PoolId]()
+  private var statusById = Map[PoolId, PoolInterfaceStatus]()
+  private var idByPool = Map[PoolInterface, PoolId]()
 
   /**
    * Start a new pool interface actor, register it in our maps, and watch its death. No actor should
@@ -141,7 +141,7 @@ private[http] final class PoolMasterActor extends Actor with ActorLogging {
    * @param fm the materializer to use for this pool
    * @return the newly created actor ref
    */
-  private[this] def startPoolInterface(poolId: PoolId)(implicit fm: Materializer): PoolInterface = {
+  private def startPoolInterface(poolId: PoolId)(implicit fm: Materializer): PoolInterface = {
     if (statusById.contains(poolId)) {
       throw new IllegalStateException(s"pool interface actor for $poolId already exists")
     }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -76,7 +76,7 @@ private[client] object NewHostConnectionPool {
 
         setHandlers(requestsIn, responsesOut, this)
 
-        private[this] var lastTimeoutId = 0L
+        private var lastTimeoutId = 0L
 
         val slots = Vector.tabulate(_settings.maxConnections)(new Slot(_))
         val slotsWaitingForDispatch: util.Deque[Slot] = new util.ArrayDeque[Slot]
@@ -205,8 +205,8 @@ private[client] object NewHostConnectionPool {
         }
 
         protected trait StateHandling {
-          private[this] var _state: SlotState = Unconnected
-          private[this] var _changedIntoThisStateNanos: Long = System.nanoTime()
+          private var _state: SlotState = Unconnected
+          private var _changedIntoThisStateNanos: Long = System.nanoTime()
 
           def changedIntoThisStateNanos: Long = _changedIntoThisStateNanos
           def state: SlotState = _state
@@ -217,12 +217,12 @@ private[client] object NewHostConnectionPool {
         }
 
         final class Slot(val slotId: Int) extends SlotContext with StateHandling {
-          private[this] var currentTimeoutId: Long = -1
-          private[this] var currentTimeout: Cancellable = _
-          private[this] var disconnectAt: Long = Long.MaxValue
-          private[this] var isEnqueuedForResponseDispatch: Boolean = false
+          private var currentTimeoutId: Long = -1
+          private var currentTimeout: Cancellable = null
+          private var disconnectAt: Long = Long.MaxValue
+          private var isEnqueuedForResponseDispatch: Boolean = false
 
-          private[this] var connection: SlotConnection = _
+          private var connection: SlotConnection = null
           def isIdle: Boolean = state.isIdle
           def isConnected: Boolean = state.isConnected
           def shutdown(): Unit = {
@@ -435,7 +435,7 @@ private[client] object NewHostConnectionPool {
             Instant.now().toEpochMilli > disconnectAt
           } else false
 
-          private[this] def cancelCurrentTimeout(): Unit =
+          private def cancelCurrentTimeout(): Unit =
             if (currentTimeout ne null) {
               currentTimeout.cancel()
               currentTimeout = null

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
@@ -67,7 +67,7 @@ private[http] final class Http2Ext(implicit val system: ActorSystem)
 
   import Http2._
 
-  private[this] final val DefaultPortForProtocol = -1 // any negative value
+  private final val DefaultPortForProtocol = -1 // any negative value
 
   val http = Http(system)
   val telemetry = TelemetrySpi.create(system)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2Demux.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2Demux.scala
@@ -321,7 +321,7 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings,
         multiplexer.pushControlFrame(frame)
         // FIXME: handle the connection closing according to the specification
       }
-      private[this] var allowReadingIncomingFrames: Boolean = true
+      private var allowReadingIncomingFrames: Boolean = true
       override def allowReadingIncomingFrames(allow: Boolean): Unit = {
         if (allow != allowReadingIncomingFrames)
           if (allow) {

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
@@ -55,7 +55,7 @@ private[http] final class BodyPartParser(
   sealed trait StateResult // phantom type for ensuring soundness of our parsing method setup
 
   // TODO: prevent re-priming header parser from scratch
-  private[this] val headerParser = HttpHeaderParser(settings, log)
+  private val headerParser = HttpHeaderParser(settings, log)
 
   val in = Inlet[ByteString]("BodyPartParser.in")
   val out = Outlet[BodyPartParser.Output]("BodyPartParser.out")

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BoyerMoore.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BoyerMoore.scala
@@ -22,9 +22,9 @@ import org.apache.pekko.util.ByteString
 private[parsing] class BoyerMoore(needle: Array[Byte]) {
   require(needle.length > 0, "needle must be non-empty")
 
-  private[this] val nl1 = needle.length - 1
+  private val nl1 = needle.length - 1
 
-  private[this] val charTable: Array[Int] = {
+  private val charTable: Array[Int] = {
     val table = Array.fill(256)(needle.length)
     @tailrec def rec(i: Int): Unit =
       if (i < nl1) {
@@ -35,7 +35,7 @@ private[parsing] class BoyerMoore(needle: Array[Byte]) {
     table
   }
 
-  private[this] val offsetTable: Array[Int] = {
+  private val offsetTable: Array[Int] = {
     val table = new Array[Int](needle.length)
 
     @tailrec def isPrefix(i: Int, j: Int): Boolean =

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -83,13 +83,13 @@ private[engine] final class HttpHeaderParser private (
     val settings: HttpHeaderParser.Settings,
     val log: LoggingAdapter,
     onIllegalHeader: ErrorInfo => Unit,
-    private[this] var nodes: Array[Char] = new Array(512), // initial size, can grow as needed
-    private[this] var nodeCount: Int = 0,
-    private[this] var branchData: Array[Short] = new Array(254 * 3),
-    private[this] var branchDataCount: Int = 0,
-    private[this] var values: Array[AnyRef] = new Array(255), // fixed size of 255
-    private[this] var valueCount: Int = 0,
-    private[this] var trieIsPrivate: Boolean = false) { // signals the trie data can be mutated w/o having to copy first
+    private var nodes: Array[Char] = new Array(512), // initial size, can grow as needed
+    private var nodeCount: Int = 0,
+    private var branchData: Array[Short] = new Array(254 * 3),
+    private var branchDataCount: Int = 0,
+    private var values: Array[AnyRef] = new Array(255), // fixed size of 255
+    private var valueCount: Int = 0,
+    private var trieIsPrivate: Boolean = false) { // signals the trie data can be mutated w/o having to copy first
 
   // TODO: evaluate whether switching to a value-class-based approach allows us to improve code readability without sacrificing performance
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
@@ -47,14 +47,14 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
   //   - null: currently no output
   //   - Output: one output element
   //   - ListBuffer: several output elements
-  private[this] var result: AnyRef = null
-  private[this] var state: ByteString => StateResult = startNewMessage(_, 0)
-  private[this] var protocol: HttpProtocol = `HTTP/1.1`
+  private var result: AnyRef = null
+  private var state: ByteString => StateResult = startNewMessage(_, 0)
+  private var protocol: HttpProtocol = `HTTP/1.1`
   protected var completionHandling: CompletionHandling = CompletionOk
   protected var terminated = false
 
-  private[this] var lastSession: SSLSession = null // used to prevent having to recreate header on each message
-  private[this] var tlsSessionInfoHeader: `Tls-Session-Info` = null
+  private var lastSession: SSLSession = null // used to prevent having to recreate header on each message
+  private var tlsSessionInfoHeader: `Tls-Session-Info` = null
 
   protected def settings: ParserSettings
   protected def headerParser: HttpHeaderParser

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpRequestParser.scala
@@ -66,9 +66,9 @@ private[http] final class HttpRequestParser(
       override val headerParser = self.headerParser.createShallowCopy()
       override val isResponseParser = false
 
-      private[this] var method: HttpMethod = _
-      private[this] var uri: Uri = _
-      private[this] var uriBytes: ByteString = _
+      private var method: HttpMethod = null
+      private var uri: Uri = null
+      private var uriBytes: ByteString = null
 
       override def onPush(): Unit = handleParserOutput(parseSessionBytes(grab(in)))
       override def onPull(): Unit = handleParserOutput(doPull())

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpResponseParser.scala
@@ -41,8 +41,8 @@ private[http] class HttpResponseParser(protected val settings: ParserSettings,
   import HttpMessageParser._
   import settings._
 
-  private[this] var contextForCurrentResponse: Option[ResponseContext] = None
-  private[this] var statusCode: StatusCode = StatusCodes.OK
+  private var contextForCurrentResponse: Option[ResponseContext] = None
+  private var statusCode: StatusCode = StatusCodes.OK
 
   final override val isResponseParser = true
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
@@ -127,7 +127,7 @@ private[http] object HttpServerBluePrint {
 
         var downstreamPullWaiting = false
         var completionDeferred = false
-        var entitySource: SubSourceOutlet[RequestOutput] = _
+        var entitySource: SubSourceOutlet[RequestOutput] = null
 
         // optimization: to avoid allocations the "idle" case in and out handlers are put directly on the GraphStageLogic itself
         override def onPull(): Unit = {

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/Utf8Decoder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/Utf8Decoder.scala
@@ -50,8 +50,8 @@ import scala.util.Try
  */
 @InternalApi
 private[http] object Utf8Decoder extends StreamingCharsetDecoder {
-  private[this] val Utf8Accept = 0
-  private[this] val Utf8Reject = 12
+  private val Utf8Accept = 0
+  private val Utf8Reject = 12
 
   val characterClasses =
     Array[Byte](

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/WebSocket.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/WebSocket.scala
@@ -95,13 +95,13 @@ private[http] object WebSocket {
     }
   }
 
-  private[this] final val PingFullFrame: FrameStart =
+  private final val PingFullFrame: FrameStart =
     FrameEvent.fullFrame(Opcode.Ping, None, ByteString.empty, fin = true)
-  private[this] final val mkDirectAnswerPing = () => DirectAnswer(PingFullFrame)
+  private final val mkDirectAnswerPing = () => DirectAnswer(PingFullFrame)
 
-  private[this] final val PongFullFrame: FrameStart =
+  private final val PongFullFrame: FrameStart =
     FrameEvent.fullFrame(Opcode.Pong, None, ByteString.empty, fin = true)
-  private[this] final val mkDirectAnswerPong = () => DirectAnswer(PongFullFrame)
+  private final val mkDirectAnswerPong = () => DirectAnswer(PongFullFrame)
 
   /**
    * The layer that implements all low-level frame handling, like handling control frames, collecting messages

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/UriParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/UriParser.scala
@@ -31,7 +31,7 @@ import org.parboiled2.Parser.DeliveryScheme.Either
  */
 @InternalApi
 private[http] final class UriParser(
-    private[this] var _input: ParserInput,
+    private var _input: ParserInput,
     val uriParsingCharset: Charset,
     val uriParsingMode: Uri.ParsingMode,
     val maxValueStackSize: Int) extends Parser(maxValueStackSize = maxValueStackSize)
@@ -119,40 +119,40 @@ private[http] final class UriParser(
     Uri.fail(s"Illegal $target: " + formatter.format(error, input), formatter.formatErrorLine(error, input))
   }
 
-  private[this] val `path-segment-char` = uriParsingMode match {
+  private val `path-segment-char` = uriParsingMode match {
     case Uri.ParsingMode.Strict => `pchar-base`
     case _                      => `relaxed-path-segment-char`
   }
-  private[this] val `query-char` = uriParsingMode match {
+  private val `query-char` = uriParsingMode match {
     case Uri.ParsingMode.Strict => `query-fragment-char`
     case _                      => `relaxed-query-char`
   }
-  private[this] val `query-key-char` = uriParsingMode match {
+  private val `query-key-char` = uriParsingMode match {
     case Uri.ParsingMode.Strict  => `strict-query-key-char`
     case Uri.ParsingMode.Relaxed => `relaxed-query-key-char`
   }
-  private[this] val `query-value-char` = uriParsingMode match {
+  private val `query-value-char` = uriParsingMode match {
     case Uri.ParsingMode.Strict  => `strict-query-value-char`
     case Uri.ParsingMode.Relaxed => `relaxed-query-value-char`
   }
-  private[this] val `fragment-char` = uriParsingMode match {
+  private val `fragment-char` = uriParsingMode match {
     case Uri.ParsingMode.Strict => `query-fragment-char`
     case _                      => `relaxed-fragment-char`
   }
 
   // New vars need to be reset in `reset` below
-  private[this] var _scheme = ""
-  private[this] var _userinfo = ""
-  private[this] var _host: Host = Host.Empty
-  private[this] var _port: Int = 0
-  private[this] var _path: Path = Path.Empty
+  private var _scheme = ""
+  private var _userinfo = ""
+  private var _host: Host = Host.Empty
+  private var _port: Int = 0
+  private var _path: Path = Path.Empty
 
   /**
    *  Percent-encoded. When in in 'relaxed' mode, characters not permitted by https://tools.ietf.org/html/rfc3986#section-3.4
    *  are already automatically percent-encoded here
    */
-  private[this] var _rawQueryString: Option[String] = None
-  private[this] var _fragment: Option[String] = None
+  private var _rawQueryString: Option[String] = None
+  private var _fragment: Option[String] = None
 
   /** Allows to reuse this parser. */
   def reset(newInput: ParserInput): Unit = {
@@ -167,14 +167,14 @@ private[http] final class UriParser(
     _firstPercentIx = -1
   }
 
-  private[this] def setScheme(scheme: String): Unit = _scheme = scheme
-  private[this] def setUserInfo(userinfo: String): Unit = _userinfo = userinfo
-  private[this] def setHost(host: Host): Unit = _host = host
-  private[this] def setPort(port: Int): Unit = _port = port
-  private[this] def setPath(path: Path): Unit = _path = path
-  private[this] def setRawQueryString(rawQueryString: String): Unit =
+  private def setScheme(scheme: String): Unit = _scheme = scheme
+  private def setUserInfo(userinfo: String): Unit = _userinfo = userinfo
+  private def setHost(host: Host): Unit = _host = host
+  private def setPort(port: Int): Unit = _port = port
+  private def setPath(path: Path): Unit = _path = path
+  private def setRawQueryString(rawQueryString: String): Unit =
     _rawQueryString = Some(parseSafeRawQueryString(rawQueryString))
-  private[this] def setFragment(fragment: String): Unit = _fragment = Some(fragment)
+  private def setFragment(fragment: String): Unit = _fragment = Some(fragment)
 
   // http://tools.ietf.org/html/rfc3986#appendix-A
 
@@ -371,7 +371,7 @@ private[http] final class UriParser(
 
   private def savePath() = rule { run(setPath(Path(sb.toString, uriParsingCharset))) }
 
-  private[this] var _firstPercentIx = -1
+  private var _firstPercentIx = -1
 
   private def clearSBForDecoding(): Rule0 = rule { run { sb.setLength(0); _firstPercentIx = -1 } }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ParserSettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ParserSettingsImpl.scala
@@ -88,8 +88,8 @@ private[pekko] final case class ParserSettingsImpl(
 
 object ParserSettingsImpl extends SettingsCompanionImpl[ParserSettingsImpl]("pekko.http.parsing") {
 
-  private[this] val noCustomMethods: String => Option[HttpMethod] = ConstantFun.scalaAnyToNone
-  private[this] val noCustomStatusCodes: Int => Option[StatusCode] = ConstantFun.scalaAnyToNone
+  private val noCustomMethods: String => Option[HttpMethod] = ConstantFun.scalaAnyToNone
+  private val noCustomStatusCodes: Int => Option[StatusCode] = ConstantFun.scalaAnyToNone
   private[ParserSettingsImpl] val noCustomMediaTypes: (String, String) => Option[MediaType] =
     ConstantFun.scalaAnyTwoToNone
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/ObjectRegistry.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/ObjectRegistry.scala
@@ -23,7 +23,7 @@ import org.apache.pekko.annotation.InternalApi
  */
 @InternalApi
 private[http] trait ObjectRegistry[K, V <: AnyRef] {
-  private[this] var _registry = Map.empty[K, V]
+  private var _registry = Map.empty[K, V]
 
   protected final def register(key: K, obj: V): obj.type = {
     require(!_registry.contains(key), s"ObjectRegistry for ${getClass.getSimpleName} already contains value for $key")

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/Rendering.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/Rendering.scala
@@ -67,7 +67,7 @@ private[http] trait LazyValueBytesRenderable extends Renderable {
   // unsynchronized and non-volatile lazy init, worst case: we init once per core
   // which, since instances of derived classes are usually long-lived, is still better
   // that a synchronization overhead or even @volatile reads
-  private[this] var _valueBytes: Array[Byte] = _
+  private var _valueBytes: Array[Byte] = null
   private def valueBytes =
     if (_valueBytes != null) _valueBytes else { _valueBytes = value.asciiBytes; _valueBytes }
 
@@ -84,7 +84,7 @@ private[http] trait LazyValueBytesRenderable extends Renderable {
  */
 @InternalApi
 private[http] trait SingletonValueRenderable extends Product with Renderable {
-  private[this] val valueBytes = value.asciiBytes
+  private val valueBytes = value.asciiBytes
   def value = productPrefix
   def render[R <: Rendering](r: R): r.type = r ~~ valueBytes
 }
@@ -281,7 +281,7 @@ private[http] object Rendering {
  */
 @InternalApi
 private[http] class StringRendering extends Rendering {
-  private[this] val sb = new java.lang.StringBuilder
+  private val sb = new java.lang.StringBuilder
   def ~~(ch: Char): this.type = { sb.append(ch); this }
   def ~~(bytes: Array[Byte]): this.type = {
     @tailrec def rec(ix: Int = 0): this.type =
@@ -316,9 +316,9 @@ private[http] class StringRendering extends Rendering {
 private[http] class ByteArrayRendering(sizeHint: Int, logDiscardedHeader: String => Unit = _ => ()) extends Rendering {
   def this(sizeHint: Int) = this(sizeHint, _ => ())
 
-  private[this] var array = new Array[Byte](sizeHint)
+  private var array = new Array[Byte](sizeHint)
 
-  private[this] var size = 0
+  private var size = 0
 
   def get: Array[Byte] =
     if (size == array.length) array
@@ -388,7 +388,7 @@ private[http] class ByteArrayRendering(sizeHint: Int, logDiscardedHeader: String
 private[http] class ByteStringRendering(sizeHint: Int, logDiscardedHeader: String => Unit = _ => ()) extends Rendering {
   def this(sizeHint: Int) = this(sizeHint, _ => ())
 
-  private[this] val builder = new ByteStringBuilder
+  private val builder = new ByteStringBuilder
   builder.sizeHint(sizeHint)
 
   def get: ByteString = builder.result()
@@ -434,8 +434,8 @@ private[http] class ByteStringRendering(sizeHint: Int, logDiscardedHeader: Strin
  */
 @InternalApi
 private[http] class CustomCharsetByteStringRendering(nioCharset: Charset, sizeHint: Int) extends Rendering {
-  private[this] val charBuffer = CharBuffer.allocate(64)
-  private[this] val builder = new ByteStringBuilder
+  private val charBuffer = CharBuffer.allocate(64)
+  private val builder = new ByteStringBuilder
   builder.sizeHint(sizeHint)
 
   def get: ByteString = {

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/SettingsCompanionImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/SettingsCompanionImpl.scala
@@ -31,7 +31,7 @@ import pekko.annotation.InternalApi
 @InternalApi
 private[http] abstract class SettingsCompanionImpl[T](protected val prefix: String) {
   private final val MaxCached = 8
-  private[this] var cache = ListMap.empty[ActorSystem, T]
+  private var cache = ListMap.empty[ActorSystem, T]
 
   implicit def default(implicit refFactory: ActorRefFactory): T =
     apply(actorSystem)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -106,7 +106,7 @@ private[http] object StreamUtils {
           setHandlers(in, out, this)
 
           // KillSwitch implementation
-          private[this] val killCallback = getAsyncCallback[Try[Unit]](handleKill)
+          private val killCallback = getAsyncCallback[Try[Unit]](handleKill)
 
           def handleKill(result: Try[Unit]): Unit = result match {
             case Success(_)  => completeStage()

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
@@ -56,7 +56,7 @@ package object util {
       byteStrings: Source[ByteString, Mat]): EnhancedByteStringSource[Mat] =
     new EnhancedByteStringSource(byteStrings)
 
-  private[this] var eventStreamLogger: ActorRef = _
+  private var eventStreamLogger: ActorRef = null
   private[http] def installEventStreamLoggerFor(channel: Class[?])(implicit system: ActorSystem): Unit = {
     synchronized {
       if (eventStreamLogger == null)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
@@ -82,11 +82,11 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
 
   import Http._
 
-  private[this] val defaultConnectionPoolSettings = ConnectionPoolSettings(system)
+  private val defaultConnectionPoolSettings = ConnectionPoolSettings(system)
 
   // configured default HttpsContext for the client-side
   // SYNCHRONIZED ACCESS ONLY!
-  private[this] var _defaultClientHttpsConnectionContext: HttpsConnectionContext = _
+  private var _defaultClientHttpsConnectionContext: HttpsConnectionContext = null
 
   // ** SERVER ** //
 
@@ -321,7 +321,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
   // ** CLIENT ** //
 
   private[http] val poolMaster: PoolMaster = PoolMaster()
-  private[this] val systemMaterializer = SystemMaterializer(system).materializer
+  private val systemMaterializer = SystemMaterializer(system).materializer
 
   /**
    * Creates a builder which will create a single connection to a host every time the built flow is materialized. There

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ContentType.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ContentType.scala
@@ -59,7 +59,7 @@ sealed trait ContentType extends jm.ContentType with ValueRenderable {
   def mediaType: MediaType
   def charsetOption: Option[HttpCharset]
 
-  private[this] var _toString: String = _
+  private var _toString: String = null
   override def toString: String = {
     if (_toString eq null)
       _toString = super.toString

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/DateTime.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/DateTime.scala
@@ -138,8 +138,8 @@ final case class DateTime private (
 }
 
 object DateTime {
-  private[this] val WEEKDAYS = Array("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
-  private[this] val MONTHS = Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+  private val WEEKDAYS = Array("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
+  private val MONTHS = Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
 
   /**
    * Returns the three-letter string for the weekday with the given index. Sunday is zero.

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpCharset.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpCharset.scala
@@ -61,7 +61,7 @@ object HttpCharsetRange {
 
 final case class HttpCharset private[http] (override val value: String)(val aliases: immutable.Seq[String])
     extends jm.HttpCharset with SingletonValueRenderable with WithQValue[HttpCharsetRange] {
-  @transient private[this] var _nioCharset: Try[Charset] = HttpCharset.findNioCharset(value)
+  @transient private var _nioCharset: Try[Charset] = HttpCharset.findNioCharset(value)
 
   /** Returns the Charset for this charset if available or throws an exception otherwise */
   def nioCharset: Charset = _nioCharset.get

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/MediaType.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/MediaType.scala
@@ -325,7 +325,7 @@ object MediaTypes extends ObjectRegistry[(String, String), MediaType] {
   /** Function used to find a custom media type. Called before the predefined media types. Strings will be lowercase. */
   type FindCustom = (String, String) => Option[MediaType]
 
-  private[this] var extensionMap = Map.empty[String, MediaType]
+  private var extensionMap = Map.empty[String, MediaType]
 
   def forExtensionOption(ext: String): Option[MediaType] = extensionMap.get(ext.toLowerCase)
   def forExtension(ext: String): MediaType = extensionMap.getOrElse(ext.toLowerCase, `application/octet-stream`)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
@@ -37,7 +37,7 @@ import pekko.http.scaladsl.model._
 sealed abstract class ModeledCompanion[T: ClassTag] extends Renderable {
   val name = ModeledCompanion.nameFromClass(getClass)
   val lowercaseName = name.toRootLowerCase
-  private[this] val nameAndColonSpaceBytes = (name + ": ").asciiBytes
+  private val nameAndColonSpaceBytes = (name + ": ").asciiBytes
   final def render[R <: Rendering](r: R): r.type = r ~~ nameAndColonSpaceBytes
 
   /**
@@ -71,7 +71,7 @@ sealed trait ModeledHeader extends HttpHeader with Serializable {
   def renderInRequests: Boolean = false // default implementation
   def renderInResponses: Boolean = false // default implementation
   def name: String = companion.name
-  private[this] var _value: String = _
+  private var _value: String = null
   def value: String = {
     if (_value eq null) _value = renderValue(new StringRendering).get
     _value
@@ -105,7 +105,7 @@ abstract class CustomHeader extends jm.headers.CustomHeader {
  */
 abstract class ModeledCustomHeaderCompanion[H <: ModeledCustomHeader[H]] {
   def name: String
-  private var _lowercaseName: String = _
+  private var _lowercaseName: String = null
   def lowercaseName: String = {
     if (_lowercaseName eq null) _lowercaseName = name.toRootLowerCase
     _lowercaseName

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/WebSocketUpgrade.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/WebSocketUpgrade.scala
@@ -104,7 +104,7 @@ trait WebSocketUpgrade extends jm.ws.WebSocketUpgrade {
       subprotocol: String): HttpResponse =
     handleMessages(createScalaFlow(inSink, outSource), subprotocol = Some(subprotocol))
 
-  private[this] def createScalaFlow(inSink: Graph[SinkShape[jm.ws.Message], ? <: Any],
+  private def createScalaFlow(inSink: Graph[SinkShape[jm.ws.Message], ? <: Any],
       outSource: Graph[SourceShape[jm.ws.Message], ? <: Any]): Graph[FlowShape[Message, Message], NotUsed] =
     JavaMapping.toScala(scaladsl.Flow.fromSinkAndSourceMat(inSink, outSource)(scaladsl.Keep.none): Graph[FlowShape[
         jm.ws.Message, jm.ws.Message], NotUsed])

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/util/FastFuture.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/util/FastFuture.scala
@@ -78,7 +78,7 @@ object FastFuture {
     case Success(t) => FulfilledFuture(t)
     case Failure(e) => ErrorFuture(e)
   }
-  private[this] val _successful: Any => Future[Any] = FulfilledFuture.apply
+  private val _successful: Any => Future[Any] = FulfilledFuture.apply
   def successful[T]: T => Future[T] = _successful.asInstanceOf[T => Future[T]]
   val failed: Throwable => Future[Nothing] = ErrorFuture.apply
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -351,12 +351,12 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends Pekko
       zeroHashStrings.next().hashCode should be(0)
 
       def regular(): Unit = {
-        val (_, accept: Accept) = parseLine(regularHeader)
-        accept.mediaRanges.head.getParams.size should be(numKeys)
+        val (_, accept) = parseLine(regularHeader)
+        accept.asInstanceOf[Accept].mediaRanges.head.getParams.size should be(numKeys)
       }
       def colliding(): Unit = {
-        val (_, accept: Accept) = parseLine(collidingHeader)
-        accept.mediaRanges.head.getParams.size should be(numKeys)
+        val (_, accept) = parseLine(collidingHeader)
+        accept.asInstanceOf[Accept].mediaRanges.head.getParams.size should be(numKeys)
       }
 
       BenchUtils.nanoRace(regular(), colliding()) should be < 3.0 // speed must be in same order of magnitude
@@ -423,7 +423,7 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends Pekko
       if (headerA eq headerB) 1 else 0
     }
 
-    private[this] val random = new Random(42)
+    private val random = new Random(42)
     def nextRandomPrintableChar(): Char = random.nextPrintableChar()
     def nextRandomInt(min: Int, max: Int) = random.nextInt(max - min) + min
     @tailrec final def nextRandomAlphaNumChar(): Char = {

--- a/http-core/src/test/scala/org/apache/pekko/testkit/Coroner.scala
+++ b/http-core/src/test/scala/org/apache/pekko/testkit/Coroner.scala
@@ -262,7 +262,7 @@ object Coroner {
 trait WatchedByCoroner {
   self: TestKit =>
 
-  @volatile private var coronerWatch: Coroner.WatchHandle = _
+  @volatile private var coronerWatch: Coroner.WatchHandle = null
 
   final def startCoroner(): Unit = {
     coronerWatch = Coroner.watch(expectedTestDuration.dilated, getClass.getName, System.err,

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/ActorSystemExtension.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/ActorSystemExtension.scala
@@ -45,7 +45,7 @@ class ActorSystemExtension(name: String, additionalConfig: Config)
   implicit def system: ActorSystem = _system
   implicit def materializer: Materializer = SystemMaterializer.get(system).materializer
 
-  private[this] var _system: ActorSystem = null
+  private var _system: ActorSystem = null
 
   override def beforeEach(context: ExtensionContext): Unit = {
     require(_system eq null, "ActorSystem already created; nested test execution is not supported")

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/JUnitRouteTest.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/JUnitRouteTest.scala
@@ -70,7 +70,7 @@ abstract class JUnitRouteTestBase extends RouteTest {
 abstract class JUnitRouteTest extends JUnitRouteTestBase {
   protected def additionalConfig: Config = ConfigFactory.empty()
 
-  private[this] val _systemResource = new ActorSystemResource(Logging.simpleName(getClass), additionalConfig)
+  private val _systemResource = new ActorSystemResource(Logging.simpleName(getClass), additionalConfig)
   @Rule
   protected def systemResource: ActorSystemResource = _systemResource
 }
@@ -83,7 +83,7 @@ class ActorSystemResource(name: String, additionalConfig: Config) extends Extern
   implicit def system: ActorSystem = _system
   implicit def materializer: Materializer = SystemMaterializer.get(system).materializer
 
-  private[this] var _system: ActorSystem = null
+  private var _system: ActorSystem = null
 
   override def before(): Unit = {
     require(_system eq null)

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestResultComponent.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestResultComponent.scala
@@ -34,8 +34,8 @@ trait RouteTestResultComponent {
    * A receptacle for the response or rejections created by a route.
    */
   class RouteTestResult(timeout: FiniteDuration)(implicit fm: Materializer) {
-    private[this] var result: Option[Either[immutable.Seq[Rejection], HttpResponse]] = None
-    private[this] val latch = new CountDownLatch(1)
+    private var result: Option[Either[immutable.Seq[Rejection], HttpResponse]] = None
+    private val latch = new CountDownLatch(1)
 
     def handled: Boolean = synchronized { result.isDefined && result.get.isRight }
 
@@ -100,7 +100,7 @@ trait RouteTestResultComponent {
       this
     }
 
-    private[this] lazy val entityRecreator: () => ResponseEntity =
+    private lazy val entityRecreator: () => ResponseEntity =
       rawResponse.entity match {
         case s: HttpEntity.Strict => () => s
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/PathMatchers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/PathMatchers.scala
@@ -29,29 +29,29 @@ final class PathMatchers
 object PathMatchers {
   import JavaPathMatchers._
 
-  private[this] val IntegerSegment: PathMatcher1[java.lang.Integer] = fromScala1(SPathMatchers.IntNumber.map { i =>
+  private val IntegerSegment: PathMatcher1[java.lang.Integer] = fromScala1(SPathMatchers.IntNumber.map { i =>
     i: java.lang.Integer
   })
-  private[this] val LongSegment: PathMatcher1[java.lang.Long] = fromScala1(SPathMatchers.LongNumber.map { i =>
+  private val LongSegment: PathMatcher1[java.lang.Long] = fromScala1(SPathMatchers.LongNumber.map { i =>
     i: java.lang.Long
   })
-  private[this] val HexIntegerSegment: PathMatcher1[java.lang.Integer] =
+  private val HexIntegerSegment: PathMatcher1[java.lang.Integer] =
     fromScala1(SPathMatchers.HexIntNumber.map { i => i: java.lang.Integer })
-  private[this] val HexLongSegment: PathMatcher1[java.lang.Long] = fromScala1(SPathMatchers.HexLongNumber.map { i =>
+  private val HexLongSegment: PathMatcher1[java.lang.Long] = fromScala1(SPathMatchers.HexLongNumber.map { i =>
     i: java.lang.Long
   })
-  private[this] val DoubleSegment: PathMatcher1[java.lang.Double] = fromScala1(SPathMatchers.DoubleNumber.map { i =>
+  private val DoubleSegment: PathMatcher1[java.lang.Double] = fromScala1(SPathMatchers.DoubleNumber.map { i =>
     i: java.lang.Double
   })
-  private[this] val UUIDSegment: PathMatcher1[UUID] = fromScala1(SPathMatchers.JavaUUID)
+  private val UUIDSegment: PathMatcher1[UUID] = fromScala1(SPathMatchers.JavaUUID)
 
-  private[this] val Neutral = fromScala0(SPathMatchers.Neutral)
-  private[this] val Slash = new PathMatcher0(SPathMatchers.Slash)
-  private[this] val PathEnd = new PathMatcher0(SPathMatchers.PathEnd)
-  private[this] val Remaining = new PathMatcher1[String](SPathMatchers.Remaining)
-  private[this] val RemainingPath = new PathMatcher1[Path](SPathMatchers.RemainingPath)
-  private[this] val Segment = new PathMatcher1[String](SPathMatchers.Segment)
-  private[this] val Segments = new PathMatcher1[java.util.List[String]](SPathMatchers.Segments.map(_.asJava))
+  private val Neutral = fromScala0(SPathMatchers.Neutral)
+  private val Slash = new PathMatcher0(SPathMatchers.Slash)
+  private val PathEnd = new PathMatcher0(SPathMatchers.PathEnd)
+  private val Remaining = new PathMatcher1[String](SPathMatchers.Remaining)
+  private val RemainingPath = new PathMatcher1[Path](SPathMatchers.RemainingPath)
+  private val Segment = new PathMatcher1[String](SPathMatchers.Segment)
+  private val Segments = new PathMatcher1[java.util.List[String]](SPathMatchers.Segments.map(_.asJava))
 
   /**
    * Converts a path string containing slashes into a PathMatcher that interprets slashes as

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -66,7 +66,7 @@ abstract class FramedEntityStreamingDirectives extends TimeoutDirectives {
     D.complete(response)
   }
 
-  private[this] val ByteStringAsEntityFn = new java.util.function.Function[ByteString, HttpEntity]() {
+  private val ByteStringAsEntityFn = new java.util.function.Function[ByteString, HttpEntity]() {
     override def apply(bs: ByteString): HttpEntity = HttpEntities.create(bs)
   }
 }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
@@ -71,8 +71,8 @@ private[coding] object GzipCompressor {
 private[coding] class GzipDecompressor(
     maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
   override def createLogic(attr: Attributes) = new ParsingLogic {
-    private[this] val inflater = new Inflater(true)
-    private[this] val crc32: CRC32 = new CRC32
+    private val inflater = new Inflater(true)
+    private val crc32: CRC32 = new CRC32
 
     trait Step extends ParseStep[ByteString] {
       override def onTruncation(): Unit = failStage(new ZipException("Truncated GZIP stream"))

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RejectionHandler.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RejectionHandler.scala
@@ -75,8 +75,8 @@ object RejectionHandler {
   def newBuilder(): Builder = new Builder(isDefault = false)
 
   final class Builder private[RejectionHandler] (isDefault: Boolean) {
-    private[this] val cases = new immutable.VectorBuilder[Handler]
-    private[this] var notFound: Option[Route] = None
+    private val cases = new immutable.VectorBuilder[Handler]
+    private var notFound: Option[Route] = None
 
     /**
      * Handles a single [[Rejection]] with the given partial function.


### PR DESCRIPTION
## Summary

- Replace `private[this]` with `private` across ~40 files (Scala 3 deprecation: `private[this]` is subsumed by `private`)
- Replace `= _` with explicit defaults (`= null`, `= 0L`, etc.) across ~15 files (Scala 3 deprecation)
- Fix refutable pattern in `HttpHeaderParserSpec` (`val` type annotation → `asInstanceOf`)

## Details

These are purely mechanical changes to address Scala 3 deprecation warnings. No behavioral changes.

### `private[this]` → `private`
Affects benchmarks, core engine classes, parsers, model classes, testkit, and test code.

### `= _` → explicit defaults
Replaces uninitialized var declarations with explicit defaults (`= null` for reference types, `= 0L` for longs, etc.).

### Test fix
`HttpHeaderParserSpec`: refutable pattern in `val` definition (type annotation) replaced with `asInstanceOf`.

## Test plan
- [x] `sbt "++ 2.13 Test/compile"` passes
- [x] `sbt "++ 3.3 Test/compile"` passes
- [x] No behavioral changes — purely mechanical refactoring

### Motivation
Scala 3 deprecates `private[this]` and `= _` syntax. These changes ensure forward compatibility.

### Modification
Mechanical replacement of deprecated syntax across ~50 files.

### Result
All modules compile cleanly on both Scala 2.13.18 and 3.3.8 with no deprecation warnings for these patterns.

### Tests
- `sbt "++ 2.13 Test/compile"` passes
- `sbt "++ 3.3 Test/compile"` passes

### References
None - Scala 3 forward compatibility