### PR TITLE
refactor: replace .collect(Collectors.toList()) with .toList()

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/HttpClientDecodingExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpClientDecodingExampleTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.http.javadsl.coding.Coder;
@@ -63,7 +62,7 @@ public class HttpClientDecodingExampleTest {
         httpRequests.stream()
             .map(req -> http.singleRequest(req).thenApply(decodeResponse))
             .map(CompletionStage::toCompletableFuture)
-            .collect(Collectors.toList());
+            .toList();
 
     for (CompletableFuture<HttpResponse> futureResponse : futureResponses) {
       final HttpResponse httpResponse = futureResponse.get();


### PR DESCRIPTION
### Motivation
Java 16+ `Stream.toList()` provides a concise way to collect stream elements into an unmodifiable list.

### Modification
Replace `.collect(Collectors.toList())` with `.toList()` in HttpClientDecodingExampleTest. Remove unused `Collectors` import.

### Result
Cleaner stream collection code using Java 17 API.

### Tests
Not run - compile-only test file changes

### References
None - Java 17 API modernization