### PR TITLE
refactor: fold InHandler and OutHandler into GraphStageLogic in DecoderSpec

### DIFF
--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DecoderSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DecoderSpec.scala
@@ -56,16 +56,12 @@ class DecoderSpec extends AnyWordSpec with CodecSpecSupport {
     override def newDecompressorStage(maxBytesPerChunk: Int): () => GraphStage[FlowShape[ByteString, ByteString]] =
       () =>
         new SimpleLinearGraphStage[ByteString] {
-          override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
-            setHandler(in,
-              new InHandler {
-                override def onPush(): Unit = push(out, grab(in) ++ ByteString("compressed"))
-              })
-            setHandler(out,
-              new OutHandler {
-                override def onPull(): Unit = pull(in)
-              })
-          }
+          override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+            new GraphStageLogic(shape) with InHandler with OutHandler {
+              override def onPush(): Unit = push(out, grab(in) ++ ByteString("compressed"))
+              override def onPull(): Unit = pull(in)
+              setHandlers(in, out, this)
+            }
         }
   }
 


### PR DESCRIPTION
### Motivation

Port akka-http PR #4158 remaining change: the `DummyDecoder` test helper in `DecoderSpec` still uses separate `InHandler`/`OutHandler` objects instead of folding them into the `GraphStageLogic` itself. This is a minor allocation optimization from the upstream PR that was missed during migration.

### Modification

Fold `InHandler` and `OutHandler` into `GraphStageLogic` using `with InHandler with OutHandler` and `setHandlers(in, out, this)`, matching the pattern already used in production code (e.g. `WebSocket.scala`, `package.scala` ToStrict).

### Result

Reduces object allocations in the test `DummyDecoder` decompressor stage. Aligns test code with production code patterns.

### Tests

- `sbt "http-tests / Test / testOnly org.apache.pekko.http.scaladsl.coding.DecoderSpec"` — 2/2 passed

### References

Refs akka/akka-http#4158