### PR TITLE
Add directional test for NUL byte in request target

### DIFF
--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
@@ -625,6 +625,16 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
           ErrorInfo("The server does not support the HTTP protocol version used in the request."))
       }
 
+      "a NUL byte in the request target" in new Test {
+        val result = multiParse(newParser)(Seq("GET /\u0000HTTP/1.1 HTTP/1.1\r\n"))
+        result.length shouldEqual 1
+        result.head match {
+          case Left(MessageStartError(BadRequest, info)) =>
+            info.summary should startWith("Illegal request-target")
+          case other => fail(s"Expected BadRequest MessageStartError but got $other")
+        }
+      }
+
       "with an illegal char in a header name" in new Test {
         """GET / HTTP/1.1
           |User@Agent: curl/7.19.7""" should parseToError(BadRequest, ErrorInfo("Illegal character '@' in header name"))


### PR DESCRIPTION
### Motivation

A request-smuggling class of vulnerability exists when HTTP parsers silently strip boundary control bytes (NUL, CR, LF, VT, FF) from the version token before matching — see [netty/netty#16970](https://github.com/netty/netty/issues/16970).

Pekko HTTP uses byte-level exact matching at fixed offsets in `HttpMessageParser.parseProtocol` (`HttpMessageParser.scala:130-140`) — no `trim()` or whitespace/control-character stripping. Analysis confirms Pekko HTTP is **not affected** by this vulnerability: a NUL byte in the request line is consumed into the URI by `parseRequestTarget` and rejected by the URI parser before the version token is ever reached.

However, no existing test in `RequestParserSpec` exercises this code path with control characters. This PR adds a directional test to lock in the behavior and prevent regressions from future parsing refactors.

### Modification

Add a directional test case `"a NUL byte in the request target"` in `RequestParserSpec` that feeds a NUL byte inside the request target and asserts the parser rejects the request with `BadRequest` and an `"Illegal request-target"` error summary.

### Result

The test suite now explicitly covers control-character rejection in the request line, guarding against regressions from future parsing refactors that might introduce `trim()`-like behavior.

### Tests

- `sbt "http-core / Test / testOnly *RequestParserCRLFSpec *RequestParserLFSpec"` — 106 tests passed, 0 failed

### References

- Refs #1087
- Refs https://github.com/netty/netty/issues/16970