### PR TITLE
refactor: apply misc Java 11-17 improvements

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
@@ -223,7 +223,11 @@ public class JsonStreamingExamplesTest extends JUnitJupiterRouteTest {
     routes
         .run(HttpRequest.GET("/tweets?n=2").addHeader(acceptCsv))
         .assertStatusCode(200)
-        .assertEntity("12,Hello World!\n" + "12,Hello World!\n");
+        .assertEntity(
+            """
+            12,Hello World!
+            12,Hello World!
+            """);
 
     // test responses to potential errors
     final Accept acceptText = Accept.create(MediaRanges.ALL_APPLICATION);

--- a/http-tests/src/main/java/org/apache/pekko/http/javadsl/server/examples/petstore/Pet.java
+++ b/http-tests/src/main/java/org/apache/pekko/http/javadsl/server/examples/petstore/Pet.java
@@ -13,24 +13,6 @@
 
 package org.apache.pekko.http.javadsl.server.examples.petstore;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Pet {
-  private final int id;
-  private final String name;
-
-  @JsonCreator
-  public Pet(@JsonProperty("id") int id, @JsonProperty("name") String name) {
-    this.id = id;
-    this.name = name;
-  }
-
-  public int getId() {
-    return id;
-  }
-
-  public String getName() {
-    return name;
-  }
-}
+public record Pet(@JsonProperty("id") int id, @JsonProperty("name") String name) {}

--- a/http-tests/src/main/java/org/apache/pekko/http/javadsl/server/examples/petstore/PetStoreExample.java
+++ b/http-tests/src/main/java/org/apache/pekko/http/javadsl/server/examples/petstore/PetStoreExample.java
@@ -39,12 +39,12 @@ public class PetStoreExample {
 
   // #marshall
   private static Route putPetHandler(Map<Integer, Pet> pets, Pet thePet) {
-    pets.put(thePet.getId(), thePet);
+    pets.put(thePet.id(), thePet);
     return complete(StatusCodes.OK, thePet, Jackson.<Pet>marshaller());
   }
 
   private static Route alternativeFuturePutPetHandler(Map<Integer, Pet> pets, Pet thePet) {
-    pets.put(thePet.getId(), thePet);
+    pets.put(thePet.id(), thePet);
     CompletableFuture<Pet> futurePet = CompletableFuture.supplyAsync(() -> thePet);
     return completeOKWithFuture(futurePet, Jackson.<Pet>marshaller());
   }

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/directives/ParameterDirectivesTest.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/directives/ParameterDirectivesTest.java
@@ -404,8 +404,12 @@ public class ParameterDirectivesTest extends JUnitJupiterRouteTest {
 
                   StringBuilder res = new StringBuilder();
                   res.append(paramEntries.size()).append(": [");
-                  for (Map.Entry<String, String> entry : entries)
-                    res.append(entry.getKey()).append(" -> ").append(entry.getValue()).append(", ");
+                  entries.forEach(
+                      entry ->
+                          res.append(entry.getKey())
+                              .append(" -> ")
+                              .append(entry.getValue())
+                              .append(", "));
                   res.append(']');
                   return complete(res.toString());
                 }));

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/examples/petstore/PetStoreAPITest.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/server/examples/petstore/PetStoreAPITest.java
@@ -33,8 +33,8 @@ public class PetStoreAPITest extends JUnitJupiterRouteTest {
     response.assertStatusCode(StatusCodes.OK).assertMediaType("application/json");
 
     Pet pet = response.entity(Jackson.unmarshaller(Pet.class));
-    assertEquals("cat", pet.getName());
-    assertEquals(1, pet.getId());
+    assertEquals("cat", pet.name());
+    assertEquals(1, pet.id());
   }
 
   @Test
@@ -54,8 +54,8 @@ public class PetStoreAPITest extends JUnitJupiterRouteTest {
     response.assertStatusCode(StatusCodes.OK);
 
     Pet pet = response.entity(Jackson.unmarshaller(Pet.class));
-    assertEquals("giraffe", pet.getName());
-    assertEquals(1, pet.getId());
+    assertEquals("giraffe", pet.name());
+    assertEquals(1, pet.id());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `Map.forEach` replacing entrySet iteration loop
- Text block `"""..."""` replacing multi-line string concatenation
- Java 16+ record replacing simple data holder class

## Changes

### Map.forEach (Java 8+)
- `ParameterDirectivesTest.java` — entrySet loop → `entries.forEach(entry -> ...)`

### Text blocks (Java 15+)
- `JsonStreamingExamplesTest.java` — string concatenation → text block

### Records (Java 16+)
- `Pet.java` (http-tests/src/main) → `record Pet(long id, String name)`
- Removed `@JsonCreator` annotation (modern Jackson handles records natively)
- Updated callers: `PetStoreExample.java` (2 sites), `PetStoreAPITest.java` (4 sites)

## Notes
- All changes in test/example code only, no production API modifications
- `javafmtAll` verified — no formatting changes needed