### PR TITLE
refactor: use Optional.isEmpty() (Java 11+)

### DIFF
--- a/http/src/main/java/org/apache/pekko/http/javadsl/server/HttpApp.java
+++ b/http/src/main/java/org/apache/pekko/http/javadsl/server/HttpApp.java
@@ -131,7 +131,7 @@ public abstract class HttpApp extends AllDirectives {
           .handle(
               (success, exception) -> {
                 postServerShutdown(Optional.ofNullable(exception), theSystem);
-                if (!system.isPresent()) {
+                if (system.isEmpty()) {
                   // we created the system. we should cleanup!
                   theSystem.terminate();
                 }


### PR DESCRIPTION
## Summary
- Replace `!system.isPresent()` with `system.isEmpty()` in HttpApp (main source code)
- Java 11+ API: `Optional.isEmpty()` expresses intent more directly than `!isPresent()`

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17