### PR TITLE
refactor: migrate String.format to String.formatted (Java 15+)

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/HttpRequestDetailedStringExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpRequestDetailedStringExampleTest.java
@@ -31,7 +31,7 @@ public class HttpRequestDetailedStringExampleTest {
     RequestEntity entity = request.entity();
     HttpProtocol protocol = request.protocol();
 
-    return String.format("HttpRequest(%s, %s, %s, %s, %s)", method, uri, headers, entity, protocol);
+    return "HttpRequest(%s, %s, %s, %s, %s)".formatted(method, uri, headers, entity, protocol);
   }
 
   @Test

--- a/docs/src/test/java/docs/http/javadsl/HttpResponseDetailedStringExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpResponseDetailedStringExampleTest.java
@@ -31,7 +31,7 @@ public class HttpResponseDetailedStringExampleTest {
     HttpEntity entity = response.entity();
     HttpProtocol protocol = response.protocol();
 
-    return String.format("HttpResponse(%s, %s, %s, %s)", status, headers, entity, protocol);
+    return "HttpResponse(%s, %s, %s, %s)".formatted(status, headers, entity, protocol);
   }
 
   @Test

--- a/docs/src/test/java/docs/http/javadsl/server/FormFieldRequestValsExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/FormFieldRequestValsExampleTest.java
@@ -48,7 +48,7 @@ public class FormFieldRequestValsExampleTest extends JUnitJupiterRouteTest {
                 formField(
                     StringUnmarshallers.INTEGER,
                     "age",
-                    a -> complete(String.format("Name: %s, age: %d", n, a))));
+                    a -> complete("Name: %s, age: %d".formatted(n, a))));
 
     // tests:
     final FormData formData =
@@ -66,7 +66,7 @@ public class FormFieldRequestValsExampleTest extends JUnitJupiterRouteTest {
         StringUnmarshaller.sync(s -> new SampleId(Integer.valueOf(s)));
 
     final Route route =
-        formField(SAMPLE_ID, "id", sid -> complete(String.format("SampleId: %s", sid.id)));
+        formField(SAMPLE_ID, "id", sid -> complete("SampleId: %s".formatted(sid.id)));
 
     // tests:
     final FormData formData = FormData.create(Pair.create("id", "1337"));

--- a/docs/src/test/java/docs/http/javadsl/server/HeaderRequestValsExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HeaderRequestValsExampleTest.java
@@ -38,7 +38,7 @@ public class HeaderRequestValsExampleTest extends JUnitJupiterRouteTest {
   public void testHeaderVals() {
     // #by-class
 
-    final Route route = extractHost(host -> complete(String.format("Host header was: %s", host)));
+    final Route route = extractHost(host -> complete("Host header was: %s".formatted(host)));
 
     // tests:
     final HttpRequest request =
@@ -57,7 +57,7 @@ public class HeaderRequestValsExampleTest extends JUnitJupiterRouteTest {
         headerValueByName(
             "X-Fish-Name",
             xFishName ->
-                complete(String.format("The `X-Fish-Name` header's value was: %s", xFishName)));
+                complete("The `X-Fish-Name` header's value was: %s".formatted(xFishName)));
 
     // tests:
     final HttpRequest request =

--- a/docs/src/test/java/docs/http/javadsl/server/HeaderRequestValsExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HeaderRequestValsExampleTest.java
@@ -56,8 +56,7 @@ public class HeaderRequestValsExampleTest extends JUnitJupiterRouteTest {
         // extract the `value` of the header:
         headerValueByName(
             "X-Fish-Name",
-            xFishName ->
-                complete("The `X-Fish-Name` header's value was: %s".formatted(xFishName)));
+            xFishName -> complete("The `X-Fish-Name` header's value was: %s".formatted(xFishName)));
 
     // tests:
     final HttpRequest request =

--- a/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
@@ -135,9 +135,7 @@ public class WebSocketCoreExample {
         defaultSettings
             .getWebsocketSettings()
             .withPeriodicKeepAliveData(
-                () ->
-                    ByteString.fromString(
-                        "debug-%d".formatted(pingCounter.incrementAndGet())));
+                () -> ByteString.fromString("debug-%d".formatted(pingCounter.incrementAndGet())));
 
     ServerSettings customServerSettings =
         defaultSettings.withWebsocketSettings(customWebsocketSettings);
@@ -160,9 +158,7 @@ public class WebSocketCoreExample {
         defaultSettings
             .getWebsocketSettings()
             .withPeriodicKeepAliveData(
-                () ->
-                    ByteString.fromString(
-                        "debug-%d".formatted(pingCounter.incrementAndGet())));
+                () -> ByteString.fromString("debug-%d".formatted(pingCounter.incrementAndGet())));
 
     ClientConnectionSettings customSettings =
         defaultSettings.withWebsocketSettings(customWebsocketSettings);

--- a/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
@@ -137,7 +137,7 @@ public class WebSocketCoreExample {
             .withPeriodicKeepAliveData(
                 () ->
                     ByteString.fromString(
-                        String.format("debug-%d", pingCounter.incrementAndGet())));
+                        "debug-%d".formatted(pingCounter.incrementAndGet())));
 
     ServerSettings customServerSettings =
         defaultSettings.withWebsocketSettings(customWebsocketSettings);
@@ -162,7 +162,7 @@ public class WebSocketCoreExample {
             .withPeriodicKeepAliveData(
                 () ->
                     ByteString.fromString(
-                        String.format("debug-%d", pingCounter.incrementAndGet())));
+                        "debug-%d".formatted(pingCounter.incrementAndGet())));
 
     ClientConnectionSettings customSettings =
         defaultSettings.withWebsocketSettings(customWebsocketSettings);

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
@@ -82,8 +82,7 @@ public class CachingDirectivesExamplesTest extends JUnitJupiterRouteTest {
                         extractUri(
                             uri ->
                                 complete(
-                                    String.format(
-                                        "Request for %s @ count %d",
+                                    "Request for %s @ count %d".formatted(
                                         uri, count.incrementAndGet())))));
 
     // tests:
@@ -137,8 +136,7 @@ public class CachingDirectivesExamplesTest extends JUnitJupiterRouteTest {
                         extractUri(
                             uri ->
                                 complete(
-                                    String.format(
-                                        "Request for %s @ count %d",
+                                    "Request for %s @ count %d".formatted(
                                         uri, count.incrementAndGet())))));
 
     // tests:
@@ -188,7 +186,7 @@ public class CachingDirectivesExamplesTest extends JUnitJupiterRouteTest {
     final Route innerRoute =
         extractUri(
             uri ->
-                complete(String.format("Request for %s @ count %d", uri, count.incrementAndGet())));
+                complete("Request for %s @ count %d".formatted(uri, count.incrementAndGet())));
 
     // #create-cache
     final CachingSettings defaultCachingSettings = CachingSettings.create(system());

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
@@ -82,8 +82,8 @@ public class CachingDirectivesExamplesTest extends JUnitJupiterRouteTest {
                         extractUri(
                             uri ->
                                 complete(
-                                    "Request for %s @ count %d".formatted(
-                                        uri, count.incrementAndGet())))));
+                                    "Request for %s @ count %d"
+                                        .formatted(uri, count.incrementAndGet())))));
 
     // tests:
     testRoute(route)
@@ -136,8 +136,8 @@ public class CachingDirectivesExamplesTest extends JUnitJupiterRouteTest {
                         extractUri(
                             uri ->
                                 complete(
-                                    "Request for %s @ count %d".formatted(
-                                        uri, count.incrementAndGet())))));
+                                    "Request for %s @ count %d"
+                                        .formatted(uri, count.incrementAndGet())))));
 
     // tests:
     testRoute(route)
@@ -185,8 +185,7 @@ public class CachingDirectivesExamplesTest extends JUnitJupiterRouteTest {
     final AtomicInteger count = new AtomicInteger(0);
     final Route innerRoute =
         extractUri(
-            uri ->
-                complete("Request for %s @ count %d".formatted(uri, count.incrementAndGet())));
+            uri -> complete("Request for %s @ count %d".formatted(uri, count.incrementAndGet())));
 
     // #create-cache
     final CachingSettings defaultCachingSettings = CachingSettings.create(system());

--- a/docs/src/test/java/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
@@ -122,7 +122,7 @@ public class DebuggingDirectivesExamplesTest extends JUnitJupiterRouteTest {
     Function<HttpResponse, LogEntry> showSuccessAsInfo =
         (response) ->
             LogEntry.create(
-                String.format("Response code '%d'", response.status().intValue()), InfoLevel());
+                "Response code '%d'".formatted(response.status().intValue()), InfoLevel());
 
     Function<List<Rejection>, LogEntry> showRejectionAsInfo =
         (rejections) ->

--- a/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
@@ -39,8 +39,7 @@ public class SchemeDirectivesExamplesTest extends JUnitJupiterRouteTest {
   @Test
   public void testScheme() {
     // #extractScheme
-    final Route route =
-        extractScheme((scheme) -> complete("The scheme is '%s'".formatted(scheme)));
+    final Route route = extractScheme((scheme) -> complete("The scheme is '%s'".formatted(scheme)));
     testRoute(route)
         .run(HttpRequest.GET("https://www.example.com/"))
         .assertEntity("The scheme is 'https'");

--- a/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
@@ -40,7 +40,7 @@ public class SchemeDirectivesExamplesTest extends JUnitJupiterRouteTest {
   public void testScheme() {
     // #extractScheme
     final Route route =
-        extractScheme((scheme) -> complete(String.format("The scheme is '%s'", scheme)));
+        extractScheme((scheme) -> complete("The scheme is '%s'".formatted(scheme)));
     testRoute(route)
         .run(HttpRequest.GET("https://www.example.com/"))
         .assertEntity("The scheme is 'https'");

--- a/docs/src/test/java/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
@@ -53,7 +53,7 @@ public class TimeoutDirectivesExamplesTest extends AllDirectives {
   private final Http http = Http.get(system);
 
   private void shutdown(ServerBinding b) throws Exception {
-    System.out.println(String.format("Unbinding from %s", b.localAddress()));
+    System.out.println("Unbinding from %s".formatted(b.localAddress()));
 
     b.unbind().toCompletableFuture().get(3, TimeUnit.SECONDS);
   }

--- a/http-tests/src/main/java/org/apache/pekko/http/javadsl/server/examples/simple/SimpleServerApp.java
+++ b/http-tests/src/main/java/org/apache/pekko/http/javadsl/server/examples/simple/SimpleServerApp.java
@@ -45,7 +45,7 @@ public class SimpleServerApp {
   // #https-http-app
   public Route multiply(int x, int y) {
     int result = x * y;
-    return complete(String.format("%d * %d = %d", x, y, result));
+    return complete("%d * %d = %d".formatted(x, y, result));
   }
 
   public CompletionStage<Route> multiplyAsync(Executor ctx, int x, int y) {
@@ -63,13 +63,13 @@ public class SimpleServerApp {
                     "y",
                     y -> {
                       int result = x + y;
-                      return complete(String.format("%d + %d = %d", x, y, result));
+                      return complete("%d + %d = %d".formatted(x, y, result));
                     }));
 
     BiFunction<Integer, Integer, Route> subtractHandler =
         (x, y) -> {
           int result = x - y;
-          return complete(String.format("%d - %d = %d", x, y, result));
+          return complete("%d - %d = %d".formatted(x, y, result));
         };
 
     return concat(

--- a/http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
+++ b/http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
@@ -70,7 +70,7 @@ public class HandlerExampleDocTest extends JUnitJupiterRouteTest {
                   extractUri(
                       uri ->
                           complete(
-                              String.format("This was a %s request to %s", method.name(), uri))));
+                              "This was a %s request to %s".formatted(method.name(), uri))));
 
       Route handlerResponse =
           extractMethod(
@@ -81,7 +81,7 @@ public class HandlerExampleDocTest extends JUnitJupiterRouteTest {
                         final HttpResponse response =
                             HttpResponse.create()
                                 .withEntity(
-                                    String.format("Accepted %s request to %s", method.name(), uri))
+                                    "Accepted %s request to %s".formatted(method.name(), uri))
                                 .withStatus(StatusCodes.ACCEPTED);
                         return complete(response);
                       }));

--- a/http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
+++ b/http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
@@ -69,8 +69,7 @@ public class HandlerExampleDocTest extends JUnitJupiterRouteTest {
               method ->
                   extractUri(
                       uri ->
-                          complete(
-                              "This was a %s request to %s".formatted(method.name(), uri))));
+                          complete("This was a %s request to %s".formatted(method.name(), uri))));
 
       Route handlerResponse =
           extractMethod(

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/CompleteTest.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/CompleteTest.java
@@ -69,7 +69,7 @@ public class CompleteTest extends JUnitJupiterRouteTest {
     return CompletableFuture.supplyAsync(
         () -> {
           int result = x + y;
-          return String.format("%d + %d = %d", x, y, result);
+          return "%d + %d = %d".formatted(x, y, result);
         });
   }
 

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/JavaTestServer.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/JavaTestServer.java
@@ -79,7 +79,7 @@ public class JavaTestServer {
                 authenticateBasic(
                     "My basic secure site",
                     handleAuth,
-                    (login) -> complete(String.format("Hello, %s!", login))));
+                    (login) -> complete("Hello, %s!".formatted(login))));
 
     final Route ping = path("ping", () -> complete("PONG!"));
 
@@ -198,7 +198,7 @@ public class JavaTestServer {
   private CompletionStage<Void> shutdown(CompletionStage<ServerBinding> binding) {
     return binding.thenAccept(
         b -> {
-          System.out.println(String.format("Unbinding from %s", b.localAddress()));
+          System.out.println("Unbinding from %s".formatted(b.localAddress()));
 
           final CompletionStage<?> unbound = b.unbind();
           try {

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/directives/PathDirectivesTest.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/directives/PathDirectivesTest.java
@@ -204,7 +204,7 @@ public class PathDirectivesTest extends JUnitJupiterRouteTest {
         testRoute(
             path(
                 segment("multiply").slash(integerSegment()).slash("with").slash(integerSegment()),
-                (x, y) -> complete(String.format("%d * %d = %d", x, y, x * y))));
+                (x, y) -> complete("%d * %d = %d".formatted(x, y, x * y))));
 
     route.run(HttpRequest.GET("/multiply/3/with/6")).assertEntity("3 * 6 = 18");
   }


### PR DESCRIPTION
## Summary
- Migrate `String.format("literal", args)` to `"literal".formatted(args)` (Java 15+ API)
- 14 files updated including HTTP server examples, test files, and SimpleServerApp
- Behavior-preserving refactoring, no functional changes

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17