### PR TITLE
build: remove stale scalafix dependency from docs module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -398,7 +398,7 @@ lazy val docs = project("docs")
   .addPekkoModuleDependency("pekko-actor-testkit-typed", "provided", PekkoCoreDependency.default)
   .dependsOn(
     httpCore, http, httpXml, http2Tests, httpMarshallersJava, httpMarshallersScala, httpCaching, httpCors,
-    httpTests % "compile;test->test", httpTestkit % "compile;test->test", httpScalafixRules % ScalafixConfig)
+    httpTests % "compile;test->test", httpTestkit % "compile;test->test")
   .settings(Dependencies.docs)
   .settings(
     name := "pekko-http-docs",


### PR DESCRIPTION
### Motivation

`sbt clean` fails with `IllegalArgumentException: Cannot add dependency 'org.apache.pekko#pekko-http-scalafix-rules_2.13;...' to configuration 'scalafix' of module org.apache.pekko#pekko-http-docs_2.13;... because this configuration doesn't exist!`.

The `docs` module disables `ScalafixPlugin` via `.disablePlugins(ScalafixPlugin)`, which means the `scalafix` Ivy configuration is never created. However, `.dependsOn(...)` still references `httpScalafixRules % ScalafixConfig`, causing Ivy to fail when resolving the dependency graph — even during `sbt clean` (which triggers `cleanIvy`).

### Modification

Remove the unused `httpScalafixRules % ScalafixConfig` dependency from the `docs` module's `.dependsOn(...)`. The docs module does not use scalafix rules, so this dependency was a leftover from copy-pasted configuration.

### Result

`sbt clean` no longer crashes on the docs module due to a missing Ivy configuration. The build graph resolves correctly.

### Tests

Not run - build configuration only

### References

Fixes #925