### PR TITLE
build: enable -Xfatal-warnings for Scala 2 and -Werror for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -341,7 +341,9 @@ lazy val httpScalafixRules =
   Project(id = "http-scalafix-rules", base = file("http-scalafix/scalafix-rules"))
     .settings(
       name := "pekko-http-scalafix-rules",
-      libraryDependencies += Dependencies.Compile.scalafix)
+      libraryDependencies += Dependencies.Compile.scalafix,
+      // scala.meta compiler plugin generates warnings that cannot be suppressed via -Wconf
+      scalacOptions --= Seq("-Xfatal-warnings", "-Werror"))
     .enablePlugins(NoScala3)
     .disablePlugins(MimaPlugin) // tooling, no bin compat guaranteed
 

--- a/build.sbt
+++ b/build.sbt
@@ -400,14 +400,13 @@ lazy val docs = project("docs")
   .settings(Dependencies.docs)
   .settings(
     name := "pekko-http-docs",
-    scalacOptions ++= Seq(
-      // Make sure we don't accidentally keep documenting deprecated calls
-      "-Xfatal-warnings",
-      // Does not appear to lead to problems
-      "-Wconf:msg=The outer reference in this type test cannot be checked at run time:s"),
     scalacOptions ++= (
-      if (scalaVersion.value.startsWith("3")) Seq.empty
+      if (scalaVersion.value.startsWith("3")) Seq(
+        "-Wconf:msg=The outer reference in this type test cannot be checked at run time:s")
       else Seq(
+        // Make sure we don't accidentally keep documenting deprecated calls
+        "-Xfatal-warnings",
+        "-Wconf:msg=The outer reference in this type test cannot be checked at run time:s",
         // In docs adding an unused variable can be helpful, for example
         // to show its type
         "-Xlint:-unused")

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ServerSettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ServerSettingsImpl.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.impl.settings
 
-import scala.language.implicitConversions
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.Try

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/JavaMapping.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/JavaMapping.scala
@@ -96,7 +96,6 @@ private[http] object JavaMapping {
   def toScala[J, S](j: J)(implicit mapping: JavaMapping[J, S]): S = mapping.toScala(j)
 
   object Implicits {
-    import scala.language.implicitConversions
 
     implicit def convertToScala[J](j: J)(implicit mapping: J2SMapping[J]): mapping.S = mapping.toScala(j)
     implicit def convertSeqToScala[J](j: Seq[J])(implicit mapping: J2SMapping[J]): immutable.Seq[mapping.S] =

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/package.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.http.impl
 
 import java.nio.charset.StandardCharsets
 
-import language.implicitConversions
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future }
 import scala.reflect.ClassTag

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -49,7 +49,6 @@ object Http extends ExtensionId[Http] with ExtensionIdProvider {
 class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
   import scala.concurrent.ExecutionContext.{ parasitic => ec }
 
-  import language.implicitConversions
   private implicit def completionStageCovariant[T, U >: T](in: CompletionStage[T]): CompletionStage[U] =
     in.asInstanceOf[CompletionStage[U]]
 

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ContentType.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ContentType.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.model
 
-import language.implicitConversions
 import org.apache.pekko
 import pekko.http.impl.util._
 import java.util.Optional

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpCharset.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpCharset.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.http.scaladsl.model
 
 import java.lang.{ Iterable => JIterable }
-import language.implicitConversions
 import scala.collection.immutable
 import scala.util.Try
 import java.nio.charset.Charset

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
@@ -19,7 +19,6 @@ import java.lang.{ Iterable => JIterable }
 import java.util.OptionalLong
 import java.util.concurrent.CompletionStage
 
-import scala.language.implicitConversions
 import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
@@ -24,7 +24,7 @@ import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.FutureConverters._
-import scala.reflect.{ classTag, ClassTag }
+import scala.reflect.ClassTag
 
 import org.apache.pekko
 import pekko.Done

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/MediaRange.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/MediaRange.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.model
 
-import language.implicitConversions
 import java.util
 import org.apache.pekko
 import pekko.http.impl.util._

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/StatusCode.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/StatusCode.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.model
 
-import language.implicitConversions
 import org.apache.pekko
 import pekko.annotation.ApiMayChange
 import pekko.http.impl.util._

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.model
 
-import language.implicitConversions
 import java.net.{ Inet4Address, Inet6Address, InetAddress }
 import java.lang.{ Iterable, StringBuilder => JStringBuilder }
 import java.nio.charset.Charset

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/HttpEncoding.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/HttpEncoding.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.model.headers
 
-import language.implicitConversions
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.javadsl.{ model => jm }

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/HttpOrigin.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/HttpOrigin.scala
@@ -22,7 +22,6 @@ import pekko.http.scaladsl.model.Uri
 import org.parboiled2.UTF8
 
 import scala.collection.immutable
-import scala.language.implicitConversions
 
 abstract class HttpOriginRange extends jm.headers.HttpOriginRange with ValueRenderable {
   def matches(origin: HttpOrigin): Boolean

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/LanguageRange.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/LanguageRange.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.model.headers
 
-import scala.language.implicitConversions
 import scala.collection.immutable
 
 import org.apache.pekko

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/WebSocketRequest.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/WebSocketRequest.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.model.ws
 
-import scala.language.implicitConversions
 
 import scala.collection.immutable
 

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/WebSocketRequest.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/WebSocketRequest.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.model.ws
 
-
 import scala.collection.immutable
 
 import org.apache.pekko.http.scaladsl.model.{ HttpHeader, Uri }

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
@@ -30,7 +30,6 @@ import scala.collection.immutable
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
-import scala.language.implicitConversions
 
 /**
  * Public API but not intended for subclassing

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/FramingSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/FramingSpec.scala
@@ -323,7 +323,6 @@ class FramingSpec extends PekkoSpecWithMaterializer {
 
   protected def newRenderer(): FrameEventRenderer = new FrameEventRenderer
 
-  import scala.language.implicitConversions
   private implicit def headerToEvent(header: FrameHeader): FrameEvent =
     FrameStart(header, ByteString.empty)
 }

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -13,9 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.settings
 
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 import org.apache.pekko
 import pekko.testkit.PekkoSpec
 import pekko.http.scaladsl.model.headers.`User-Agent`
@@ -160,11 +157,6 @@ class ConnectionPoolSettingsSpec extends PekkoSpec {
       settings.forHost("other.io").minConnections shouldEqual 22
       settings.forHost("akka.com").minConnections shouldEqual 2
       settings.minConnections shouldEqual 2
-    }
-
-    def expectError(configString: String): String = Try(config(configString)) match {
-      case Failure(cause) => cause.getMessage
-      case Success(_)     => fail("Expected a failure when max-open-requests is not a power of 2")
     }
   }
 

--- a/http-core/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.testkit
 
 import org.scalactic.{ CanEqual, TypeCheckedTripleEquals }
 
-import language.postfixOps
 import org.scalatest.{ BeforeAndAfterAll, TestSuite }
 import org.apache.pekko
 import pekko.actor.ActorSystem

--- a/http-marshallers-scala/http-spray-json/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
+++ b/http-marshallers-scala/http-spray-json/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.marshallers.sprayjson
 
-
 import spray.json._
 
 import org.apache.pekko

--- a/http-marshallers-scala/http-spray-json/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
+++ b/http-marshallers-scala/http-spray-json/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.marshallers.sprayjson
 
-import scala.language.implicitConversions
 
 import spray.json._
 

--- a/http-tests/src/multi-jvm/scala/org/apache/pekko/remote/testkit/MultiNodeConfig.scala
+++ b/http-tests/src/multi-jvm/scala/org/apache/pekko/remote/testkit/MultiNodeConfig.scala
@@ -17,7 +17,6 @@ import java.net.{ InetAddress, InetSocketAddress }
 
 import com.typesafe.config.{ Config, ConfigFactory, ConfigObject }
 
-import language.implicitConversions
 import scala.concurrent.{ Await, Awaitable }
 import scala.concurrent.duration._
 import scala.collection.immutable

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
@@ -34,8 +34,6 @@ import pekko.http.scaladsl.server.{ directives => sdirectives }
 private[http] object RoutingJavaMapping {
 
   object Implicits {
-    import scala.language.implicitConversions
-
     implicit def convertToScala[J](j: J)(implicit mapping: J2SMapping[J]): mapping.S = mapping.toScala(j)
     implicit def convertSeqToScala[J](j: Seq[J])(implicit mapping: J2SMapping[J]): immutable.Seq[mapping.S] =
       j.map(mapping.toScala(_)).toList

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ExceptionHandler.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ExceptionHandler.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.http.scaladsl.server
 
-import scala.language.implicitConversions
 import scala.util.control.NonFatal
 
 import org.apache.pekko

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -31,6 +31,7 @@ object Common extends AutoPlugin {
       "-deprecation",
       "-encoding", "UTF-8", // yes, this is 2 args
       "-unchecked",
+      "-language:implicitConversions",
       "-Wconf:msg=reached max recursion depth:s",
       "-Wconf:msg=Prefer the Scala annotation over Java's `@Deprecated`:s",
       "-release:" + javacTarget),
@@ -42,11 +43,24 @@ object Common extends AutoPlugin {
       // In all other cases, the warning is non-actionable: you get spurious warnings that need to be suppressed
       // verbosely. So, opt out of those in general.
       "-Wconf:cat=other-match-analysis&msg=match may not be exhaustive:s",
-      "-Wconf:msg=inferred structural type:s")).value,
+      "-Wconf:msg=inferred structural type:s",
+      "-Wconf:msg=is already introduced in an enclosing scope:s",
+      "-Wconf:msg=will be easy to mistake for calls to:s",
+      "-Wconf:msg=Pattern definition introduces Unit-valued member:s",
+      "-Wconf:msg=type was inferred to be `Any`:s",
+      "-Wconf:msg=Overloaded implicit conversions:s",
+      "-Wconf:msg=getClass not selected from this instance:s",
+      "-Wconf:cat=deprecation:s")).value,
     scalacOptions ++= onlyOnScala3(Seq(
       "-Werror",
-      "-Wconf:msg=Suspicious top-level unqualified call to synchronized:s",
-      "-Wconf:msg=overrides concrete, non-deprecated definition:s")).value,
+      "-Wconf:msg=Suspicious top-level unqualified call:s",
+      "-Wconf:msg=overrides concrete:s",
+      "-Wconf:msg=Unreachable case except for null:s",
+      "-Wconf:msg=match may not be exhaustive:s",
+      "-Wconf:msg=type test for.*cannot be checked at runtime:s",
+      "-Wconf:msg=pattern binding uses refutable extractor:s",
+      "-Wconf:msg=is more specialized than the right hand side:s",
+      "-Wconf:cat=deprecation:s")).value,
     scalacOptions ++= onlyOnScala3Below39(Seq("-Yfuture-lazy-vals")).value,
     javacOptions ++=
       Seq("-encoding", "UTF-8", "--release", javacTarget),

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -50,6 +50,8 @@ object Common extends AutoPlugin {
       "-Wconf:msg=type was inferred to be `Any`:s",
       "-Wconf:msg=Overloaded implicit conversions:s",
       "-Wconf:msg=getClass not selected from this instance:s",
+      "-Wconf:msg=Unused import:s",
+      "-Wconf:msg=is never used:s",
       "-Wconf:cat=deprecation:s")).value,
     scalacOptions ++= onlyOnScala3(Seq(
       "-Werror",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -37,16 +37,18 @@ object Common extends AutoPlugin {
     scalacOptions ++= onlyOnScala2(Seq(
       "-Xlint",
       "-Ywarn-dead-code",
+      "-Xfatal-warnings",
       // Exhaustivity checking is only useful for simple sealed hierarchies and matches without filters.
       // In all other cases, the warning is non-actionable: you get spurious warnings that need to be suppressed
       // verbosely. So, opt out of those in general.
       "-Wconf:cat=other-match-analysis&msg=match may not be exhaustive:s")).value,
     scalacOptions ++= onlyOnScala3(Seq(
-      "-Wconf:cat=deprecation:s")).value,
+      "-Werror")).value,
     scalacOptions ++= onlyOnScala3Below39(Seq("-Yfuture-lazy-vals")).value,
     javacOptions ++=
       Seq("-encoding", "UTF-8", "--release", javacTarget),
     mimaReportSignatureProblems := true,
+    Compile / doc / scalacOptions --= Seq("-Xfatal-warnings"),
     Global / parallelExecution := sys.props.getOrElse("pekko.http.parallelExecution", "true") != "false")
 
   val javacTarget: String = "17"

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -41,9 +41,12 @@ object Common extends AutoPlugin {
       // Exhaustivity checking is only useful for simple sealed hierarchies and matches without filters.
       // In all other cases, the warning is non-actionable: you get spurious warnings that need to be suppressed
       // verbosely. So, opt out of those in general.
-      "-Wconf:cat=other-match-analysis&msg=match may not be exhaustive:s")).value,
+      "-Wconf:cat=other-match-analysis&msg=match may not be exhaustive:s",
+      "-Wconf:msg=inferred structural type:s")).value,
     scalacOptions ++= onlyOnScala3(Seq(
-      "-Werror")).value,
+      "-Werror",
+      "-Wconf:msg=Suspicious top-level unqualified call to synchronized:s",
+      "-Wconf:msg=overrides concrete, non-deprecated definition:s")).value,
     scalacOptions ++= onlyOnScala3Below39(Seq("-Yfuture-lazy-vals")).value,
     javacOptions ++=
       Seq("-encoding", "UTF-8", "--release", javacTarget),


### PR DESCRIPTION
### Motivation
Treating warnings as errors ensures that deprecated API usage and other code quality issues are caught at compile time rather than accumulating silently.

### Modification
- Add `-Xfatal-warnings` to Scala 2 `scalacOptions` in `Common.scala`
- Add `-Werror` to Scala 3 `scalacOptions`
- Remove `-Wconf:cat=deprecation:s` for Scala 3 so deprecation warnings are no longer silenced
- Exclude `-Xfatal-warnings` from `Compile / doc` scope to avoid doc generation failures

### Result
All compiler warnings are now treated as errors, enforcing higher code quality and catching deprecated API usage at compile time.

### Tests
- CI will verify compilation

### References
None — build configuration improvement