### PR TITLE
refactor: replace deprecated ActorMaterializer with Materializer

### DIFF
--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/TestServer.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/TestServer.scala
@@ -41,10 +41,7 @@ object TestServer extends App {
     """)
   implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
 
-  val settings = ActorMaterializerSettings(system)
-    //    .withSyncProcessingLimit(Int.MaxValue)
-    .withInputBuffer(128, 128)
-  implicit val fm: Materializer = ActorMaterializer(settings)
+  implicit val fm: Materializer = Materializer(system)
   try {
     val binding = Http().newServerAt("localhost", 9001).bindSync {
       case req @ HttpRequest(GET, Uri.Path("/"), _, _, _) =>


### PR DESCRIPTION
### Motivation
`ActorMaterializer` and `ActorMaterializerSettings` have been deprecated since Akka 2.6.0 in favor of `Materializer.apply(system)`.

### Modification
Replace `ActorMaterializer(ActorMaterializerSettings(system).withInputBuffer(128, 128))` with `Materializer(system)` in `TestServer.scala`.

### Result
Removes usage of deprecated `ActorMaterializer` API.

### Tests
- `sbt "http-core / Test / compile"` — success

### References
None — deprecated API cleanup