### PR TITLE
Fix nightly docs workflow caused by Scala 3 unmoored doc comment warnings

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -375,7 +375,7 @@ private[client] object NewHostConnectionPool {
                   OptionVal.Some(Event.onPreConnect)
               }
 
-            /** Run a loop of state transitions */
+            // Run a loop of state transitions
             /* @tailrec (does not work for some reason?) */
             def loop[U](event: Event[U], arg: U, remainingIterations: Int): Unit =
               if (remainingIterations > 0)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/StreamPrioritizer.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/StreamPrioritizer.scala
@@ -57,10 +57,8 @@ private[http2] object StreamPrioritizer {
       /** Choose a substream from a set of substream ids that have data available */
       def chooseSubstream(streams: Set[Int]): Int = {
 
-        /**
-         * Chooses one of the children, returns the chosen stream id (which must be part of `streams` or
-         * -1 if no eligible stream was found in that part of the tree).
-         */
+        // Chooses one of the children, returns the chosen stream id (which must be part of `streams` or
+        // -1 if no eligible stream was found in that part of the tree).
         def chooseFromChildren(prioNode: PriorityNode): Int = {
           if (streams.contains(prioNode.streamId)) prioNode.streamId
           else {

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/DateHeaderRendering.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/DateHeaderRendering.scala
@@ -43,7 +43,7 @@ import scala.concurrent.ExecutionContext
 
     sealed trait DateState
 
-    /** Date has not been used for a while */
+    // Date has not been used for a while
     case object Idle extends DateState
     case class AutoUpdated(value: String) extends DateState {
       var wasUsed: Boolean = false


### PR DESCRIPTION
See https://github.com/apache/pekko-http/actions/runs/28489114213/job/84441821925

```
[error] /home/runner/work/pekko-http/pekko-http/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala:378:13: discarding unmoored doc comment
[error]             /** Run a loop of state transitions */
[error]             ^
[69.482s][info][gc] GC(56) Pause Young (Normal) (G1 Evacuation Pause) 1256M->660M(1614M) 52.776ms
[error] /home/runner/work/pekko-http/pekko-http/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/StreamPrioritizer.scala:60:9: discarding unmoored doc comment
[error]         /**
[error]         ^
[error] /home/runner/work/pekko-http/pekko-http/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/DateHeaderRendering.scala:46:5: discarding unmoored doc comment
[error]     /** Date has not been used for a while */
[error]     ^
[error] three errors found
[error] (http-core / Compile / compileIncremental) Compilation failed
[error] Total time: 36 s, completed 2026 Jul 1 02:23:20
```

Because of 82a03b120 the publish workflow now treats Scala compiler warnings as errors. Scala 3 reports local Scaladoc comments as discarded unmoored doc comments, which breaks the cross-built publish task.

Fix is to convert the affected local Scaladoc comments in `http-core` implementation code to ordinary comments.

