### PR TITLE
refactor: replace .toArray().length with .size()

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
@@ -101,7 +101,7 @@ public class RangeDirectivesExamplesTest extends JUnitJupiterRouteTest {
     try {
       final List<Multipart.ByteRanges.BodyPart> bodyParts =
           completionStage.toCompletableFuture().get(3, TimeUnit.SECONDS);
-      assertEquals(2, bodyParts.toArray().length);
+      assertEquals(2, bodyParts.size());
 
       final Multipart.ByteRanges.BodyPart part1 = bodyParts.get(0);
       assertEquals(bytes028Range, part1.getContentRange());


### PR DESCRIPTION
## Summary
- Replace `bodyParts.toArray().length` with `bodyParts.size()` in `RangeDirectivesExamplesTest.java`

Creating an array just to check its length is unnecessary. `List.size()` is more idiomatic and avoids the allocation.

## Test plan
- [x] `sbt javafmtAll` — formatted
- [x] `sbt "docs / Test / compile"` — compiles successfully
- [ ] CI validates full test suite

Part of the Java 17 modernization effort.