### PR TITLE
refactor: migrate switch statements to modern switch syntax (Java 14+)

### DIFF
--- a/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
+++ b/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
@@ -123,19 +123,13 @@ public class Jackson {
 
   private static RecyclerPool<BufferRecycler> getBufferRecyclerPool(final Config cfg) {
     final String poolType = cfg.getString("buffer-recycler.pool-instance");
-    switch (poolType) {
-      case "thread-local":
-        return JsonRecyclerPools.threadLocalPool();
-      case "concurrent-deque":
-        return JsonRecyclerPools.newConcurrentDequePool();
-      case "shared-concurrent-deque":
-        return JsonRecyclerPools.sharedConcurrentDequePool();
-      case "bounded":
-        return JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"));
-      case "non-recycling":
-        return JsonRecyclerPools.nonRecyclingPool();
-      default:
-        throw new IllegalArgumentException("Unknown recycler-pool: " + poolType);
-    }
+    return switch (poolType) {
+      case "thread-local" -> JsonRecyclerPools.threadLocalPool();
+      case "concurrent-deque" -> JsonRecyclerPools.newConcurrentDequePool();
+      case "shared-concurrent-deque" -> JsonRecyclerPools.sharedConcurrentDequePool();
+      case "bounded" -> JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"));
+      case "non-recycling" -> JsonRecyclerPools.nonRecyclingPool();
+      default -> throw new IllegalArgumentException("Unknown recycler-pool: " + poolType);
+    };
   }
 }

--- a/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
+++ b/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
@@ -127,7 +127,8 @@ public class Jackson {
       case "thread-local" -> JsonRecyclerPools.threadLocalPool();
       case "concurrent-deque" -> JsonRecyclerPools.newConcurrentDequePool();
       case "shared-concurrent-deque" -> JsonRecyclerPools.sharedConcurrentDequePool();
-      case "bounded" -> JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"));
+      case "bounded" ->
+          JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"));
       case "non-recycling" -> JsonRecyclerPools.nonRecyclingPool();
       default -> throw new IllegalArgumentException("Unknown recycler-pool: " + poolType);
     };

--- a/http-marshallers-java/http-jackson3/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson3/Jackson.java
+++ b/http-marshallers-java/http-jackson3/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson3/Jackson.java
@@ -133,7 +133,8 @@ public class Jackson {
       case "thread-local" -> JsonRecyclerPools.threadLocalPool();
       case "concurrent-deque" -> JsonRecyclerPools.newConcurrentDequePool();
       case "shared-concurrent-deque" -> JsonRecyclerPools.sharedConcurrentDequePool();
-      case "bounded" -> JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"));
+      case "bounded" ->
+          JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"));
       case "non-recycling" -> JsonRecyclerPools.nonRecyclingPool();
       default -> throw new IllegalArgumentException("Unknown recycler-pool: " + poolType);
     };

--- a/http-marshallers-java/http-jackson3/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson3/Jackson.java
+++ b/http-marshallers-java/http-jackson3/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson3/Jackson.java
@@ -129,19 +129,13 @@ public class Jackson {
 
   private static RecyclerPool<BufferRecycler> getBufferRecyclerPool(final Config cfg) {
     final String poolType = cfg.getString("buffer-recycler.pool-instance");
-    switch (poolType) {
-      case "thread-local":
-        return JsonRecyclerPools.threadLocalPool();
-      case "concurrent-deque":
-        return JsonRecyclerPools.newConcurrentDequePool();
-      case "shared-concurrent-deque":
-        return JsonRecyclerPools.sharedConcurrentDequePool();
-      case "bounded":
-        return JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"));
-      case "non-recycling":
-        return JsonRecyclerPools.nonRecyclingPool();
-      default:
-        throw new IllegalArgumentException("Unknown recycler-pool: " + poolType);
-    }
+    return switch (poolType) {
+      case "thread-local" -> JsonRecyclerPools.threadLocalPool();
+      case "concurrent-deque" -> JsonRecyclerPools.newConcurrentDequePool();
+      case "shared-concurrent-deque" -> JsonRecyclerPools.sharedConcurrentDequePool();
+      case "bounded" -> JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"));
+      case "non-recycling" -> JsonRecyclerPools.nonRecyclingPool();
+      default -> throw new IllegalArgumentException("Unknown recycler-pool: " + poolType);
+    };
   }
 }

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/MarshallerTest.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/MarshallerTest.java
@@ -34,22 +34,15 @@ public class MarshallerTest extends JUnitJupiterRouteTest {
     final Marshaller<Integer, RequestEntity> numberAsNameMarshaller =
         Marshaller.wrapEntity(
             (Integer param) -> {
-              switch (param) {
-                case 0:
-                  return "null";
-                case 1:
-                  return "eins";
-                case 2:
-                  return "zwei";
-                case 3:
-                  return "drei";
-                case 4:
-                  return "vier";
-                case 5:
-                  return "fünf";
-                default:
-                  return "wat?";
-              }
+              return switch (param) {
+                case 0 -> "null";
+                case 1 -> "eins";
+                case 2 -> "zwei";
+                case 3 -> "drei";
+                case 4 -> "vier";
+                case 5 -> "fünf";
+                default -> "wat?";
+              };
             },
             Marshaller.stringToEntity(),
             MediaTypes.TEXT_X_SPEECH);
@@ -95,14 +88,11 @@ public class MarshallerTest extends JUnitJupiterRouteTest {
     final Marshaller<Integer, RequestEntity> numberAsJsonListMarshaller =
         Marshaller.wrapEntity(
             (Integer param) -> {
-              switch (param) {
-                case 1:
-                  return ByteString.fromString("[1]");
-                case 5:
-                  return ByteString.fromString("[1,2,3,4,5]");
-                default:
-                  return ByteString.fromString("[]");
-              }
+              return switch (param) {
+                case 1 -> ByteString.fromString("[1]");
+                case 5 -> ByteString.fromString("[1,2,3,4,5]");
+                default -> ByteString.fromString("[]");
+              };
             },
             Marshaller.byteStringToEntity(),
             MediaTypes.APPLICATION_JSON);
@@ -142,15 +132,15 @@ public class MarshallerTest extends JUnitJupiterRouteTest {
         Marshaller.withFixedContentType(
             MediaTypes.APPLICATION_JSON.toContentType(),
             (Integer param) -> {
-              switch (param) {
-                case 1:
-                  return HttpEntities.create(MediaTypes.APPLICATION_JSON.toContentType(), "[1]");
-                case 5:
-                  return HttpEntities.create(
+              return switch (param) {
+                case 1 ->
+                  HttpEntities.create(MediaTypes.APPLICATION_JSON.toContentType(), "[1]");
+                case 5 ->
+                  HttpEntities.create(
                       MediaTypes.APPLICATION_JSON.toContentType(), "[1,2,3,4,5]");
-                default:
-                  return HttpEntities.create(MediaTypes.APPLICATION_JSON.toContentType(), "[]");
-              }
+                default ->
+                  HttpEntities.create(MediaTypes.APPLICATION_JSON.toContentType(), "[]");
+              };
             });
 
     final Function<Integer, Route> nummerHandler =
@@ -188,16 +178,15 @@ public class MarshallerTest extends JUnitJupiterRouteTest {
         Marshaller.withFixedContentType(
             MediaTypes.APPLICATION_JSON.toContentType(),
             (Integer param) -> {
-              switch (param) {
-                case 1:
-                  return HttpResponse.create()
+              return switch (param) {
+                case 1 ->
+                  HttpResponse.create()
                       .withEntity(MediaTypes.APPLICATION_JSON.toContentType(), "[1]");
-                case 5:
-                  return HttpResponse.create()
+                case 5 ->
+                  HttpResponse.create()
                       .withEntity(MediaTypes.APPLICATION_JSON.toContentType(), "[1,2,3,4,5]");
-                default:
-                  return HttpResponse.create().withStatus(StatusCodes.NOT_FOUND);
-              }
+                default -> HttpResponse.create().withStatus(StatusCodes.NOT_FOUND);
+              };
             });
 
     final Function<Integer, Route> nummerHandler =

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/MarshallerTest.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/MarshallerTest.java
@@ -133,13 +133,10 @@ public class MarshallerTest extends JUnitJupiterRouteTest {
             MediaTypes.APPLICATION_JSON.toContentType(),
             (Integer param) -> {
               return switch (param) {
-                case 1 ->
-                  HttpEntities.create(MediaTypes.APPLICATION_JSON.toContentType(), "[1]");
+                case 1 -> HttpEntities.create(MediaTypes.APPLICATION_JSON.toContentType(), "[1]");
                 case 5 ->
-                  HttpEntities.create(
-                      MediaTypes.APPLICATION_JSON.toContentType(), "[1,2,3,4,5]");
-                default ->
-                  HttpEntities.create(MediaTypes.APPLICATION_JSON.toContentType(), "[]");
+                    HttpEntities.create(MediaTypes.APPLICATION_JSON.toContentType(), "[1,2,3,4,5]");
+                default -> HttpEntities.create(MediaTypes.APPLICATION_JSON.toContentType(), "[]");
               };
             });
 
@@ -180,11 +177,11 @@ public class MarshallerTest extends JUnitJupiterRouteTest {
             (Integer param) -> {
               return switch (param) {
                 case 1 ->
-                  HttpResponse.create()
-                      .withEntity(MediaTypes.APPLICATION_JSON.toContentType(), "[1]");
+                    HttpResponse.create()
+                        .withEntity(MediaTypes.APPLICATION_JSON.toContentType(), "[1]");
                 case 5 ->
-                  HttpResponse.create()
-                      .withEntity(MediaTypes.APPLICATION_JSON.toContentType(), "[1,2,3,4,5]");
+                    HttpResponse.create()
+                        .withEntity(MediaTypes.APPLICATION_JSON.toContentType(), "[1,2,3,4,5]");
                 default -> HttpResponse.create().withStatus(StatusCodes.NOT_FOUND);
               };
             });

--- a/http/src/main/java/org/apache/pekko/http/javadsl/settings/OversizedSseStrategy.java
+++ b/http/src/main/java/org/apache/pekko/http/javadsl/settings/OversizedSseStrategy.java
@@ -43,18 +43,16 @@ public enum OversizedSseStrategy {
 
   /** Convert this Java enum to the corresponding Scala enum value. */
   public org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy asScala() {
-    switch (this) {
-      case FailStream:
-        return org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy.FailStream$.MODULE$;
-      case LogAndSkip:
-        return org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy.LogAndSkip$.MODULE$;
-      case Truncate:
-        return org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy.Truncate$.MODULE$;
-      case DeadLetter:
-        return org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy.DeadLetter$.MODULE$;
-      default:
-        throw new IllegalArgumentException("Unknown OversizedSseStrategy: " + this);
-    }
+    return switch (this) {
+      case FailStream ->
+          org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy.FailStream$.MODULE$;
+      case LogAndSkip ->
+          org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy.LogAndSkip$.MODULE$;
+      case Truncate ->
+          org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy.Truncate$.MODULE$;
+      case DeadLetter ->
+          org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy.DeadLetter$.MODULE$;
+    };
   }
 
   /** Convert from a Scala enum value to the corresponding Java enum value. */


### PR DESCRIPTION
## Summary
- Migrate switch statements to enhanced switch syntax and switch expressions (Java 14+ API)
- 4 files updated: MarshallerTest (4 switches), OversizedSseStrategy, Jackson (jackson module), Jackson (jackson3 module)
- Behavior-preserving refactoring, no functional changes

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17