### PR TITLE
make withLevel package private

### DIFF
--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Deflate.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Deflate.scala
@@ -18,7 +18,7 @@ import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.HttpEncodings
 
-@InternalApi // used by javadsl.Coder
+@InternalApi // used by javadsl.coding.Coder
 @deprecated("Actual implementation of Deflate is internal API, use Coders.Deflate instead", since = "Akka HTTP 10.2.0")
 class Deflate private[http] (compressionLevel: Int, val messageFilter: HttpMessage => Boolean) extends Coder
     with StreamDecoder {
@@ -30,9 +30,9 @@ class Deflate private[http] (compressionLevel: Int, val messageFilter: HttpMessa
   private[http] def newCompressor = new DeflateCompressor(compressionLevel)
   def newDecompressorStage(maxBytesPerChunk: Int) = () => new DeflateDecompressor(maxBytesPerChunk)
 
-  @InternalApi // used by javadsl.Coder
+  @InternalApi // used by javadsl.coding.Coder
   private[http] def withLevel(level: Int): Deflate = new Deflate(level, messageFilter)
 }
-@InternalApi // used by javadsl.Coder
+@InternalApi // used by javadsl.coding.Coder
 @deprecated("Actual implementation of Deflate is internal API, use Coders.Deflate instead", since = "Akka HTTP 10.2.0")
 object Deflate extends Deflate(Encoder.DefaultFilter)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Deflate.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Deflate.scala
@@ -18,7 +18,7 @@ import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.HttpEncodings
 
-@InternalApi
+@InternalApi // used by javadsl.Coder
 @deprecated("Actual implementation of Deflate is internal API, use Coders.Deflate instead", since = "Akka HTTP 10.2.0")
 class Deflate private[http] (compressionLevel: Int, val messageFilter: HttpMessage => Boolean) extends Coder
     with StreamDecoder {
@@ -30,9 +30,9 @@ class Deflate private[http] (compressionLevel: Int, val messageFilter: HttpMessa
   private[http] def newCompressor = new DeflateCompressor(compressionLevel)
   def newDecompressorStage(maxBytesPerChunk: Int) = () => new DeflateDecompressor(maxBytesPerChunk)
 
-  @deprecated("Use Coders.Deflate(compressionLevel = ...) instead", since = "Akka HTTP 10.2.0")
-  def withLevel(level: Int): Deflate = new Deflate(level, messageFilter)
+  @InternalApi // used by javadsl.Coder
+  private[http] def withLevel(level: Int): Deflate = new Deflate(level, messageFilter)
 }
-@InternalApi
+@InternalApi // used by javadsl.Coder
 @deprecated("Actual implementation of Deflate is internal API, use Coders.Deflate instead", since = "Akka HTTP 10.2.0")
 object Deflate extends Deflate(Encoder.DefaultFilter)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Gzip.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Gzip.scala
@@ -18,7 +18,7 @@ import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.HttpEncodings
 
-@InternalApi // used by javadsl.Coder
+@InternalApi // used by javadsl.coding.Coder
 @deprecated("Actual implementation of Gzip is internal, use Coders.Gzip instead", since = "Akka HTTP 10.2.0")
 class Gzip private[http] (compressionLevel: Int, val messageFilter: HttpMessage => Boolean) extends Coder
     with StreamDecoder {
@@ -30,14 +30,14 @@ class Gzip private[http] (compressionLevel: Int, val messageFilter: HttpMessage 
   private[http] def newCompressor = new GzipCompressor(compressionLevel)
   def newDecompressorStage(maxBytesPerChunk: Int) = () => new GzipDecompressor(maxBytesPerChunk)
 
-  @InternalApi // used by javadsl.Coder
+  @InternalApi // used by javadsl.coding.Coder
   private[http] def withLevel(level: Int): Gzip = new Gzip(level, messageFilter)
 }
 
 /**
  * An encoder and decoder for the HTTP 'gzip' encoding.
  */
-@InternalApi // used by javadsl.Coder
+@InternalApi // used by javadsl.coding.Coder
 @deprecated("Actual implementation of Gzip is internal API, use Coders.Gzip instead", since = "Akka HTTP 10.2.0")
 object Gzip extends Gzip(Encoder.DefaultFilter) {
   def apply(messageFilter: HttpMessage => Boolean) = new Gzip(messageFilter)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Gzip.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Gzip.scala
@@ -18,7 +18,7 @@ import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.HttpEncodings
 
-@InternalApi
+@InternalApi // used by javadsl.Coder
 @deprecated("Actual implementation of Gzip is internal, use Coders.Gzip instead", since = "Akka HTTP 10.2.0")
 class Gzip private[http] (compressionLevel: Int, val messageFilter: HttpMessage => Boolean) extends Coder
     with StreamDecoder {
@@ -30,14 +30,14 @@ class Gzip private[http] (compressionLevel: Int, val messageFilter: HttpMessage 
   private[http] def newCompressor = new GzipCompressor(compressionLevel)
   def newDecompressorStage(maxBytesPerChunk: Int) = () => new GzipDecompressor(maxBytesPerChunk)
 
-  @deprecated("Use Coders.Gzip(compressionLevel = ...) instead", since = "Akka HTTP 10.2.0")
-  def withLevel(level: Int): Gzip = new Gzip(level, messageFilter)
+  @InternalApi // used by javadsl.Coder
+  private[http] def withLevel(level: Int): Gzip = new Gzip(level, messageFilter)
 }
 
 /**
  * An encoder and decoder for the HTTP 'gzip' encoding.
  */
-@InternalApi
+@InternalApi // used by javadsl.Coder
 @deprecated("Actual implementation of Gzip is internal API, use Coders.Gzip instead", since = "Akka HTTP 10.2.0")
 object Gzip extends Gzip(Encoder.DefaultFilter) {
   def apply(messageFilter: HttpMessage => Boolean) = new Gzip(messageFilter)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/NoCoding.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/NoCoding.scala
@@ -25,7 +25,7 @@ import pekko.util.ByteString
 /**
  * An encoder and decoder for the HTTP 'identity' encoding.
  */
-@InternalApi // used by javadsl.Coder
+@InternalApi // used by javadsl.coding.Coder
 @deprecated("Actual implementation of NoCoding is internal API, use Coders.NoCoding instead",
   since = "Akka HTTP 10.2.0")
 object NoCoding extends Coder with StreamDecoder {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/NoCoding.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/NoCoding.scala
@@ -25,7 +25,7 @@ import pekko.util.ByteString
 /**
  * An encoder and decoder for the HTTP 'identity' encoding.
  */
-@InternalApi
+@InternalApi // used by javadsl.Coder
 @deprecated("Actual implementation of NoCoding is internal API, use Coders.NoCoding instead",
   since = "Akka HTTP 10.2.0")
 object NoCoding extends Coder with StreamDecoder {


### PR DESCRIPTION
some code that is marked deprecated is actually used by the JavaDSL code under the hood