### PR TITLE
refactor: remove JUnit 4 support and upgrade to JUnit 6.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ import java.nio.file.attribute.{ PosixFileAttributeView, PosixFilePermission }
 import sbtdynver.GitDescribeOutput
 import spray.boilerplate.BoilerplatePlugin
 import com.lightbend.paradox.apidoc.ApidocPlugin.autoImport.apidocRootPackage
+import com.github.sbt.junit.jupiter.sbt.Import.JupiterKeys
 
 sourceDistName := "apache-pekko-http"
 sourceDistIncubating := false
@@ -26,6 +27,9 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 ThisBuild / javafmtSortImports := false
+
+ThisBuild / JupiterKeys.junitJupiterVersion := "6.1.0"
+ThisBuild / JupiterKeys.junitPlatformVersion := "6.1.0"
 
 addCommandAlias("checkCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; +headerCheckAll")
 addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")

--- a/docs/src/test/java/docs/http/javadsl/RespondWithHeaderHandlerExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/RespondWithHeaderHandlerExampleTest.java
@@ -15,7 +15,7 @@ package docs.http.javadsl;
 
 // #respond-with-header-exceptionhandler-example
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.concurrent.CompletionStage;


### PR DESCRIPTION
## Summary
- Remove deprecated JUnit 4 testkit classes (`JUnitRouteTest`, `JUnitRouteTestBase`, `ActorSystemResource`)
- Remove `junit:junit:4.13.2` and `scalatestplus:junit-4-13` dependencies
- Upgrade JUnit Jupiter and Platform to 6.1.0
- Update documentation references to use `JUnitJupiterRouteTest`

## Modification
- Deleted `JUnitRouteTest.scala` (deprecated since 2.0.0, users should use `JUnitJupiterRouteTest`)
- Removed `junit4Version`, `Test.junit4`, and `Test.scalatestplusJUnit` from `Dependencies.scala`
- Removed `scalatestplusJUnit` from `httpCore`, `httpJackson`, `httpJackson3`, and `httpTestkit` modules
- Added `JupiterKeys.junitJupiterVersion := "6.1.0"` and `JupiterKeys.junitPlatformVersion := "6.1.0"` as `ThisBuild` overrides
- Updated Scaladoc and Paradox documentation to reference `JUnitJupiterRouteTest`

## Test plan
- [ ] CI passes with JUnit 6.1.0
- [ ] All existing Jupiter tests continue to run correctly
- [ ] MiMa check passes (may need exclusion for removed deprecated classes)