### PR TITLE
add since markers on Deprecated annotations

### DIFF
--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/HttpMethods.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/HttpMethods.java
@@ -41,7 +41,7 @@ public final class HttpMethods {
    *     org.apache.pekko.http.javadsl.model.RequestEntityAcceptance, boolean)} instead. Deprecated
    *     since 1.4.0.
    */
-  @Deprecated
+  @Deprecated(since = "1.4.0")
   public static HttpMethod custom(
       String value,
       boolean safe,

--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/StatusCodes.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/StatusCodes.java
@@ -103,7 +103,7 @@ public final class StatusCodes {
   /**
    * @deprecated deprecated in favor of CONTENT_TOO_LARGE since 1.1.0
    */
-  @Deprecated
+  @Deprecated(since = "1.1.0")
   public static final StatusCode PAYLOAD_TOO_LARGE =
       org.apache.pekko.http.scaladsl.model.StatusCodes.PayloadTooLarge();
 
@@ -129,7 +129,7 @@ public final class StatusCodes {
   /**
    * @deprecated deprecated in favor of UNPROCESSABLE_CONTENT since 1.1.0
    */
-  @Deprecated
+  @Deprecated(since = "1.1.0")
   public static final StatusCode UNPROCESSABLE_ENTITY =
       org.apache.pekko.http.scaladsl.model.StatusCodes.UnprocessableEntity();
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ParserSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ParserSettings.scala
@@ -121,21 +121,21 @@ object ParserSettings extends SettingsCompanion[ParserSettings] {
   /**
    * @deprecated Use forServer or forClient instead.
    */
-  @Deprecated
+  @Deprecated(since = "Akka HTTP 10.2.0")
   @deprecated("Use forServer or forClient instead", since = "Akka HTTP 10.2.0")
   override def create(config: Config): ParserSettings = ParserSettingsImpl(config)
 
   /**
    * @deprecated Use forServer or forClient instead.
    */
-  @Deprecated
+  @Deprecated(since = "Akka HTTP 10.2.0")
   @deprecated("Use forServer or forClient instead", since = "Akka HTTP 10.2.0")
   override def create(configOverrides: String): ParserSettings = ParserSettingsImpl(configOverrides)
 
   /**
    * @deprecated Use forServer or forClient instead.
    */
-  @Deprecated
+  @Deprecated(since = "Akka HTTP 10.2.0")
   @deprecated("Use forServer or forClient instead", since = "Akka HTTP 10.2.0")
   override def create(system: ActorSystem): ParserSettings = create(system.settings.config)
 

--- a/http/src/main/java/org/apache/pekko/http/javadsl/coding/Coder.java
+++ b/http/src/main/java/org/apache/pekko/http/javadsl/coding/Coder.java
@@ -52,7 +52,7 @@ public enum Coder {
   /**
    * @deprecated Synchronous encoding is deprecated since Akka HTTP 10.2.0
    */
-  @Deprecated
+  @Deprecated(since = "Akka HTTP 10.2.0")
   public ByteString encode(ByteString input) {
     return underlying.encode(input);
   }

--- a/http/src/main/java/org/apache/pekko/http/javadsl/server/HttpApp.java
+++ b/http/src/main/java/org/apache/pekko/http/javadsl/server/HttpApp.java
@@ -35,7 +35,7 @@ import org.apache.pekko.http.javadsl.settings.ServerSettings;
  *
  * @deprecated HttpApp this doesn't reflect the latest APIs, since Akka HTTP 10.2.0
  */
-@Deprecated
+@Deprecated(since = "Akka HTTP 10.2.0")
 public abstract class HttpApp extends AllDirectives {
 
   private AtomicReference<ServerBinding> serverBinding = new AtomicReference<>();

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
@@ -33,7 +33,7 @@ object Directives extends AllDirectives {
   // These are repeated here since sometimes (?) the Scala compiler won't actually generate java-compatible
   // signatures for varargs methods, making them show up as Seq<Object> instead of T... in Java.
 
-  @Deprecated
+  @Deprecated(since = "Akka HTTP 10.1.6")
   @varargs
   override def route(alternatives: Route*): Route =
     super.route(alternatives: _*)

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
@@ -350,7 +350,7 @@ abstract class BasicDirectives {
    * @param timeout The directive is failed if the stream isn't completed after the given timeout.
    * @deprecated As of 1.3.0, use the overloaded method taking a `java.time.Duration` instead.
    */
-  @Deprecated
+  @Deprecated(since = "1.3.0")
   @deprecated("use the overloaded method taking a `java.time.Duration` instead.", "1.3.0")
   def extractStrictEntity(timeout: FiniteDuration, inner: JFunction[HttpEntity.Strict, Route]): Route = RouteAdapter {
     D.extractStrictEntity(timeout) { strict => inner.apply(strict).delegate }
@@ -386,7 +386,7 @@ abstract class BasicDirectives {
    * @param timeout The directive is failed if the stream isn't completed after the given timeout.
    * @deprecated As of 1.3.0, use the overloaded method taking a `java.time.Duration` instead.
    */
-  @Deprecated
+  @Deprecated(since = "1.3.0")
   @deprecated("use the overloaded method taking a `java.time.Duration` instead.", "1.3.0")
   def extractStrictEntity(timeout: FiniteDuration, maxBytes: Long, inner: JFunction[HttpEntity.Strict, Route]): Route =
     RouteAdapter {
@@ -423,7 +423,7 @@ abstract class BasicDirectives {
    * @param timeout The directive is failed if the stream isn't completed after the given timeout.
    * @deprecated As of 1.3.0, use the overloaded method taking a `java.time.Duration` instead.
    */
-  @Deprecated
+  @Deprecated(since = "1.3.0")
   @deprecated("use the overloaded method taking a `java.time.Duration` instead.", "1.3.0")
   def toStrictEntity(timeout: FiniteDuration, inner: Supplier[Route]): Route = RouteAdapter {
     D.toStrictEntity(timeout) { inner.get.delegate }
@@ -457,7 +457,7 @@ abstract class BasicDirectives {
    * @param timeout The directive is failed if the stream isn't completed after the given timeout.
    * @deprecated As of 1.3.0, use the overloaded method taking a `java.time.Duration` instead.
    */
-  @Deprecated
+  @Deprecated(since = "1.3.0")
   @deprecated("use the overloaded method taking a `java.time.Duration` instead.", "1.3.0")
   def toStrictEntity(timeout: FiniteDuration, maxBytes: Long, inner: Supplier[Route]): Route = RouteAdapter {
     D.toStrictEntity(timeout, maxBytes) { inner.get.delegate }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteDirectives.scala
@@ -52,7 +52,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
    * rather than having to explicitly call route1.orElse(route2).orElse(route3).
    * @deprecated Use the `RouteDirectives.concat` method instead.
    */
-  @Deprecated
+  @Deprecated(since = "Akka HTTP 10.1.6")
   @deprecated("Use the RouteDirectives.concat method instead.", "Akka HTTP 10.1.6")
   @CorrespondsTo("concat")
   @varargs def route(alternatives: Route*): Route = RouteAdapter {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/TimeoutDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/TimeoutDirectives.scala
@@ -47,7 +47,7 @@ abstract class TimeoutDirectives extends WebSocketDirectives {
    * the previously set timeout has expired!
    * @deprecated As of 1.3.0, use the overloaded method taking a `java.time.Duration` instead.
    */
-  @Deprecated
+  @Deprecated(since = "1.3.0")
   @deprecated("use the overloaded method taking a `java.time.Duration` instead.", "1.3.0")
   def withRequestTimeout(timeout: scala.concurrent.duration.Duration, inner: Supplier[Route]): RouteAdapter =
     RouteAdapter {
@@ -73,7 +73,7 @@ abstract class TimeoutDirectives extends WebSocketDirectives {
    * the previously set timeout has expired!
    * @deprecated As of 1.3.0, use the overloaded method taking a `java.time.Duration` instead.
    */
-  @Deprecated
+  @Deprecated(since = "1.3.0")
   @deprecated("use the overloaded method taking a `java.time.Duration` instead.", "1.3.0")
   def withRequestTimeout(timeout: scala.concurrent.duration.Duration,
       timeoutHandler: JFunction[HttpRequest, HttpResponse],


### PR DESCRIPTION
allowed now that we don't support Java 8

I am looking separately at whether we can remove some of these methods but they seem to be used heavily in our tests and the alternative code is more complicated.