### PR TITLE
refactor: modernize Java test code with Java 17 features

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
@@ -101,31 +101,11 @@ public class HttpServerActorInteractionExample extends AllDirectives {
   static class Auction extends AbstractBehavior<Auction.Message> {
     interface Message {}
 
-    static class Bid implements Message {
-      public final String userId;
-      public final int offer;
+    record Bid(String userId, int offer) implements Message {}
 
-      Bid(String userId, int offer) {
-        this.userId = userId;
-        this.offer = offer;
-      }
-    }
+    record GetBids(ActorRef<Bids> replyTo) implements Message {}
 
-    static class GetBids implements Message {
-      final ActorRef<Bids> replyTo;
-
-      GetBids(ActorRef<Bids> replyTo) {
-        this.replyTo = replyTo;
-      }
-    }
-
-    static class Bids {
-      public final List<Bid> bids;
-
-      Bids(List<Bid> bids) {
-        this.bids = bids;
-      }
-    }
+    record Bids(List<Bid> bids) {}
 
     public Auction(ActorContext<Message> context) {
       super(context);
@@ -147,12 +127,12 @@ public class HttpServerActorInteractionExample extends AllDirectives {
 
     private Behavior<Message> onBid(Bid bid) {
       bids.add(bid);
-      getContext().getLog().info("Bid complete: {}, {}", bid.userId, bid.offer);
+      getContext().getLog().info("Bid complete: {}, {}", bid.userId(), bid.offer());
       return this;
     }
 
     private Behavior<Message> onGetBids(GetBids getBids) {
-      getBids.replyTo.tell(new Bids(bids));
+      getBids.replyTo().tell(new Bids(bids));
       return this;
     }
   }

--- a/http-marshallers-java/http-jackson/src/test/java/org/apache/pekko/http/javadsl/marshallers/jackson/JacksonTest.java
+++ b/http-marshallers-java/http-jackson/src/test/java/org/apache/pekko/http/javadsl/marshallers/jackson/JacksonTest.java
@@ -15,8 +15,6 @@ package org.apache.pekko.http.javadsl.marshallers.jackson;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.core.util.BufferRecycler;
@@ -39,14 +37,7 @@ import org.junit.jupiter.api.Test;
 
 public class JacksonTest extends JUnitJupiterRouteTest {
 
-  public static class SomeData {
-    public final String field;
-
-    @JsonCreator
-    public SomeData(@JsonProperty("field") String field) {
-      this.field = field;
-    }
-  }
+  public record SomeData(@com.fasterxml.jackson.annotation.JsonProperty("field") String field) {}
 
   RequestEntity invalidEntity =
       HttpEntities.create(
@@ -79,7 +70,8 @@ public class JacksonTest extends JUnitJupiterRouteTest {
 
   @Test
   public void detailsShouldBeHiddenFromResponseEntity() throws Exception {
-    Route route = entity(Jackson.unmarshaller(SomeData.class), theData -> complete(theData.field));
+    Route route =
+        entity(Jackson.unmarshaller(SomeData.class), theData -> complete(theData.field()));
 
     runRoute(route.seal(), HttpRequest.PUT("/").withEntity(invalidEntity))
         .assertEntity("The request content was malformed:\nCannot unmarshal JSON as SomeData");
@@ -94,23 +86,16 @@ public class JacksonTest extends JUnitJupiterRouteTest {
     final long maxTokenCount = 9876543210L;
     final int maxNestingDepth = 5;
     String configText =
-        "read.max-number-length="
-            + maxNumLen
-            + "\n"
-            + "read.max-name-length="
-            + maxNameLen
-            + "\n"
-            + "read.max-string-length="
-            + maxStringLen
-            + "\n"
-            + "read.max-document-length="
-            + maxDocLen
-            + "\n"
-            + "read.max-token-count="
-            + maxTokenCount
-            + "\n"
-            + "read.max-nesting-depth="
-            + maxNestingDepth;
+        """
+        read.max-number-length=%d
+        read.max-name-length=%d
+        read.max-string-length=%d
+        read.max-document-length=%d
+        read.max-token-count=%d
+        read.max-nesting-depth=%d\
+        """
+            .formatted(
+                maxNumLen, maxNameLen, maxStringLen, maxDocLen, maxTokenCount, maxNestingDepth);
     Config config = ConfigFactory.parseString(configText).withFallback(getDefaultConfig());
     ObjectMapper mapper = Jackson.createMapper(config);
     StreamReadConstraints constraints = mapper.getFactory().streamReadConstraints();
@@ -144,10 +129,11 @@ public class JacksonTest extends JUnitJupiterRouteTest {
     final String poolType = "bounded";
     final int poolSize = 10;
     String configText =
-        "buffer-recycler.pool-instance="
-            + poolType
-            + "\nbuffer-recycler.bounded-pool-size="
-            + poolSize;
+        """
+        buffer-recycler.pool-instance=%s
+        buffer-recycler.bounded-pool-size=%d\
+        """
+            .formatted(poolType, poolSize);
     Config config = ConfigFactory.parseString(configText).withFallback(getDefaultConfig());
     ObjectMapper mapper = Jackson.createMapper(config);
     RecyclerPool<BufferRecycler> recyclerPool = mapper.getFactory()._getRecyclerPool();

--- a/http-marshallers-java/http-jackson3/src/test/java/org/apache/pekko/http/javadsl/marshallers/jackson3/JacksonTest.java
+++ b/http-marshallers-java/http-jackson3/src/test/java/org/apache/pekko/http/javadsl/marshallers/jackson3/JacksonTest.java
@@ -15,8 +15,6 @@ package org.apache.pekko.http.javadsl.marshallers.jackson3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.concurrent.CompletionStage;
@@ -39,14 +37,7 @@ import tools.jackson.core.util.RecyclerPool;
 
 public class JacksonTest extends JUnitJupiterRouteTest {
 
-  public static class SomeData {
-    public final String field;
-
-    @JsonCreator
-    public SomeData(@JsonProperty("field") String field) {
-      this.field = field;
-    }
-  }
+  public record SomeData(@com.fasterxml.jackson.annotation.JsonProperty("field") String field) {}
 
   RequestEntity invalidEntity =
       HttpEntities.create(
@@ -79,7 +70,8 @@ public class JacksonTest extends JUnitJupiterRouteTest {
 
   @Test
   public void detailsShouldBeHiddenFromResponseEntity() throws Exception {
-    Route route = entity(Jackson.unmarshaller(SomeData.class), theData -> complete(theData.field));
+    Route route =
+        entity(Jackson.unmarshaller(SomeData.class), theData -> complete(theData.field()));
 
     runRoute(route.seal(), HttpRequest.PUT("/").withEntity(invalidEntity))
         .assertEntity("The request content was malformed:\nCannot unmarshal JSON as SomeData");
@@ -94,23 +86,16 @@ public class JacksonTest extends JUnitJupiterRouteTest {
     final long maxTokenCount = 9876543210L;
     final int maxNestingDepth = 5;
     String configText =
-        "read.max-number-length="
-            + maxNumLen
-            + "\n"
-            + "read.max-name-length="
-            + maxNameLen
-            + "\n"
-            + "read.max-string-length="
-            + maxStringLen
-            + "\n"
-            + "read.max-document-length="
-            + maxDocLen
-            + "\n"
-            + "read.max-token-count="
-            + maxTokenCount
-            + "\n"
-            + "read.max-nesting-depth="
-            + maxNestingDepth;
+        """
+        read.max-number-length=%d
+        read.max-name-length=%d
+        read.max-string-length=%d
+        read.max-document-length=%d
+        read.max-token-count=%d
+        read.max-nesting-depth=%d\
+        """
+            .formatted(
+                maxNumLen, maxNameLen, maxStringLen, maxDocLen, maxTokenCount, maxNestingDepth);
     Config config = ConfigFactory.parseString(configText).withFallback(getDefaultConfig());
     JsonFactory jsonFactory = Jackson.createJsonFactory(config);
     StreamReadConstraints constraints = jsonFactory.streamReadConstraints();
@@ -144,10 +129,11 @@ public class JacksonTest extends JUnitJupiterRouteTest {
     final String poolType = "bounded";
     final int poolSize = 10;
     String configText =
-        "buffer-recycler.pool-instance="
-            + poolType
-            + "\nbuffer-recycler.bounded-pool-size="
-            + poolSize;
+        """
+        buffer-recycler.pool-instance=%s
+        buffer-recycler.bounded-pool-size=%d\
+        """
+            .formatted(poolType, poolSize);
     Config config = ConfigFactory.parseString(configText).withFallback(getDefaultConfig());
     JsonFactory jsonFactory = Jackson.createJsonFactory(config);
     RecyclerPool<BufferRecycler> recyclerPool = jsonFactory._getRecyclerPool();


### PR DESCRIPTION
### Motivation
Java 17 introduced records and text blocks that make Java code more concise and readable.

### Modification
- Convert SomeData to a record in both Jackson and Jackson3 test modules
- Convert Bid, GetBids, Bids to records in HttpServerActorInteractionExample
- Use text blocks for multi-line config strings in Jackson tests
- Update field accesses to use record accessor methods

### Result
Test Java code is more concise and idiomatic for Java 17+, reducing boilerplate.

### Tests
- `sbt "http-marshallers-java/http-jackson / Test / compile"` (to be verified by CI)
- `sbt "http-marshallers-java/http-jackson3 / Test / compile"` (to be verified by CI)
- `sbt "docs / Test / compile"` (to be verified by CI)

### References
None - code modernization