### PR TITLE
fix: fix scaladoc warnings across all modules

### DIFF
--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
@@ -39,7 +39,7 @@ object LfuCache {
     apply(scaladsl.CachingSettings(system))
 
   /**
-   * Creates a new [[pekko.http.caching.LfuCache]], with optional expiration depending
+   * Creates a new `LfuCache`, with optional expiration depending
    * on whether a non-zero and finite timeToLive and/or timeToIdle is set or not.
    */
   def apply[K, V](cachingSettings: scaladsl.CachingSettings): pekko.http.caching.scaladsl.Cache[K, V] = {
@@ -55,7 +55,7 @@ object LfuCache {
 
   /**
    * Java API
-   * Creates a new [[pekko.http.caching.LfuCache]] using configuration of the system,
+   * Creates a new `LfuCache` using configuration of the system,
    * with optional expiration depending on whether a non-zero and finite timeToLive and/or timeToIdle is set or not.
    */
   def create[K, V](system: ActorSystem): pekko.http.caching.javadsl.Cache[K, V] =
@@ -63,7 +63,7 @@ object LfuCache {
 
   /**
    * Java API
-   * Creates a new [[pekko.http.caching.LfuCache]], with optional expiration depending
+   * Creates a new `LfuCache`, with optional expiration depending
    * on whether a non-zero and finite timeToLive and/or timeToIdle is set or not.
    */
   def create[K, V](settings: javadsl.CachingSettings): pekko.http.caching.javadsl.Cache[K, V] =

--- a/http-caching/src/main/scala/org/apache/pekko/http/javadsl/server/directives/CachingDirectives.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/javadsl/server/directives/CachingDirectives.scala
@@ -62,7 +62,7 @@ object CachingDirectives {
   }
 
   /**
-   * Wraps its inner Route with caching support using the given [[Cache]] implementation and
+   * Wraps its inner Route with caching support using the given `Cache` implementation and
    * keyer function. Note that routes producing streaming responses cannot be wrapped with this directive.
    */
   def alwaysCache[K](cache: Cache[K, RouteResult], keyer: PartialFunction[RequestContext, K], inner: Supplier[Route]) =
@@ -73,9 +73,9 @@ object CachingDirectives {
     }
 
   /**
-   * Creates an [[LfuCache]]
+   * Creates an `LfuCache`
    *
-   * Default settings are available via [[pekko.http.caching.javadsl.CachingSettings.create]].
+   * Default settings are available via `CachingSettings.create`.
    */
   def routeCache[K](settings: CachingSettings): Cache[K, RouteResult] =
     LfuCache.create[K, RouteResult](settings)

--- a/http-caching/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CachingDirectives.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CachingDirectives.scala
@@ -31,7 +31,7 @@ trait CachingDirectives {
   import pekko.http.scaladsl.server.directives.RouteDirectives._
 
   /**
-   * Wraps its inner Route with caching support using the given [[Cache]] implementation and
+   * Wraps its inner Route with caching support using the given `Cache` implementation and
    * keyer function.
    */
   def cache[K](cache: Cache[K, RouteResult], keyer: PartialFunction[RequestContext, K]): Directive0 =
@@ -52,7 +52,7 @@ trait CachingDirectives {
     }).flatMap(if (_) pass else reject)
 
   /**
-   * Wraps its inner Route with caching support using the given [[Cache]] implementation and
+   * Wraps its inner Route with caching support using the given `Cache` implementation and
    * keyer function. Note that routes producing streaming responses cannot be wrapped with this directive.
    */
   def alwaysCache[K](cache: Cache[K, RouteResult], keyer: PartialFunction[RequestContext, K]): Directive0 =
@@ -68,13 +68,13 @@ trait CachingDirectives {
     }
 
   /**
-   * Creates an [[LfuCache]] with default settings obtained from the system's configuration.
+   * Creates an `LfuCache` with default settings obtained from the system's configuration.
    */
   def routeCache[K](implicit s: ActorSystem): Cache[K, RouteResult] =
     LfuCache[K, RouteResult](s)
 
   /**
-   * Creates an [[LfuCache]].
+   * Creates an `LfuCache`.
    */
   def routeCache[K](settings: CachingSettings): Cache[K, RouteResult] =
     LfuCache[K, RouteResult](settings)

--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/ModeledCustomHeaderFactory.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/ModeledCustomHeaderFactory.java
@@ -19,7 +19,7 @@ import org.apache.pekko.util.Helpers;
 
 /**
  * Companion class for the {@link ModeledCustomHeader} class. It offers methods to create {@link
- * ModeledCustomHeader} from {@link String} or {@link HttpHeader}.
+ * ModeledCustomHeader} from {@code String} or {@link HttpHeader}.
  */
 public abstract class ModeledCustomHeaderFactory<H extends ModeledCustomHeader> {
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ClientTransport.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ClientTransport.scala
@@ -71,7 +71,7 @@ object ClientTransport {
 
   /**
    * Returns a [[ClientTransport]] that runs all connection through the given HTTP(S) proxy using the
-   * HTTP CONNECT method. This call also takes [[HttpCredentials]] to base proxy credentials along with
+   * HTTP CONNECT method. This call also takes `HttpCredentials` to base proxy credentials along with
    * the request.
    *
    * An HTTP(S) proxy is a proxy that will create one TCP connection to the HTTP(S) proxy for each target connection. The
@@ -84,7 +84,7 @@ object ClientTransport {
 
   /**
    * Returns a [[ClientTransport]] that runs all connection through the given HTTP(S) proxy using the
-   * HTTP CONNECT method. This method also takes [[HttpCredentials]] in order to pass along to the proxy.
+   * HTTP CONNECT method. This method also takes `HttpCredentials` in order to pass along to the proxy.
    *
    * Pulls the host/port pair from the application.conf: pekko.client.proxy.https.{host, port}
    */
@@ -94,7 +94,7 @@ object ClientTransport {
   /**
    * Returns a [[ClientTransport]] that allows to customize host name resolution.
    * @param lookup A function that will be called with hostname and port and that should (potentially asynchronously resolve the given host/port
-   *               to an [[InetSocketAddress]]
+   *               to an `InetSocketAddress`
    */
   def withCustomResolver(lookup: BiFunction[String, Int, CompletionStage[InetSocketAddress]]): ClientTransport = {
     import scala.jdk.FutureConverters._

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectHttp.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectHttp.scala
@@ -64,7 +64,7 @@ object ConnectHttp {
    * port is ignored.
    *
    * If the given port is 0, a new local port will be assigned by the operating system,
-   * which can then be retrieved by the materialized [[pekko.http.javadsl.Http.ServerBinding]].
+   * which can then be retrieved by the materialized `Http.ServerBinding`.
    */
   def toHost(host: String, port: Int): ConnectHttp = {
     require(port >= 0, "port must be >= 0")
@@ -104,7 +104,7 @@ object ConnectHttp {
    * port is ignored.
    *
    * If the given port is 0, a new local port will be assigned by the operating system,
-   * which can then be retrieved by the materialized [[org.apache.pekko.http.javadsl.Http.ServerBinding]].
+   * which can then be retrieved by the materialized `Http.ServerBinding`.
    *
    * Uses the default HTTPS context.
    */

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/HostConnectionPool.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/HostConnectionPool.scala
@@ -27,7 +27,7 @@ abstract class HostConnectionPool private[http] {
   /**
    * Asynchronously triggers the shutdown of the host connection pool.
    *
-   * The produced [[CompletionStage]] is fulfilled when the shutdown has been completed.
+   * The produced `CompletionStage` is fulfilled when the shutdown has been completed.
    */
   def shutdown(): CompletionStage[Done]
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -80,7 +80,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     adaptServerLayer(delegate.serverLayer(settings.asScala, remoteAddress.asScala))
 
   /**
-   * Constructs a server layer stage using the given [[ServerSettings]]. The returned [[pekko.stream.javadsl.BidiFlow]] isn't reusable and
+   * Constructs a server layer stage using the given `ServerSettings`. The returned [[pekko.stream.javadsl.BidiFlow]] isn't reusable and
    * can only be materialized once.
    */
   def serverLayer(
@@ -113,7 +113,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     adaptClientLayer(delegate.clientLayer(JavaMapping.toScala(hostHeader), settings.asScala))
 
   /**
-   * Constructs a client layer stage using the given [[ClientConnectionSettings]].
+   * Constructs a client layer stage using the given `ClientConnectionSettings`.
    */
   def clientLayer(
       hostHeader: headers.Host,
@@ -170,7 +170,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
   /**
    * Creates a builder which will create a single connection to a host every time the built flow is materialized. There
    * is no pooling and you are yourself responsible for lifecycle management of the connection. For a more convenient
-   * Request level API see [[singleRequest()]]
+   * Request level API see `singleRequest()`
    *
    * @return A builder to configure more specific setup for the connection and then build a `Flow&gt;Request, Response, CompletionStage&gt;OutgoingConnection>>`.
    */
@@ -214,7 +214,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     adaptTupleFlow(delegate.newHostConnectionPool[T](to.host, to.port)(materializer).mapMaterializedValue(_.toJava))
 
   /**
-   * Same as [[newHostConnectionPool]] but with HTTPS encryption.
+   * Same as `newHostConnectionPool` but with HTTPS encryption.
    *
    * The given [[ConnectionContext]] will be used for encryption on the connection.
    */
@@ -294,7 +294,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * object of type `T` from the application which is emitted together with the corresponding response.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a `ConnectionPoolSettings` explicitly.
    */
   def cachedHostConnectionPool[T](
       to: ConnectHttp,
@@ -304,7 +304,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
       _.toJava))
 
   /**
-   * Same as [[cachedHostConnectionPool]] but with HTTPS encryption.
+   * Same as `cachedHostConnectionPool` but with HTTPS encryption.
    *
    * When an [[HttpConnectionContext]] is defined in the given [[ConnectHttp]] it will be used, otherwise the default client-side context will be used.
    */
@@ -317,7 +317,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
       .mapMaterializedValue(_.toJava))
 
   /**
-   * Same as [[cachedHostConnectionPool]] but with HTTPS encryption.
+   * Same as `cachedHostConnectionPool` but with HTTPS encryption.
    *
    * When an [[HttpConnectionContext]] is defined in the given [[ConnectHttp]] it will be used, otherwise the default client-side context will be used.
    */
@@ -384,7 +384,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     adaptTupleFlow(delegate.superPool[T](defaultClientHttpsContext.asScala, settings.asScala, log))
 
   /**
-   * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's
+   * Fires a single `HttpRequest` across the (cached) host connection pool for the request's
    * effective URI to produce a response future.
    *
    * The [[defaultClientHttpsContext]] is used to configure TLS for the connection.
@@ -396,7 +396,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     delegate.singleRequest(request.asScala).asJava
 
   /**
-   * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's
+   * Fires a single `HttpRequest` across the (cached) host connection pool for the request's
    * effective URI to produce a response future.
    *
    * The [[defaultClientHttpsContext]] is used to configure TLS for the connection.
@@ -408,7 +408,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     delegate.singleRequest(request.asScala, connectionContext.asScala).asJava
 
   /**
-   * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's
+   * Fires a single `HttpRequest` across the (cached) host connection pool for the request's
    * effective URI to produce a response future.
    *
    * The given [[HttpsConnectionContext]] will be used for encryption if the request is sent to an https endpoint.
@@ -433,7 +433,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     adaptWsBidiFlow(delegate.webSocketClientLayer(request.asScala))
 
   /**
-   * Constructs a WebSocket [[pekko.stream.javadsl.BidiFlow]] using the configured default [[ClientConnectionSettings]],
+   * Constructs a WebSocket [[pekko.stream.javadsl.BidiFlow]] using the configured default `ClientConnectionSettings`,
    * configured using the `pekko.http.client` config section.
    *
    * The layer is not reusable and must only be materialized once.
@@ -445,7 +445,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     adaptWsBidiFlow(delegate.webSocketClientLayer(request.asScala, settings.asScala))
 
   /**
-   * Constructs a WebSocket [[pekko.stream.javadsl.BidiFlow]] using the configured default [[ClientConnectionSettings]],
+   * Constructs a WebSocket [[pekko.stream.javadsl.BidiFlow]] using the configured default `ClientConnectionSettings`,
    * configured using the `pekko.http.client` config section.
    *
    * The layer is not reusable and must only be materialized once.

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/OutgoingConnectionBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/OutgoingConnectionBuilder.scala
@@ -27,7 +27,7 @@ import pekko.stream.javadsl.Flow
 
 /**
  * Builder for setting up a flow that will create one single connection per materialization to the specified host.
- * When customization is done, the flow is created using [[#http()]], [[#https()]], [[#http2()]] or [[#http2WithPriorKnowledge()]].
+ * When customization is done, the flow is created using `http()`, `https()`, `http2()` or `http2WithPriorKnowledge()`.
  *
  * Not for user extension
  */
@@ -104,7 +104,7 @@ trait OutgoingConnectionBuilder {
   def withCustomHttpsConnectionContext(httpsConnectionContext: HttpsConnectionContext): OutgoingConnectionBuilder
 
   /**
-   * Use custom [[ClientConnectionSettings]] for the connection.
+   * Use custom `ClientConnectionSettings` for the connection.
    */
   def withClientConnectionSettings(settings: ClientConnectionSettings): OutgoingConnectionBuilder
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
@@ -34,7 +34,7 @@ import scala.jdk.FutureConverters._
 /**
  * Builder API to create server bindings.
  *
- * Use [[Http.newServerAt()]] to create a builder, use methods to customize settings,
+ * Use `Http.newServerAt()` to create a builder, use methods to customize settings,
  * and then call one of the bind* methods to bind a server.
  */
 trait ServerBuilder {
@@ -49,7 +49,7 @@ trait ServerBuilder {
   def logTo(log: LoggingAdapter): ServerBuilder
 
   /**
-   * Use custom [[ServerSettings]] for the binding.
+   * Use custom `ServerSettings` for the binding.
    */
   def withSettings(settings: ServerSettings): ServerBuilder
 
@@ -64,7 +64,7 @@ trait ServerBuilder {
   def enableHttps(context: HttpsConnectionContext): ServerBuilder
 
   /**
-   * Use custom [[Materializer]] for the binding
+   * Use custom `Materializer` for the binding
    */
   def withMaterializer(materializer: Materializer): ServerBuilder
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/WebSocketUpgrade.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/WebSocketUpgrade.scala
@@ -20,7 +20,7 @@ import pekko.http.javadsl.model.HttpResponse
 import pekko.stream.{ FlowShape, Graph, SinkShape, SourceShape }
 
 /**
- * An attribute that WebSocket requests will contain. Use [[WebSocketUpgrade.handleMessagesWith]] to
+ * An attribute that WebSocket requests will contain. Use `WebSocketUpgrade.handleMessagesWith` to
  * create a WebSocket handshake response and handle the WebSocket message stream with the given handler.
  *
  * This is a low-level API. You might want to use `handleWebSocketMessages` instead as documented

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ClientTransport.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ClientTransport.scala
@@ -91,7 +91,7 @@ object ClientTransport {
 
   /**
    * Returns a [[ClientTransport]] that runs all connection through the given HTTP(S) proxy using the
-   * HTTP CONNECT method. This method also takes [[HttpCredentials]] in order to pass along to the proxy.
+   * HTTP CONNECT method. This method also takes `HttpCredentials` in order to pass along to the proxy.
    *
    * An HTTP(S) proxy is a proxy that will create one TCP connection to the HTTP(S) proxy for each target connection. The
    * proxy transparently forwards the TCP connection to the target host.
@@ -103,7 +103,7 @@ object ClientTransport {
 
   /**
    * Returns a [[ClientTransport]] that runs all connection through the given HTTP(S) proxy using the
-   * HTTP CONNECT method. This method also takes [[HttpCredentials]] in order to pass along to the proxy.
+   * HTTP CONNECT method. This method also takes `HttpCredentials` in order to pass along to the proxy.
    *
    * Pulls the host/port pair from the application.conf: pekko.client.proxy.https.{host, port}
    */
@@ -115,7 +115,7 @@ object ClientTransport {
   /**
    * Returns a [[ClientTransport]] that allows to customize host name resolution.
    * @param lookup A function that will be called with hostname and port and that should (potentially asynchronously resolve the given host/port
-   *               to an [[InetSocketAddress]]
+   *               to an `InetSocketAddress`
    */
   def withCustomResolver(lookup: (String, Int) => Future[InetSocketAddress]): ClientTransport =
     ClientTransportWithCustomResolver(lookup)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
@@ -55,7 +55,7 @@ import scala.util.control.NonFatal
 /**
  * Pekko extension for HTTP which serves as the main entry point into pekko-http.
  *
- * Use as `Http().bindAndHandle` etc. with an implicit [[ActorSystem]] in scope.
+ * Use as `Http().bindAndHandle` etc. with an implicit `ActorSystem` in scope.
  */
 @DoNotInherit
 class HttpExt @InternalStableApi /* constructor signature is hardcoded in Telemetry */ private[http] (
@@ -326,7 +326,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
   /**
    * Creates a builder which will create a single connection to a host every time the built flow is materialized. There
    * is no pooling and you are yourself responsible for lifecycle management of the connection. For a more convenient
-   * Request level API see [[singleRequest()]]
+   * Request level API see `singleRequest()`
    *
    * @return A builder to configure more specific setup for the connection and then build a `Flow[Request, Response, Future[OutgoingConnection]]`.
    */
@@ -447,7 +447,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * object of type `T` from the application which is emitted together with the corresponding response.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a `ConnectionPoolSettings` explicitly.
    */
   def newHostConnectionPool[T](host: String, port: Int = 80,
       settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
@@ -464,7 +464,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * for encryption on the connections.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a `ConnectionPoolSettings` explicitly.
    */
   def newHostConnectionPoolHttps[T](host: String, port: Int = 443,
       connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
@@ -505,7 +505,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * object of type `T` from the application which is emitted together with the corresponding response.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a `ConnectionPoolSettings` explicitly.
    */
   def cachedHostConnectionPool[T](host: String, port: Int = 80,
       settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
@@ -522,7 +522,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * for encryption on the connections.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a `ConnectionPoolSettings` explicitly.
    */
   def cachedHostConnectionPoolHttps[T](host: String, port: Int = 443,
       connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
@@ -572,7 +572,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
    * object of type `T` from the application which is emitted together with the corresponding response.
    *
    * To configure additional settings for the pool (and requests made using it),
-   * use the `pekko.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
+   * use the `pekko.http.host-connection-pool` config section or pass in a `ConnectionPoolSettings` explicitly.
    */
   def superPool[T](
       connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
@@ -892,7 +892,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
     /**
      * Completes when the [[terminate]] is called and server termination is in progress.
      * Can be useful to make parts of your application aware that termination has been issued,
-     * and they have [[Deadline]] time remaining to clean-up before the server will forcefully close
+     * and they have `Deadline` time remaining to clean-up before the server will forcefully close
      * existing connections.
      *
      * Note that while termination is in progress, no new connections will be accepted (i.e. termination implies prior [[unbind]]).

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/OutgoingConnectionBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/OutgoingConnectionBuilder.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 
 /**
  * Builder for setting up a flow that will create one single connection per materialization to the specified host.
- * When customization is done, the flow is created using [[#http()]], [[#https()]], [[#http2()]] or [[#http2WithPriorKnowledge()]].
+ * When customization is done, the flow is created using `http()`, `https()`, `http2()` or `http2WithPriorKnowledge()`.
  *
  * Not for user extension
  */
@@ -105,7 +105,7 @@ trait OutgoingConnectionBuilder {
   def withCustomHttpsConnectionContext(httpsConnectionContext: HttpsConnectionContext): OutgoingConnectionBuilder
 
   /**
-   * Use custom [[ClientConnectionSettings]] for the connection.
+   * Use custom `ClientConnectionSettings` for the connection.
    */
   def withClientConnectionSettings(settings: ClientConnectionSettings): OutgoingConnectionBuilder
 

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ServerBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ServerBuilder.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 /**
  * Builder API to create server bindings.
  *
- * Use [[HttpExt.newServerAt()]] to create a builder, use methods to customize settings,
+ * Use `HttpExt.newServerAt()` to create a builder, use methods to customize settings,
  * and then call one of the bind* methods to bind a server.
  */
 trait ServerBuilder {
@@ -45,7 +45,7 @@ trait ServerBuilder {
   def logTo(log: LoggingAdapter): ServerBuilder
 
   /**
-   * Use custom [[ServerSettings]] for the binding.
+   * Use custom `ServerSettings` for the binding.
    */
   def withSettings(settings: ServerSettings): ServerBuilder
 
@@ -60,7 +60,7 @@ trait ServerBuilder {
   def enableHttps(context: HttpsConnectionContext): ServerBuilder
 
   /**
-   * Use custom [[Materializer]] for the binding
+   * Use custom `Materializer` for the binding
    */
   def withMaterializer(materializer: Materializer): ServerBuilder
 

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
@@ -715,7 +715,7 @@ object HttpEntity {
     def completionStage: CompletionStage[Done] = f.asJava
   }
 
-  /** Adds Scala DSL idiomatic methods to [[HttpEntity]], e.g. versions of methods with an implicit [[Materializer]]. */
+  /** Adds Scala DSL idiomatic methods to [[HttpEntity]], e.g. versions of methods with an implicit `Materializer`. */
   implicit final class HttpEntityScalaDSLSugar(val httpEntity: HttpEntity) extends AnyVal {
 
     /**

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
@@ -284,7 +284,7 @@ object HttpMessage {
   }
   val AlreadyDiscardedEntity = new DiscardedEntity(Future.successful(Done))
 
-  /** Adds Scala DSL idiomatic methods to [[HttpMessage]], e.g. versions of methods with an implicit [[Materializer]]. */
+  /** Adds Scala DSL idiomatic methods to [[HttpMessage]], e.g. versions of methods with an implicit `Materializer`. */
   implicit final class HttpMessageScalaDSLSugar(val httpMessage: HttpMessage) extends AnyVal {
 
     /**

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/MediaType.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/MediaType.scala
@@ -26,22 +26,22 @@ import pekko.util.Helpers.toRootLowerCase
  * While knowledge of the MediaType alone suffices for being able to properly interpret binary content this
  * is not generally the case for non-binary (i.e. character-based) content, which also requires the definition
  * of a specific character encoding ([[HttpCharset]]).
- * Therefore [[MediaType]] instances are frequently encountered as a member of a [[ContentType]], which
+ * Therefore [[MediaType]] instances are frequently encountered as a member of a `ContentType`, which
  * groups a [[MediaType]] with a potentially required [[HttpCharset]] to hold everything required for being
  * able to interpret an [[HttpEntity]].
  *
  * MediaTypes come in three basic forms:
  *
- * 1. Binary: These do not need an additional [[HttpCharset]] to be able to form a [[ContentType]]. Therefore
+ * 1. Binary: These do not need an additional [[HttpCharset]] to be able to form a `ContentType`. Therefore
  *    they can be implicitly converted to the latter.
  *
  * 2. WithOpenCharset: Most character-based MediaTypes are of this form, which can be combined with all
- *    [[HttpCharset]] instances to form a [[ContentType]].
+ *    [[HttpCharset]] instances to form a `ContentType`.
  *
  * 3. WithFixedCharset: Some character-based MediaTypes prescribe a single, clearly defined charset and as such,
  *    similarly to binary MediaTypes, do not require the addition of an [[HttpCharset]] instances to form a
- *    [[ContentType]]. The most prominent example is probably `application/json` which must always be UTF-8 encoded.
- *    Like binary MediaTypes `WithFixedCharset` types can be implicitly converted to a [[ContentType]].
+ *    `ContentType`. The most prominent example is probably `application/json` which must always be UTF-8 encoded.
+ *    Like binary MediaTypes `WithFixedCharset` types can be implicitly converted to a `ContentType`.
  *
  * Not for user extension.
  */

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
@@ -158,13 +158,13 @@ object Multipart {
     def headers: immutable.Seq[HttpHeader]
 
     /**
-     * The potentially present [[`Content-Disposition`]] header.
+     * The potentially present `Content-Disposition` header.
      */
     def contentDispositionHeader: Option[`Content-Disposition`] =
       headers.collectFirst { case x: `Content-Disposition` => x }
 
     /**
-     * The parameters of the potentially present [[`Content-Disposition`]] header.
+     * The parameters of the potentially present `Content-Disposition` header.
      * Returns an empty map if no such header is present.
      */
     def dispositionParams: Map[String, String] =
@@ -174,7 +174,7 @@ object Multipart {
       }
 
     /**
-     * The [[pekko.http.scaladsl.model.headers.ContentDispositionType]] of the potentially present [[`Content-Disposition`]] header.
+     * The [[pekko.http.scaladsl.model.headers.ContentDispositionType]] of the potentially present `Content-Disposition` header.
      */
     def dispositionType: Option[ContentDispositionType] =
       contentDispositionHeader.map(_.dispositionType)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
@@ -71,7 +71,7 @@ sealed abstract case class Uri(scheme: String, authority: Authority, path: Path,
    *
    * If you want to use the copy constructor to update the 'rawQueryString', it is up to you to
    * make sure the query string does not contain invalid characters. For this reason we
-   * recommend using [[Uri#withRawQueryString()]] instead.
+   * recommend using `Uri#withRawQueryString()` instead.
    */
   def copy(scheme: String = scheme, authority: Authority = authority, path: Path = path,
       rawQueryString: Option[String] = rawQueryString, fragment: Option[String] = fragment): Uri =

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/headers/headers.scala
@@ -92,7 +92,7 @@ private[headers] sealed trait SyntheticHeader extends ModeledHeader
 /**
  * Superclass for user-defined custom headers defined by implementing `name` and `value`.
  *
- * Prefer to extend [[ModeledCustomHeader]] and [[ModeledCustomHeaderCompanion]] instead if
+ * Prefer to extend `ModeledCustomHeader` and `ModeledCustomHeaderCompanion` instead if
  * planning to use the defined header in match clauses (e.g. in the routing layer of Pekko HTTP),
  * as they allow the custom header to be matched from [[RawHeader]] and vice-versa.
  */
@@ -102,7 +102,7 @@ abstract class CustomHeader extends jm.headers.CustomHeader {
 }
 
 /**
- * To be extended by companion object of a custom header extending [[ModeledCustomHeader]].
+ * To be extended by companion object of a custom header extending `ModeledCustomHeader`.
  * Implements necessary apply and unapply methods to make the such defined header feel "native".
  */
 abstract class ModeledCustomHeaderCompanion[H <: ModeledCustomHeader[H]] {
@@ -133,7 +133,7 @@ abstract class ModeledCustomHeaderCompanion[H <: ModeledCustomHeader[H]] {
 
 /**
  * Support class for building user-defined custom headers defined by implementing `name` and `value`.
- * By implementing a [[ModeledCustomHeader]] instead of [[CustomHeader]] directly, all needed unapply
+ * By implementing a `ModeledCustomHeader` instead of [[CustomHeader]] directly, all needed unapply
  * methods are provided for this class, such that it can be pattern matched on from [[RawHeader]] and
  * the other way around as well.
  */

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/sse/ServerSentEvent.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/sse/ServerSentEvent.scala
@@ -28,13 +28,13 @@ import scala.jdk.OptionConverters._
 object ServerSentEvent {
 
   /**
-   * A [[ServerSentEvent]] with empty data which can be used as a heartbeat.
+   * A `ServerSentEvent` with empty data which can be used as a heartbeat.
    */
   val heartbeat: ServerSentEvent =
     ServerSentEvent("")
 
   /**
-   * Creates a [[ServerSentEvent]].
+   * Creates a `ServerSentEvent`.
    *
    * @param data data, may span multiple lines
    * @param type type, must not contain \n or \r
@@ -43,7 +43,7 @@ object ServerSentEvent {
     new ServerSentEvent(data, Some(`type`))
 
   /**
-   * Creates a [[ServerSentEvent]].
+   * Creates a `ServerSentEvent`.
    *
    * @param data data, may span multiple lines
    * @param type type, must not contain \n or \r
@@ -53,7 +53,7 @@ object ServerSentEvent {
     new ServerSentEvent(data, Some(`type`), Some(id))
 
   /**
-   * Creates a [[ServerSentEvent]].
+   * Creates a `ServerSentEvent`.
    *
    * @param data data, may span multiple lines
    * @param retry reconnection delay in milliseconds

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/Message.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/Message.scala
@@ -69,7 +69,7 @@ object TextMessage {
     Streamed(textStream)
 
   /**
-   * A strict [[TextMessage]] that contains the complete data as a [[String]].
+   * A strict [[TextMessage]] that contains the complete data as a `String`.
    */
   final case class Strict(text: String) extends TextMessage {
     def textStream: Source[String, ?] = Source.single(text)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -93,7 +93,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
     self.copyDeep(_.withResponseEntitySubscriptionTimeout(newValue), responseEntitySubscriptionTimeout = newValue)
 
   /**
-   * Since Akka HTTP 10.1.0, the transport is configured in [[ClientConnectionSettings]]. This method is a shortcut for
+   * Since Akka HTTP 10.1.0, the transport is configured in `ClientConnectionSettings`. This method is a shortcut for
    * `withUpdatedConnectionSettings(_.withTransport(newTransport))`.
    */
   def withTransport(newValue: ClientTransport): ConnectionPoolSettings =

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/ActorSystemExtension.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/ActorSystemExtension.scala
@@ -22,11 +22,11 @@ import pekko.stream.SystemMaterializer
 import com.typesafe.config.{ Config, ConfigFactory }
 
 /**
- * A JUnit 5 (Jupiter) Extension that manages the lifecycle of an [[ActorSystem]].
+ * A JUnit 5 (Jupiter) Extension that manages the lifecycle of an `ActorSystem`.
  *
- * This is the JUnit 5 counterpart of [[ActorSystemResource]] which uses JUnit 4's
- * [[org.junit.rules.ExternalResource]]. It implements [[BeforeEachCallback]] and
- * [[AfterEachCallback]] to create and terminate the ActorSystem around each test method.
+ * This is the JUnit 5 counterpart of `ActorSystemResource` which uses JUnit 4's
+ * [[org.junit.rules.ExternalResource]]. It implements `BeforeEachCallback` and
+ * `AfterEachCallback` to create and terminate the ActorSystem around each test method.
  *
  * Usage with `@RegisterExtension`:
  * {{{

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRoute.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRoute.scala
@@ -19,7 +19,7 @@ import pekko.http.javadsl.server.Route
 
 /**
  * A wrapped route that has a `run` method to run a request through the underlying route to create
- * a [[TestResponse]].
+ * a `TestResponse`.
  *
  * A TestRoute is created by deriving a test class from the concrete RouteTest implementation for your
  * testing framework (like [[JUnitRouteTest]] for JUnit) and then using its `testRoute` method to wrap

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/common/EntityStreamingSupport.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/common/EntityStreamingSupport.scala
@@ -53,7 +53,7 @@ abstract class EntityStreamingSupport {
   /**
    * Read-side, allows changing what content types are accepted by this framing.
    *
-   * EntityStreamingSupport traits MUST support re-configuring the accepted [[ContentTypeRange]].
+   * EntityStreamingSupport traits MUST support re-configuring the accepted `ContentTypeRange`.
    *
    * This is in order to support a-typical APIs which users still want to communicate with using
    * the provided support trait. Typical examples include APIs which return valid `application/json`
@@ -67,7 +67,7 @@ abstract class EntityStreamingSupport {
   /**
    * Write-side, defines what Content-Type the Marshaller should offer and the final Content-Type of the response.
    *
-   * EntityStreamingSupport traits MUST support re-configuring the offered [[ContentType]].
+   * EntityStreamingSupport traits MUST support re-configuring the offered `ContentType`.
    * This is due to the need integrating with existing systems which sometimes excpect custom Content-Types,
    * however really are just plain JSON or something else internally (perhaps with slight extensions).
    *

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/Marshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/Marshaller.scala
@@ -177,20 +177,20 @@ object Marshaller {
   }
 
   /**
-   * Helper for creating a synchronous [[Marshaller]] to content with a fixed charset from the given function.
+   * Helper for creating a synchronous `Marshaller` to content with a fixed charset from the given function.
    */
   def withFixedContentType[A, B](contentType: ContentType, f: java.util.function.Function[A, B]): Marshaller[A, B] =
     fromScala(marshalling.Marshaller.withFixedContentType(contentType.asScala)(f.apply))
 
   /**
-   * Helper for creating a synchronous [[Marshaller]] to content with a negotiable charset from the given function.
+   * Helper for creating a synchronous `Marshaller` to content with a negotiable charset from the given function.
    */
   def withOpenCharset[A, B](
       mediaType: MediaType.WithOpenCharset, f: java.util.function.BiFunction[A, HttpCharset, B]): Marshaller[A, B] =
     fromScala(marshalling.Marshaller.withOpenCharset(mediaType.asScala)(f.apply))
 
   /**
-   * Helper for creating a synchronous [[Marshaller]] to non-negotiable content from the given function.
+   * Helper for creating a synchronous `Marshaller` to non-negotiable content from the given function.
    */
   def opaque[A, B](f: function.Function[A, B]): Marshaller[A, B] =
     fromScala(scaladsl.marshalling.Marshaller.opaque[A, B] { a => f.apply(a) })

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/sse/EventStreamMarshalling.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/sse/EventStreamMarshalling.scala
@@ -23,12 +23,12 @@ import pekko.http.javadsl.model.sse.ServerSentEvent
 import pekko.stream.javadsl.Source
 
 /**
- * Using `eventStreamMarshaller` lets a source of [[ServerSentEvent]]s be marshalled to a `HttpResponse`.
+ * Using `eventStreamMarshaller` lets a source of `ServerSentEvent`s be marshalled to a `HttpResponse`.
  */
 object EventStreamMarshalling {
 
   /**
-   * Lets a source of [[ServerSentEvent]]s be marshalled to a `HttpResponse`.
+   * Lets a source of `ServerSentEvent`s be marshalled to a `HttpResponse`.
    */
   val toEventStream: Marshaller[Source[ServerSentEvent, NotUsed], RequestEntity] = {
     def asScala(eventStream: Source[ServerSentEvent, NotUsed]) =

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
@@ -208,7 +208,7 @@ abstract class BasicDirectives {
   }
 
   /**
-   * Extracts the current [[HttpRequest]] instance.
+   * Extracts the current `HttpRequest` instance.
    */
   def extractRequest(inner: JFunction[HttpRequest, Route]) = RouteAdapter {
     D.extractRequest { rq =>
@@ -236,7 +236,7 @@ abstract class BasicDirectives {
   }
 
   /**
-   * Extracts the [[Materializer]] from the [[RequestContext]].
+   * Extracts the `Materializer` from the [[RequestContext]].
    */
   def extractMaterializer(inner: JFunction[Materializer, Route]): Route = RouteAdapter(
     D.extractMaterializer { m => inner.apply(m).delegate })
@@ -249,7 +249,7 @@ abstract class BasicDirectives {
     D.extractActorSystem { system => inner.apply(system).delegate })
 
   /**
-   * Extracts the [[ExecutionContextExecutor]] from the [[RequestContext]].
+   * Extracts the `ExecutionContextExecutor` from the [[RequestContext]].
    */
   def extractExecutionContext(inner: JFunction[ExecutionContextExecutor, Route]): Route = RouteAdapter(
     D.extractExecutionContext { c => inner.apply(c).delegate })
@@ -264,7 +264,7 @@ abstract class BasicDirectives {
   }
 
   /**
-   * Runs its inner route with the given alternative [[LoggingAdapter]].
+   * Runs its inner route with the given alternative `LoggingAdapter`.
    */
   def withLog(log: LoggingAdapter, inner: Supplier[Route]): Route = RouteAdapter {
     D.withLog(log) { inner.get.delegate }
@@ -285,14 +285,14 @@ abstract class BasicDirectives {
   }
 
   /**
-   * Runs its inner route with the given alternative [[RoutingSettings]].
+   * Runs its inner route with the given alternative `RoutingSettings`.
    */
   def withSettings(s: RoutingSettings, inner: Supplier[Route]): Route = RouteAdapter {
     D.withSettings(s.asScala) { inner.get.delegate }
   }
 
   /**
-   * Extracts the [[LoggingAdapter]]
+   * Extracts the `LoggingAdapter`
    */
   def extractLog(inner: JFunction[LoggingAdapter, Route]): Route = RouteAdapter {
     D.extractLog { log => inner.apply(log).delegate }
@@ -308,7 +308,7 @@ abstract class BasicDirectives {
   }
 
   /**
-   * Extracts the [[RoutingSettings]] from the [[pekko.http.javadsl.server.RequestContext]].
+   * Extracts the `RoutingSettings` from the [[pekko.http.javadsl.server.RequestContext]].
    */
   def extractSettings(inner: JFunction[RoutingSettings, Route]) = RouteAdapter {
     D.extractSettings { settings =>

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/CookieDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/CookieDirectives.scala
@@ -30,7 +30,7 @@ import pekko.http.scaladsl.server.{ Directives => D }
 abstract class CookieDirectives extends CodingDirectives {
 
   /**
-   * Extracts the [[HttpCookiePair]] with the given name. If the cookie is not present the
+   * Extracts the `HttpCookiePair` with the given name. If the cookie is not present the
    * request is rejected with a respective [[pekko.http.javadsl.server.MissingCookieRejection]].
    */
   def cookie(name: String, inner: JFunction[HttpCookiePair, Route]): Route = RouteAdapter {
@@ -38,7 +38,7 @@ abstract class CookieDirectives extends CodingDirectives {
   }
 
   /**
-   * Extracts the [[HttpCookiePair]] with the given name as an `Option[HttpCookiePair]`.
+   * Extracts the `HttpCookiePair` with the given name as an `Option[HttpCookiePair]`.
    * If the cookie is not present a value of `None` is extracted.
    */
   def optionalCookie(name: String, inner: JFunction[Optional[HttpCookiePair], Route]): Route = RouteAdapter {
@@ -46,14 +46,14 @@ abstract class CookieDirectives extends CodingDirectives {
   }
 
   /**
-   * Adds a [[Set-Cookie]] response header with the given cookie.
+   * Adds a `Set-Cookie` response header with the given cookie.
    */
   def setCookie(cookie: HttpCookie, inner: Supplier[Route]): Route = RouteAdapter {
     D.setCookie(cookie.asScala) { inner.get.delegate }
   }
 
   /**
-   * Adds a [[Set-Cookie]] response header with the given cookies.
+   * Adds a `Set-Cookie` response header with the given cookies.
    */
   def setCookie(cookies: JIterable[HttpCookie], inner: Supplier[Route]): Route = RouteAdapter {
     cookies.asScala.toList match {
@@ -67,14 +67,14 @@ abstract class CookieDirectives extends CodingDirectives {
   }
 
   /**
-   * Adds a [[Set-Cookie]] response header expiring the given cookie.
+   * Adds a `Set-Cookie` response header expiring the given cookie.
    */
   def deleteCookie(cookie: HttpCookie, inner: Supplier[Route]): Route = RouteAdapter {
     D.deleteCookie(cookie.asScala) { inner.get.delegate }
   }
 
   /**
-   * Adds a [[Set-Cookie]] response header expiring the given cookies.
+   * Adds a `Set-Cookie` response header expiring the given cookies.
    */
   def deleteCookie(cookies: JIterable[HttpCookie], inner: Supplier[Route]): Route = RouteAdapter {
     cookies.asScala.toList match {
@@ -88,14 +88,14 @@ abstract class CookieDirectives extends CodingDirectives {
   }
 
   /**
-   * Adds a [[Set-Cookie]] response header expiring the cookie with the given properties.
+   * Adds a `Set-Cookie` response header expiring the cookie with the given properties.
    *
    * @param name Name of the cookie to match
    */
   def deleteCookie(name: String, inner: Supplier[Route]): Route = deleteCookie(name, "", "", inner)
 
   /**
-   * Adds a [[Set-Cookie]] response header expiring the cookie with the given properties.
+   * Adds a `Set-Cookie` response header expiring the cookie with the given properties.
    *
    * @param name Name of the cookie to match
    * @param domain Domain of the cookie to match, or empty string to match any domain
@@ -103,7 +103,7 @@ abstract class CookieDirectives extends CodingDirectives {
   def deleteCookie(name: String, domain: String, inner: Supplier[Route]): Route = deleteCookie(name, domain, "", inner)
 
   /**
-   * Adds a [[Set-Cookie]] response header expiring the cookie with the given properties.
+   * Adds a `Set-Cookie` response header expiring the cookie with the given properties.
    *
    * @param name Name of the cookie to match
    * @param domain Domain of the cookie to match, or empty string to match any domain

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FileAndResourceDirectives.scala
@@ -264,11 +264,11 @@ abstract class FileAndResourceDirectives extends ExecutionDirectives {
     D.listDirectoryContents(directories: _*)(directoryRenderer.asScala)
   }
 
-  /** Default [[DirectoryRenderer]] to be used with directory listing directives. */
+  /** Default `DirectoryRenderer` to be used with directory listing directives. */
   def defaultDirectoryRenderer: DirectoryRenderer =
     pekko.http.scaladsl.server.directives.FileAndResourceDirectives.DirectoryRenderer.defaultDirectoryRenderer
 
-  /** Default [[ContentTypeResolver]]. */
+  /** Default `ContentTypeResolver`. */
   def defaultContentTypeResolver: ContentTypeResolver =
     pekko.http.scaladsl.server.directives.ContentTypeResolver.Default
 }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
@@ -60,7 +60,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * completion with the future's value as an extraction of type `T` if
    * the supplied `CircuitBreaker` is closed.
    *
-   * If the supplied [[CircuitBreaker]] is open the request is rejected
+   * If the supplied `CircuitBreaker` is open the request is rejected
    * with a [[pekko.http.javadsl.server.CircuitBreakerOpenRejection]].
    *
    * @group future

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
@@ -33,10 +33,10 @@ abstract class HeaderDirectives extends FutureDirectives {
   private type ScalaHeaderMagnet = HeaderMagnet[pekko.http.scaladsl.model.HttpHeader]
 
   /**
-   * Checks that request comes from the same origin. Extracts the [[Origin]] header value and verifies that
-   * allowed range contains the obtained value. In the case of absent of the [[Origin]] header rejects
+   * Checks that request comes from the same origin. Extracts the `Origin` header value and verifies that
+   * allowed range contains the obtained value. In the case of absent of the `Origin` header rejects
    * with [[MissingHeaderRejection]]. If the origin value is not in the allowed range
-   * rejects with an [[InvalidOriginRejection]] and [[StatusCodes.FORBIDDEN]] status.
+   * rejects with an [[InvalidOriginRejection]] and `StatusCodes.FORBIDDEN` status.
    *
    * @group header
    */

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/PathDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/PathDirectives.scala
@@ -239,7 +239,7 @@ abstract class PathDirectives extends ParameterDirectives {
   /**
    * If the request path doesn't end with a slash, redirect to the same uri with trailing slash in the path.
    *
-   * '''Caveat''': [[#path]] without trailing slash and [[#pathEnd]] directives will not match inside of this directive.
+   * '''Caveat''': `path` without trailing slash and [[#pathEnd]] directives will not match inside of this directive.
    *
    * @param redirectionType A status code from StatusCodes, which must be a redirection type.
    */

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/SecurityDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/SecurityDirectives.scala
@@ -45,7 +45,7 @@ object SecurityDirectives {
      * Safely compares the passed in `secret` with the received secret part of the Credentials.
      * Use of this method instead of manual String equality testing is recommended in order to guard against timing attacks.
      *
-     * See also [[pekko.http.impl.util.EnhancedString#secure_==]], for more information.
+     * See also `org.apache.pekko.http.impl.util.EnhancedString#secure_==`, for more information.
      */
     def verify(secret: String): Boolean = asScala.verify(secret)
   }
@@ -62,7 +62,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
   import pekko.http.impl.util.JavaMapping.Implicits._
 
   /**
-   * Extracts the potentially present [[HttpCredentials]] provided with the request's [[pekko.http.javadsl.model.headers.Authorization]] header.
+   * Extracts the potentially present `HttpCredentials` provided with the request's [[pekko.http.javadsl.model.headers.Authorization]] header.
    */
   def extractCredentials(inner: JFunction[Optional[HttpCredentials], Route]): Route = RouteAdapter {
     D.extractCredentials { cred =>
@@ -315,8 +315,8 @@ abstract class SecurityDirectives extends SchemeDirectives {
   }
 
   /**
-   * Asynchronous version of [[authorize]].
-   * If the [[CompletionStage]] fails or is completed with `false`
+   * Asynchronous version of `authorize`.
+   * If the `CompletionStage` fails or is completed with `false`
    * authorization fails and the route is rejected with an [[pekko.http.javadsl.server.AuthorizationFailedRejection]].
    */
   @CorrespondsTo("authorizeAsync")

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/WebSocketDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/WebSocketDirectives.scala
@@ -41,7 +41,7 @@ abstract class WebSocketDirectives extends SecurityDirectives {
   }
 
   /**
-   * Extract the list of WebSocket subprotocols as offered by the client in the [[Sec-WebSocket-Protocol]] header if
+   * Extract the list of WebSocket subprotocols as offered by the client in the `Sec-WebSocket-Protocol` header if
    * this is a WebSocket request. Rejects with an [[ExpectedWebSocketRequestRejection]], otherwise.
    */
   def extractOfferedWsProtocols(inner: JFunction[JList[String], Route]): Route = RouteAdapter {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -182,7 +182,7 @@ abstract class Unmarshaller[-A, B] extends UnmarshallerBase[A, B] {
     asScala.apply(value)(ec, mat).asJava
 
   /**
-   * Apply this Unmarshaller to the given value. Uses the default materializer [[ExecutionContext]].
+   * Apply this Unmarshaller to the given value. Uses the default materializer `ExecutionContext`.
    * If you expect the marshalling to be heavy, it is suggested to provide a specialized context for those operations.
    */
   def unmarshal(value: A, mat: Materializer): CompletionStage[B] = unmarshal(value, mat.executionContext, mat)
@@ -194,7 +194,7 @@ abstract class Unmarshaller[-A, B] extends UnmarshallerBase[A, B] {
     unmarshal(value, ec, SystemMaterializer(system).materializer)
 
   /**
-   * Apply this Unmarshaller to the given value. Uses the default materializer [[ExecutionContext]].
+   * Apply this Unmarshaller to the given value. Uses the default materializer `ExecutionContext`.
    * If you expect the marshalling to be heavy, it is suggested to provide a specialized context for those operations.
    */
   def unmarshal(value: A, system: ClassicActorSystemProvider): CompletionStage[B] =

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Decoder.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Decoder.scala
@@ -51,7 +51,7 @@ object Decoder {
 /**
  * Internal API
  *
- * A decoder that is implemented in terms of a [[Stage]]
+ * A decoder that is implemented in terms of a `Stage`
  */
 @InternalApi
 @deprecated("StreamDecoder is internal API and will be moved or removed in the future", since = "Akka HTTP 10.2.0")

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/common/EntityStreamingSupport.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/common/EntityStreamingSupport.scala
@@ -55,7 +55,7 @@ abstract class EntityStreamingSupport extends common.EntityStreamingSupport {
   /**
    * Read-side, allows changing what content types are accepted by this framing.
    *
-   * EntityStreamingSupport traits MUST support re-configuring the accepted [[ContentTypeRange]].
+   * EntityStreamingSupport traits MUST support re-configuring the accepted `ContentTypeRange`.
    *
    * This is in order to support a-typical APIs which users still want to communicate with using
    * the provided support trait. Typical examples include APIs which return valid `application/json`
@@ -69,7 +69,7 @@ abstract class EntityStreamingSupport extends common.EntityStreamingSupport {
   /**
    * Write-side, defines what Content-Type the Marshaller should offer and the final Content-Type of the response.
    *
-   * EntityStreamingSupport traits MUST support re-configuring the offered [[ContentType]].
+   * EntityStreamingSupport traits MUST support re-configuring the offered `ContentType`.
    * This is due to the need integrating with existing systems which sometimes expect custom Content-Types,
    * however really are just plain JSON or something else internally (perhaps with slight extensions).
    *

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshal.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshal.scala
@@ -44,7 +44,7 @@ object Marshal {
 class Marshal[A](val value: A) {
 
   /**
-   * Marshals `value` using the first available [[Marshalling]] for `A` and `B` provided by the given [[Marshaller]].
+   * Marshals `value` using the first available [[Marshalling]] for `A` and `B` provided by the given `Marshaller`.
    * If the marshalling is flexible with regard to the used charset `UTF-8` is chosen.
    */
   def to[B](implicit m: Marshaller[A, B], ec: ExecutionContext): Future[B] =

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshaller.scala
@@ -34,7 +34,7 @@ sealed abstract class Marshaller[-A, +B] {
    * the [[pekko.http.scaladsl.model.MediaType]] of the marshalling result with the given one.
    * Note that not all wrappings are legal. f the underlying [[pekko.http.scaladsl.model.MediaType]] has constraints with regard to the
    * charsets it allows the new [[pekko.http.scaladsl.model.MediaType]] must be compatible, since pekko-http will never recode entities.
-   * If the wrapping is illegal the [[scala.concurrent.Future]] produced by the resulting marshaller will contain a [[RuntimeException]].
+   * If the wrapping is illegal the [[scala.concurrent.Future]] produced by the resulting marshaller will contain a `RuntimeException`.
    */
   def wrap[C, D >: B](newMediaType: MediaType)(f: C => A)(implicit mto: ContentTypeOverrider[D]): Marshaller[C, D] =
     wrapWithEC[C, D](newMediaType)(_ => f)
@@ -44,7 +44,7 @@ sealed abstract class Marshaller[-A, +B] {
    * the [[pekko.http.scaladsl.model.MediaType]] of the marshalling result with the given one.
    * Note that not all wrappings are legal. f the underlying [[pekko.http.scaladsl.model.MediaType]] has constraints with regard to the
    * charsets it allows the new [[pekko.http.scaladsl.model.MediaType]] must be compatible, since pekko-http will never recode entities.
-   * If the wrapping is illegal the [[scala.concurrent.Future]] produced by the resulting marshaller will contain a [[RuntimeException]].
+   * If the wrapping is illegal the [[scala.concurrent.Future]] produced by the resulting marshaller will contain a `RuntimeException`.
    */
   def wrapWithEC[C, D >: B](newMediaType: MediaType)(f: ExecutionContext => C => A)(
       implicit cto: ContentTypeOverrider[D]): Marshaller[C, D] =
@@ -96,7 +96,7 @@ object Marshaller
     with PredefinedToRequestMarshallers {
 
   /**
-   * Creates a [[Marshaller]] from the given function.
+   * Creates a `Marshaller` from the given function.
    */
   def apply[A, B](f: ExecutionContext => A => Future[List[Marshalling[B]]]): Marshaller[A, B] =
     new Marshaller[A, B] {
@@ -106,7 +106,7 @@ object Marshaller
     }
 
   /**
-   * Helper for creating a [[Marshaller]] using the given function.
+   * Helper for creating a `Marshaller` using the given function.
    */
   def strict[A, B](f: A => Marshalling[B]): Marshaller[A, B] =
     Marshaller { _ => a => FastFuture.successful(f(a) :: Nil) }
@@ -136,7 +136,7 @@ object Marshaller
     oneOf(values.map(f): _*)
 
   /**
-   * Helper for creating a synchronous [[Marshaller]] to content with a fixed charset from the given function.
+   * Helper for creating a synchronous `Marshaller` to content with a fixed charset from the given function.
    */
   def withFixedContentType[A, B](contentType: ContentType)(marshal: A => B): Marshaller[A, B] =
     new Marshaller[A, B] {
@@ -153,7 +153,7 @@ object Marshaller
     }
 
   /**
-   * Helper for creating a synchronous [[Marshaller]] to content with a negotiable charset from the given function.
+   * Helper for creating a synchronous `Marshaller` to content with a negotiable charset from the given function.
    */
   def withOpenCharset[A, B](mediaType: MediaType.WithOpenCharset)(marshal: (A, HttpCharset) => B): Marshaller[A, B] =
     new Marshaller[A, B] {
@@ -170,13 +170,13 @@ object Marshaller
     }
 
   /**
-   * Helper for creating a synchronous [[Marshaller]] to non-negotiable content from the given function.
+   * Helper for creating a synchronous `Marshaller` to non-negotiable content from the given function.
    */
   def opaque[A, B](marshal: A => B): Marshaller[A, B] =
     strict { value => Marshalling.Opaque(() => marshal(value)) }
 
   /**
-   * Helper for creating a [[Marshaller]] combined of the provided `marshal` function
+   * Helper for creating a `Marshaller` combined of the provided `marshal` function
    * and an implicit Marshaller which is able to produce the required final type.
    */
   def combined[A, B, C](marshal: A => B)(implicit m2: Marshaller[B, C]): Marshaller[A, C] =

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/sse/EventStreamMarshalling.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/sse/EventStreamMarshalling.scala
@@ -24,14 +24,14 @@ import pekko.http.scaladsl.model.sse.ServerSentEvent
 import pekko.stream.scaladsl.Source
 
 /**
- * Importing [[EventStreamMarshalling.toEventStream]] lets a source of [[ServerSentEvent]]s be marshalled to a
+ * Importing [[EventStreamMarshalling.toEventStream]] lets a source of `ServerSentEvent`s be marshalled to a
  * `HttpEntity` and hence as a `HttpResponse`.
  */
 @ApiMayChange
 object EventStreamMarshalling extends EventStreamMarshalling
 
 /**
- * Mixing in this trait lets a source of [[ServerSentEvent]]s be marshalled to a `HttpEntity` and hence as a
+ * Mixing in this trait lets a source of `ServerSentEvent`s be marshalled to a `HttpEntity` and hence as a
  * `HttpResponse`.
  */
 @ApiMayChange

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Directive.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Directive.scala
@@ -198,7 +198,7 @@ object Directive {
   /**
    * "Standard" transformers for [[Directive1]].
    * Easier to use than `tmap`, `tflatMap`, etc. defined on [[Directive]] itself,
-   * because they provide transparent conversion from [[Tuple1]].
+   * because they provide transparent conversion from `Tuple1`.
    */
   implicit class SingleValueTransformers[T](val underlying: Directive1[T]) extends AnyVal {
     def map[R](f: T => R)(implicit tupler: Tupler[R]): Directive[tupler.Out] =

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/HttpApp.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/HttpApp.scala
@@ -42,7 +42,7 @@ abstract class HttpApp extends Directives {
   private val serverBinding = new AtomicReference[ServerBinding]()
 
   /**
-   * [[ActorSystem]] used to start this server. Stopping this system will interfere with the proper functioning condition of the server.
+   * `ActorSystem` used to start this server. Stopping this system will interfere with the proper functioning condition of the server.
    */
   protected val systemReference = new AtomicReference[ActorSystem]()
 
@@ -55,7 +55,7 @@ abstract class HttpApp extends Directives {
   }
 
   /**
-   * Start a server on the specified host and port, using the provided [[ActorSystem]].
+   * Start a server on the specified host and port, using the provided `ActorSystem`.
    * Note that this method is blocking
    *
    * @param system ActorSystem to use for starting the app,
@@ -75,7 +75,7 @@ abstract class HttpApp extends Directives {
   }
 
   /**
-   * Start a server on the specified host and port, using the provided settings and [[ActorSystem]].
+   * Start a server on the specified host and port, using the provided settings and `ActorSystem`.
    * Note that this method is blocking.
    *
    * @param system ActorSystem to use for starting the app,
@@ -87,7 +87,7 @@ abstract class HttpApp extends Directives {
   }
 
   /**
-   * Start a server on the specified host and port, using the provided settings and [[ActorSystem]] if present.
+   * Start a server on the specified host and port, using the provided settings and `ActorSystem` if present.
    * Note that this method is blocking.
    *
    * @param system ActorSystem to use for starting the app,
@@ -127,8 +127,8 @@ abstract class HttpApp extends Directives {
   }
 
   /**
-   * It tries to retrieve the [[ServerBinding]] if the server has been successfully started. It fails otherwise.
-   * You can use this method to attempt to retrieve the [[ServerBinding]] at any point in time to, for example, stop the server due to unexpected circumstances.
+   * It tries to retrieve the `ServerBinding` if the server has been successfully started. It fails otherwise.
+   * You can use this method to attempt to retrieve the `ServerBinding` at any point in time to, for example, stop the server due to unexpected circumstances.
    */
   def binding(): Try[ServerBinding] = {
     if (serverBinding.get() == null)
@@ -138,7 +138,7 @@ abstract class HttpApp extends Directives {
 
   /**
    * Hook that will be called just after the server termination. Override this method if you want to perform some cleanup actions after the server is stopped.
-   * The `attempt` parameter is represented with a [[Try]] type that is successful only if the server was successfully shut down.
+   * The `attempt` parameter is represented with a `Try` type that is successful only if the server was successfully shut down.
    */
   protected def postServerShutdown(attempt: Try[Done], system: ActorSystem): Unit = {
     systemReference.get().log.info("Shutting down the server")

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/PathMatcher.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/PathMatcher.scala
@@ -32,12 +32,12 @@ import pekko.http.scaladsl.server.util.TupleOps._
 abstract class PathMatcher[L](implicit val ev: Tuple[L]) extends (Path => PathMatcher.Matching[L]) { self =>
   import PathMatcher._
 
-  /** Alias for [[slash]]. */
+  /** Alias for `slash`. */
   def / : PathMatcher[L] = slash
 
   def slash: PathMatcher[L] = this ~ PathMatchers.Slash
 
-  /** Alias for [[slash]]. */
+  /** Alias for `slash`. */
   def /[R](other: PathMatcher[R])(implicit join: Join[L, R]): PathMatcher[join.Out] = slash(other)
 
   def slash[R](other: PathMatcher[R])(implicit join: Join[L, R]): PathMatcher[join.Out] =

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RejectionHandler.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RejectionHandler.scala
@@ -108,7 +108,7 @@ object RejectionHandler {
      * Convenience method for handling rejections created by the onCompleteWithBreaker directive.
      * Signals that the request was rejected because the supplied circuit breaker is open and requests are failing fast.
      *
-     * Use to customise the error response being written instead of the default [[ServiceUnavailable]] response.
+     * Use to customise the error response being written instead of the default `ServiceUnavailable` response.
      */
     def handleCircuitBreakerOpenRejection(handler: CircuitBreakerOpenRejection => Route): this.type =
       handle { case r: CircuitBreakerOpenRejection => handler(r) }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectives.scala
@@ -221,7 +221,7 @@ trait BasicDirectives {
   def extractMatchedPath: Directive1[Uri.Path] = BasicDirectives._extractMatchedPath
 
   /**
-   * Extracts the current [[HttpRequest]] instance.
+   * Extracts the current `HttpRequest` instance.
    *
    * @group basic
    */
@@ -291,7 +291,7 @@ trait BasicDirectives {
     BasicDirectives._extractLog
 
   /**
-   * Runs its inner route with the given alternative [[RoutingSettings]].
+   * Runs its inner route with the given alternative `RoutingSettings`.
    *
    * @group basic
    */
@@ -307,7 +307,7 @@ trait BasicDirectives {
     mapRequestContext(ctx => ctx.withRoutingSettings(f(ctx.settings)))
 
   /**
-   * Extracts the [[RoutingSettings]] from the [[pekko.http.scaladsl.server.RequestContext]].
+   * Extracts the `RoutingSettings` from the [[pekko.http.scaladsl.server.RequestContext]].
    *
    * @group basic
    */

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectives.scala
@@ -29,7 +29,7 @@ trait CookieDirectives {
   import RouteDirectives._
 
   /**
-   * Extracts the [[HttpCookiePair]] with the given name. If the cookie is not present the
+   * Extracts the `HttpCookiePair` with the given name. If the cookie is not present the
    * request is rejected with a respective [[MissingCookieRejection]].
    *
    * @group cookie
@@ -38,7 +38,7 @@ trait CookieDirectives {
     headerValue(findCookie(name)) | reject(MissingCookieRejection(name))
 
   /**
-   * Extracts the [[HttpCookiePair]] with the given name as an `Option[HttpCookiePair]`.
+   * Extracts the `HttpCookiePair` with the given name as an `Option[HttpCookiePair]`.
    * If the cookie is not present a value of `None` is extracted.
    *
    * @group cookie
@@ -52,7 +52,7 @@ trait CookieDirectives {
   }
 
   /**
-   * Adds a [[Set-Cookie]] response header with the given cookies.
+   * Adds a `Set-Cookie` response header with the given cookies.
    *
    * @group cookie
    */
@@ -60,7 +60,7 @@ trait CookieDirectives {
     respondWithHeaders((first :: more.toList).map(`Set-Cookie`(_)))
 
   /**
-   * Adds a [[Set-Cookie]] response header expiring the given cookies.
+   * Adds a `Set-Cookie` response header expiring the given cookies.
    *
    * @group cookie
    */
@@ -70,7 +70,7 @@ trait CookieDirectives {
     })
 
   /**
-   * Adds a [[Set-Cookie]] response header expiring the cookie with the given properties.
+   * Adds a `Set-Cookie` response header expiring the cookie with the given properties.
    *
    * @group cookie
    */

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -27,7 +27,7 @@ import pekko.util.ByteString
  * Allows the [[MarshallingDirectives.entity]] directive to extract a [[pekko.stream.scaladsl.Source]] of elements.
  *
  * See [[common.EntityStreamingSupport]] for useful default framing `Flow` instances and
- * support traits such as `SprayJsonSupport` (or your other favourite JSON library) to provide the needed [[Marshaller]] s.
+ * support traits such as `SprayJsonSupport` (or your other favourite JSON library) to provide the needed `Marshaller` s.
  */
 trait FramedEntityStreamingDirectives extends MarshallingDirectives {
 
@@ -37,15 +37,15 @@ trait FramedEntityStreamingDirectives extends MarshallingDirectives {
    * Extracts entity as [[pekko.stream.scaladsl.Source]] of elements of type `T`.
    * This is achieved by applying the implicitly provided (in the following order):
    *
-   * - 1st: chunk-up the incoming [[ByteString]]s by applying the `Content-Type`-aware framing
-   * - 2nd: apply the [[Unmarshaller]] (from [[ByteString]] to `T`) for each of the respective "chunks" (e.g. for each JSON element contained within an array).
+   * - 1st: chunk-up the incoming `ByteString`s by applying the `Content-Type`-aware framing
+   * - 2nd: apply the `Unmarshaller` (from `ByteString` to `T`) for each of the respective "chunks" (e.g. for each JSON element contained within an array).
    *
    * The request will be rejected with an [[pekko.http.scaladsl.server.UnsupportedRequestContentTypeRejection]] if
-   * its [[ContentType]] is not supported by the used `framing` or `unmarshaller`.
+   * its `ContentType` is not supported by the used `framing` or `unmarshaller`.
    *
    * Cancelling extracted [[pekko.stream.scaladsl.Source]] closes the connection abruptly (same as cancelling the `entity.dataBytes`).
    *
-   * See also [[MiscDirectives.withoutSizeLimit]] as you may want to allow streaming infinite streams of data in this route.
+   * See also `MiscDirectives.withoutSizeLimit` as you may want to allow streaming infinite streams of data in this route.
    * By default the uploaded data is limited by the `pekko.http.parsing.max-content-length`.
    */
   final def asSourceOf[T](
@@ -56,15 +56,15 @@ trait FramedEntityStreamingDirectives extends MarshallingDirectives {
    * Extracts entity as [[pekko.stream.scaladsl.Source]] of elements of type `T`.
    * This is achieved by applying the implicitly provided (in the following order):
    *
-   * - 1st: chunk-up the incoming [[ByteString]]s by applying the `Content-Type`-aware framing
-   * - 2nd: apply the [[Unmarshaller]] (from [[ByteString]] to `T`) for each of the respective "chunks" (e.g. for each JSON element contained within an array).
+   * - 1st: chunk-up the incoming `ByteString`s by applying the `Content-Type`-aware framing
+   * - 2nd: apply the `Unmarshaller` (from `ByteString` to `T`) for each of the respective "chunks" (e.g. for each JSON element contained within an array).
    *
    * The request will be rejected with an [[pekko.http.scaladsl.server.UnsupportedRequestContentTypeRejection]] if
-   * its [[ContentType]] is not supported by the used `framing` or `unmarshaller`.
+   * its `ContentType` is not supported by the used `framing` or `unmarshaller`.
    *
    * Cancelling extracted [[pekko.stream.scaladsl.Source]] closes the connection abruptly (same as cancelling the `entity.dataBytes`).
    *
-   * See also [[MiscDirectives.withoutSizeLimit]] as you may want to allow streaming infinite streams of data in this route.
+   * See also `MiscDirectives.withoutSizeLimit` as you may want to allow streaming infinite streams of data in this route.
    * By default the uploaded data is limited by the `pekko.http.parsing.max-content-length`.
    */
   final def asSourceOf[T](support: EntityStreamingSupport)(

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FutureDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FutureDirectives.scala
@@ -52,7 +52,7 @@ trait FutureDirectives {
     * completion with the future's value as an extraction of type `T` if
     * the supplied `CircuitBreaker` is closed.
     *
-    * If the supplied [[CircuitBreaker]] is open the request is rejected
+    * If the supplied `CircuitBreaker` is open the request is rejected
     * with a [[CircuitBreakerOpenRejection]].
     *
     * @group future

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectives.scala
@@ -32,10 +32,10 @@ trait HeaderDirectives {
   import RouteDirectives._
 
   /**
-   * Checks that request comes from the same origin. Extracts the [[Origin]] header value and verifies that
-   * allowed range contains the obtained value. In the case of absent of the [[Origin]] header rejects
+   * Checks that request comes from the same origin. Extracts the `Origin` header value and verifies that
+   * allowed range contains the obtained value. In the case of absent of the `Origin` header rejects
    * with [[MissingHeaderRejection]]. If the origin value is not in the allowed range
-   * rejects with an [[InvalidOriginRejection]] and [[StatusCodes.Forbidden]] status.
+   * rejects with an [[InvalidOriginRejection]] and `StatusCodes.Forbidden` status.
    *
    * @group header
    */
@@ -88,8 +88,8 @@ trait HeaderDirectives {
    * Extracts the first HTTP request header of the given type.
    * If no header with a matching type is found the request is rejected with a [[pekko.http.scaladsl.server.MissingHeaderRejection]].
    *
-   * Custom headers will only be matched by this directive if they extend [[ModeledCustomHeader]]
-   * and provide a companion extending [[ModeledCustomHeaderCompanion]].
+   * Custom headers will only be matched by this directive if they extend `ModeledCustomHeader`
+   * and provide a companion extending `ModeledCustomHeaderCompanion`.
    *
    * @group header
    */
@@ -135,8 +135,8 @@ trait HeaderDirectives {
   /**
    * Extract the header value of the optional HTTP request header with the given type.
    *
-   * Custom headers will only be matched by this directive if they extend [[ModeledCustomHeader]]
-   * and provide a companion extending [[ModeledCustomHeaderCompanion]].
+   * Custom headers will only be matched by this directive if they extend `ModeledCustomHeader`
+   * and provide a companion extending `ModeledCustomHeaderCompanion`.
    *
    * @group header
    */
@@ -165,7 +165,7 @@ trait HeaderMagnet[T] {
 object HeaderMagnet extends LowPriorityHeaderMagnetImplicits {
 
   /**
-   * If possible we want to apply the special logic for [[ModeledCustomHeader]] to extract custom headers by type,
+   * If possible we want to apply the special logic for `ModeledCustomHeader` to extract custom headers by type,
    * otherwise the default `fromCompanion` is good enough (for headers that the parser emits in the right type already).
    */
   implicit def fromCompanionForModeledCustomHeader[T <: ModeledCustomHeader[T], H <: ModeledCustomHeaderCompanion[T]](

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectives.scala
@@ -58,7 +58,7 @@ trait MarshallingDirectives {
     } & cancelRejections(RequestEntityExpectedRejection.getClass, classOf[UnsupportedRequestContentTypeRejection])
 
   /**
-   * Returns the in-scope [[FromRequestUnmarshaller]] for the given type.
+   * Returns the in-scope `FromRequestUnmarshaller` for the given type.
    *
    * @group marshalling
    */

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectives.scala
@@ -98,7 +98,7 @@ trait MiscDirectives {
 
   /**
    * Disables the size limit (configured by `pekko.http.parsing.max-content-length` by default) checking on the incoming
-   * [[HttpRequest]] entity.
+   * `HttpRequest` entity.
    * Can be useful when handling arbitrarily large data uploads in specific parts of your routes.
    *
    * @note  Usage of `withoutSizeLimit` is not recommended as it turns off the too large payload protection. Therefore,

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -26,8 +26,8 @@ import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._
 
 /**
- * Provides directives for securing an inner route using the standard Http authentication headers [[`WWW-Authenticate`]]
- * and [[Authorization]]. Most prominently, HTTP Basic authentication and OAuth 2.0 Authorization Framework
+ * Provides directives for securing an inner route using the standard Http authentication headers `WWW-Authenticate`
+ * and `Authorization`. Most prominently, HTTP Basic authentication and OAuth 2.0 Authorization Framework
  * as defined in RFC 2617 and RFC 6750 respectively.
  *
  * See: <a href="https://www.ietf.org/rfc/rfc2617.txt">RFC 2617</a>.
@@ -78,7 +78,7 @@ trait SecurityDirectives {
   // #async-authenticator-pf
 
   /**
-   * Extracts the potentially present [[HttpCredentials]] provided with the request's [[Authorization]] header.
+   * Extracts the potentially present `HttpCredentials` provided with the request's `Authorization` header.
    *
    * @group security
    */
@@ -202,7 +202,7 @@ trait SecurityDirectives {
 
   /**
    * Lifts an authenticator function into a directive. The authenticator function gets passed in credentials from the
-   * [[Authorization]] header of the request. If the function returns `Right(user)` the user object is provided
+   * `Authorization` header of the request. If the function returns `Right(user)` the user object is provided
    * to the inner route. If the function returns `Left(challenge)` the request is rejected with an
    * [[AuthenticationFailedRejection]] that contains this challenge to be added to the response.
    *
@@ -224,7 +224,7 @@ trait SecurityDirectives {
 
   /**
    * Lifts an authenticator function into a directive. The authenticator function gets passed in credentials from the
-   * [[Authorization]] header of the request. If the function returns `Right(user)` the user object is provided
+   * `Authorization` header of the request. If the function returns `Right(user)` the user object is provided
    * to the inner route. If the function returns `Left(challenge)` the request is rejected with an
    * [[AuthenticationFailedRejection]] that contains this challenge to be added to the response.
    *
@@ -263,8 +263,8 @@ trait SecurityDirectives {
     authorizeAsync(ctx => Future.successful(check(ctx)))
 
   /**
-   * Asynchronous version of [[authorize]].
-   * If the [[Future]] fails or is completed with `false`
+   * Asynchronous version of `authorize`.
+   * If the `Future` fails or is completed with `false`
    * authorization fails and the route is rejected with an [[AuthorizationFailedRejection]].
    *
    * @group security
@@ -273,8 +273,8 @@ trait SecurityDirectives {
     authorizeAsync(ctx => check)
 
   /**
-   * Asynchronous version of [[authorize]].
-   * If the [[Future]] fails or is completed with `false`
+   * Asynchronous version of `authorize`.
+   * If the `Future` fails or is completed with `false`
    * authorization fails and the route is rejected with an [[AuthorizationFailedRejection]].
    *
    * @group security
@@ -306,7 +306,7 @@ object Credentials {
      * This method can be used if the secret is not stored in plain text.
      * Use of this method instead of manual String equality testing is recommended in order to guard against timing attacks.
      *
-     * See also [[EnhancedString#secure_==]], for more information.
+     * See also `org.apache.pekko.http.impl.util.EnhancedString#secure_==`, for more information.
      */
     def verify(secret: String, hasher: String => String): Boolean
 
@@ -314,7 +314,7 @@ object Credentials {
      * Safely compares the passed in `secret` with the received secret part of the Credentials.
      * Use of this method instead of manual String equality testing is recommended in order to guard against timing attacks.
      *
-     * See also [[EnhancedString#secure_==]], for more information.
+     * See also `org.apache.pekko.http.impl.util.EnhancedString#secure_==`, for more information.
      */
     def verify(secret: String): Boolean = verify(secret, x => x)
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/WebSocketDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/WebSocketDirectives.scala
@@ -43,7 +43,7 @@ trait WebSocketDirectives {
     }
 
   /**
-   * Extract the list of WebSocket subprotocols as offered by the client in the [[Sec-WebSocket-Protocol]] header if
+   * Extract the list of WebSocket subprotocols as offered by the client in the `Sec-WebSocket-Protocol` header if
    * this is a WebSocket request. Rejects with an [[ExpectedWebSocketRequestRejection]], otherwise.
    *
    * @group websocket

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/GenericUnmarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/GenericUnmarshallers.scala
@@ -45,7 +45,7 @@ sealed trait LowerPriorityGenericUnmarshallers {
       })
 
   /**
-   * Enables using [[Either]] to encode the following unmarshalling logic:
+   * Enables using `Either` to encode the following unmarshalling logic:
    * Attempt unmarshalling the entity as as `R` first (yielding `R`),
    * and if it fails attempt unmarshalling as `L` (yielding `Left`).
    *

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshal.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshal.scala
@@ -26,7 +26,7 @@ class Unmarshal[A](val value: A) {
   /**
    * Unmarshals the value to the given Type using the in-scope Unmarshaller.
    *
-   * Uses the default materializer [[ExecutionContext]] if no implicit execution context is provided.
+   * Uses the default materializer `ExecutionContext` if no implicit execution context is provided.
    * If you expect the marshalling to be heavy, it is suggested to provide a specialized context for those operations.
    */
   def to[B](implicit um: Unmarshaller[A, B], ec: ExecutionContext = null, mat: Materializer): Future[B] = {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshaller.scala
@@ -115,7 +115,7 @@ object Unmarshaller
       underlying.mapWithInput { (entity, data) => f(data, Unmarshaller.bestUnmarshallingCharsetFor(entity)) }
 
     /**
-     * Modifies the underlying [[Unmarshaller]] to only accept Content-Types matching one of the given ranges.
+     * Modifies the underlying `Unmarshaller` to only accept Content-Types matching one of the given ranges.
      * Note that you can only restrict to a subset of the Content-Types accepted by the underlying unmarshaller,
      * i.e. the given ranges must be completely supported also by the underlying Unmarshaller!
      * If a violation of this rule is detected at runtime, i.e. if an entity is encountered whose Content-Type

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamParser.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamParser.scala
@@ -25,7 +25,7 @@ import pekko.stream.scaladsl.Flow
 import pekko.util.ByteString
 
 /**
- * Flow that converts raw byte string input into [[ServerSentEvent]]s.
+ * Flow that converts raw byte string input into `ServerSentEvent`s.
  *
  * This API is made for use in non-pekko-http clients, like Play's WSClient.
  */
@@ -33,7 +33,7 @@ import pekko.util.ByteString
 object EventStreamParser {
 
   /**
-   * Flow that converts raw byte string input into [[ServerSentEvent]]s.
+   * Flow that converts raw byte string input into `ServerSentEvent`s.
    *
    * This API is made for use in non-pekko-http clients, like Play's WSClient.
    *
@@ -44,7 +44,7 @@ object EventStreamParser {
     apply(maxLineSize, maxEventSize, emitEmptyEvents = false)
 
   /**
-   * Flow that converts raw byte string input into [[ServerSentEvent]]s.
+   * Flow that converts raw byte string input into `ServerSentEvent`s.
    *
    * This API is made for use in non-pekko-http clients, like Play's WSClient.
    *
@@ -56,7 +56,7 @@ object EventStreamParser {
     apply(maxLineSize, maxEventSize, emitEmptyEvents, OversizedSseStrategy.FailStream)
 
   /**
-   * Flow that converts raw byte string input into [[ServerSentEvent]]s.
+   * Flow that converts raw byte string input into `ServerSentEvent`s.
    *
    * This API is made for use in non-pekko-http clients, like Play's WSClient.
    *
@@ -71,7 +71,7 @@ object EventStreamParser {
     apply(maxLineSize, maxEventSize, emitEmptyEvents, OversizedSseStrategy.fromString(oversizedStrategy))
 
   /**
-   * Flow that converts raw byte string input into [[ServerSentEvent]]s.
+   * Flow that converts raw byte string input into `ServerSentEvent`s.
    *
    * This API is made for use in non-pekko-http clients, like Play's WSClient.
    *
@@ -86,7 +86,7 @@ object EventStreamParser {
     apply(maxLineSize, maxEventSize, emitEmptyEvents, oversizedStrategy, oversizedStrategy)
 
   /**
-   * Flow that converts raw byte string input into [[ServerSentEvent]]s.
+   * Flow that converts raw byte string input into `ServerSentEvent`s.
    *
    * This API is made for use in non-pekko-http clients, like Play's WSClient.
    *

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamUnmarshalling.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamUnmarshalling.scala
@@ -28,8 +28,8 @@ import pekko.http.scaladsl.settings.{ OversizedSseStrategy, ServerSentEventSetti
 import pekko.stream.scaladsl.{ Keep, Source }
 
 /**
- * Importing [[EventStreamUnmarshalling.fromEventsStream]] lets an `HttpEntity` with a `text/event-stream` media type be
- * unmarshalled to a source of [[ServerSentEvent]]s.
+ * Importing `EventStreamUnmarshalling.fromEventsStream` lets an `HttpEntity` with a `text/event-stream` media type be
+ * unmarshalled to a source of `ServerSentEvent`s.
  *
  * The maximum size for parsing server-sent events is 8KiB. The maximum size for parsing lines of a server-sent event
  * is 4KiB. If you need to customize any of these, set the `pekko.http.sse.max-event-size` and
@@ -40,7 +40,7 @@ object EventStreamUnmarshalling extends EventStreamUnmarshalling
 
 /**
  * Mixing in this trait lets a `HttpEntity` with a `text/event-stream` media type be unmarshalled to a source of
- * [[ServerSentEvent]]s.
+ * `ServerSentEvent`s.
  *
  * The maximum size for parsing server-sent events is 8KiB by default and can be customized by configuring
  * `pekko.http.sse.max-event-size`. The maximum size for parsing lines of a server-sent event is 4KiB by


### PR DESCRIPTION
## Summary
- Fix ~130 scaladoc warnings across 61 files in http-core, http, http-testkit, and other modules
- Replace unresolvable `[[...]]` links with backtick-quoted code for external types
- Fix incorrect package prefixes (`pekko.` → `org.apache.pekko.`)
- Resolve ambiguous overload links using backtick-quoted code

## Test plan
- [x] `sbt doc` completes with 0 warnings
- [x] No functional changes, documentation only