### PR TITLE
fix: suppress Java compilation warnings in http-core, http and http-jackson

### DIFF
--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/AttributeKeys.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/AttributeKeys.java
@@ -15,6 +15,7 @@ package org.apache.pekko.http.javadsl.model;
 
 import org.apache.pekko.http.javadsl.model.ws.WebSocketUpgrade;
 
+@SuppressWarnings("unchecked")
 public final class AttributeKeys {
   public static final AttributeKey<RemoteAddress> remoteAddress =
       (AttributeKey<RemoteAddress>)

--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/ContentTypes.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/ContentTypes.java
@@ -21,6 +21,7 @@ import org.apache.pekko.http.scaladsl.model.ContentType$;
  * <p>If the {@link ContentType} you're looking for is not pre-defined here, you can obtain it from
  * a {@link MediaType} by using: {@code MediaTypes.TEXT_HTML.toContentType()}
  */
+@SuppressWarnings("deprecation")
 public final class ContentTypes {
   private ContentTypes() {}
 

--- a/http-core/src/test/java/org/apache/pekko/http/javadsl/settings/ParserSettingsTest.java
+++ b/http-core/src/test/java/org/apache/pekko/http/javadsl/settings/ParserSettingsTest.java
@@ -16,6 +16,7 @@ package org.apache.pekko.http.javadsl.settings;
 import org.apache.pekko.actor.ActorSystem;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation")
 public class ParserSettingsTest {
 
   @Test

--- a/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
+++ b/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
@@ -36,6 +36,7 @@ import org.apache.pekko.http.scaladsl.model.ExceptionWithErrorInfo;
 import org.apache.pekko.util.ByteString;
 
 /** A JSON marshaller/unmarshaller using the Jackson library. */
+@SuppressWarnings("deprecation")
 public class Jackson {
   private static final ObjectMapper defaultObjectMapper =
       createMapper().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);

--- a/http/src/main/java/org/apache/pekko/http/javadsl/coding/Coder.java
+++ b/http/src/main/java/org/apache/pekko/http/javadsl/coding/Coder.java
@@ -24,6 +24,7 @@ import org.apache.pekko.util.ByteString;
 import scala.jdk.javaapi.FutureConverters;
 
 /** A coder is an implementation of the predefined encoders/decoders defined for HTTP. */
+@SuppressWarnings("deprecation")
 public enum Coder {
   NoCoding(NoCoding$.MODULE$),
   Deflate(Deflate$.MODULE$),


### PR DESCRIPTION
### Motivation
Several Java source files in pekko-http produce compilation warnings during `sbt compile`:

| File | Module | Warning Type |
|---|---|---|
| `ContentTypes.java` | http-core | deprecated API usage |
| `AttributeKeys.java` | http-core | unchecked casts |
| `Coder.java` | http | deprecated internal API usage |
| `Jackson.java` | http-jackson | deprecated API usage |
| `ParserSettingsTest.java` | http-core (test) | deprecated API usage |

### Modification
- Add `@SuppressWarnings("deprecation")` to `ContentTypes`, `Coder`, `Jackson` and `ParserSettingsTest`
- Add `@SuppressWarnings("unchecked")` to `AttributeKeys`

All suppressions are on code that intentionally uses these APIs for Java interoperability with the Scala layer.

### Result
Java compilation no longer reports warnings for these files. Changes are annotation-only and cannot affect runtime behavior.

### Tests
Not run - full pekko-http clean compile requires `h2spec_darwin_amd64` dependency unavailable on macOS ARM64. The changes are annotation-only and cannot affect runtime behavior.

### References
None - cleanup