### PR TITLE
build: fix sbt lint warnings by excluding unused keys

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -15,9 +15,16 @@ import sbt._
 import Keys._
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
 import com.typesafe.tools.mima.plugin.MimaKeys._
+import sbtunidoc.BaseUnidocPlugin.autoImport.unidocProjectFilter
 
 object Common extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
+  override lazy val globalSettings = Seq(
+    Global / excludeLintKeys ++= Set(
+      projectInfoVersion,
+      mimaReportSignatureProblems,
+      autoAPIMappings,
+      unidocProjectFilter))
   override lazy val projectSettings = Seq(
     projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
     scalacOptions ++= Seq(


### PR DESCRIPTION
### Motivation
sbt lint reported 45 unused keys (`projectInfoVersion`, `mimaReportSignatureProblems`, `autoAPIMappings`, `unidocProjectFilter`) across sub-projects. These keys are intentionally set in `Common.scala` and `Doc.scala` plugins with `allRequirements` trigger but are only read in specific scopes, causing spurious lint warnings.

### Modification
Add `projectInfoVersion`, `mimaReportSignatureProblems`, `autoAPIMappings`, and `unidocProjectFilter` to `excludeLintKeys` in `project/Common.scala` `globalSettings`.

### Result
All 45 sbt lint warnings resolved with a single centralized exclusion in the common plugin.

### Tests
- `sbt "http-core / compile; http / compile; parsing / compile"` - no sbt lint warnings
- `sbt "http-caching / compile; http-cors / compile; http-testkit / compile; http-marshallers-scala / compile; http-marshallers-java / compile"` - no sbt lint warnings

### References
None - build configuration cleanup