### PR TITLE
Remove deprecated StatusCodes.PayloadTooLarge and UnprocessableEntity (since 1.1.0)

### DIFF
--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/StatusCodes.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/StatusCodes.java
@@ -100,13 +100,6 @@ public final class StatusCodes {
   public static final StatusCode CONTENT_TOO_LARGE =
       org.apache.pekko.http.scaladsl.model.StatusCodes.ContentTooLarge();
 
-  /**
-   * @deprecated deprecated in favor of CONTENT_TOO_LARGE since 1.1.0
-   */
-  @Deprecated(since = "1.1.0")
-  public static final StatusCode PAYLOAD_TOO_LARGE =
-      org.apache.pekko.http.scaladsl.model.StatusCodes.PayloadTooLarge();
-
   public static final StatusCode URI_TOO_LONG =
       org.apache.pekko.http.scaladsl.model.StatusCodes.UriTooLong();
 
@@ -125,13 +118,6 @@ public final class StatusCodes {
       org.apache.pekko.http.scaladsl.model.StatusCodes.MisdirectedRequest();
   public static final StatusCode UNPROCESSABLE_CONTENT =
       org.apache.pekko.http.scaladsl.model.StatusCodes.UnprocessableContent();
-
-  /**
-   * @deprecated deprecated in favor of UNPROCESSABLE_CONTENT since 1.1.0
-   */
-  @Deprecated(since = "1.1.0")
-  public static final StatusCode UNPROCESSABLE_ENTITY =
-      org.apache.pekko.http.scaladsl.model.StatusCodes.UnprocessableEntity();
 
   public static final StatusCode LOCKED = org.apache.pekko.http.scaladsl.model.StatusCodes.Locked();
   public static final StatusCode FAILED_DEPENDENCY =

--- a/http-core/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
+++ b/http-core/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
@@ -125,3 +125,9 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scalad
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.settings.ServerSettings.websocketRandomFactory")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.settings.ServerSettings.getWebsocketRandomFactory")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.settings.ServerSettings.withWebsocketRandomFactory")
+
+# Remove deprecated StatusCodes (since 1.1.0)
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.model.StatusCodes.PayloadTooLarge")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.model.StatusCodes.UnprocessableEntity")
+ProblemFilters.exclude[MissingFieldProblem]("org.apache.pekko.http.javadsl.model.StatusCodes.PAYLOAD_TOO_LARGE")
+ProblemFilters.exclude[MissingFieldProblem]("org.apache.pekko.http.javadsl.model.StatusCodes.UNPROCESSABLE_ENTITY")

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/StatusCode.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/StatusCode.scala
@@ -151,8 +151,6 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val LengthRequired               = reg(c(411)("Length Required", "The request did not specify the length of its content, which is required by the requested resource."))
   val PreconditionFailed           = reg(c(412)("Precondition Failed", "The server does not meet one of the preconditions that the requester put on the request."))
   val ContentTooLarge              = reg(c(413)("Content Too Large", "The request content is larger than the server is willing or able to process."))
-  @deprecated("deprecated in favor of ContentTooLarge", "1.1.0")
-  val PayloadTooLarge              = ContentTooLarge
   val UriTooLong                   = reg(c(414)("URI Too Long", "The URI provided was too long for the server to process."))
   val UnsupportedMediaType         = reg(c(415)("Unsupported Media Type", "The request entity has a media type which the server or resource does not support."))
   val RangeNotSatisfiable          = reg(c(416)("Range Not Satisfiable", "The client has asked for a portion of the file, but the server cannot supply that portion."))
@@ -161,8 +159,6 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val EnhanceYourCalm              = reg(c(420)("Enhance Your Calm", "You are being rate-limited.")) // Twitter only
   val MisdirectedRequest           = reg(c(421)("Misdirected Request", "The request was directed at a server that is not able to produce a response.")) // HTTP/2 only. https://tools.ietf.org/html/rfc7540#section-9.1.2
   val UnprocessableContent         = reg(c(422)("Unprocessable Content", "The request was well-formed but was unable to be followed due to semantic errors."))
-  @deprecated("deprecated in favor of UnprocessableContent", "1.1.0")
-  val UnprocessableEntity          = UnprocessableContent
   val Locked                       = reg(c(423)("Locked", "The resource that is being accessed is locked."))
   val FailedDependency             = reg(c(424)("Failed Dependency", "The request failed due to failure of a previous request."))
   val TooEarly                     = reg(c(425)("Too Early", "The server is unwilling to risk processing a request that might be replayed.")) // RFC 8470


### PR DESCRIPTION
## Motivation
`PayloadTooLarge` and `UnprocessableEntity` status codes were deprecated since pekko-http 1.1.0 in favor of `ContentTooLarge` and `UnprocessableContent` respectively.

## Modification
Removed deprecated vals from Scala `StatusCodes` object and Java `StatusCodes` class. Added MiMa filters for binary compatibility exceptions.

## Result
Deprecated API removed. Users should use `ContentTooLarge` and `UnprocessableContent`.