### PR TITLE
Remove deprecated ConnectionContext.defaultPort (since Akka HTTP 10.2.0)

### DIFF
--- a/http-core/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
+++ b/http-core/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
@@ -125,3 +125,8 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scalad
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.settings.ServerSettings.websocketRandomFactory")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.settings.ServerSettings.getWebsocketRandomFactory")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.settings.ServerSettings.withWebsocketRandomFactory")
+
+# Remove deprecated ConnectionContext.defaultPort (since Akka HTTP 10.2.0)
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.ConnectionContext.defaultPort")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.HttpsConnectionContext.defaultPort")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.HttpConnectionContext.defaultPort")

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ConnectionContext.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ConnectionContext.scala
@@ -18,10 +18,7 @@ import javax.net.ssl._
 import org.apache.pekko
 import pekko.annotation.{ ApiMayChange, InternalApi }
 
-trait ConnectionContext extends pekko.http.javadsl.ConnectionContext {
-  @deprecated("Internal method, left for binary compatibility", since = "Akka HTTP 10.2.0")
-  protected[http] def defaultPort: Int
-}
+trait ConnectionContext extends pekko.http.javadsl.ConnectionContext
 
 object ConnectionContext {
   // #https-server-context-creation
@@ -91,13 +88,9 @@ object ConnectionContext {
 @InternalApi
 final class HttpsConnectionContext private[http] (
     private[http] val engineCreator: Option[(String, Int)] => SSLEngine)
-    extends pekko.http.javadsl.HttpsConnectionContext with ConnectionContext {
-  protected[http] override final def defaultPort: Int = 443
-}
+    extends pekko.http.javadsl.HttpsConnectionContext with ConnectionContext
 
-sealed class HttpConnectionContext extends pekko.http.javadsl.HttpConnectionContext with ConnectionContext {
-  protected[http] override final def defaultPort: Int = 80
-}
+sealed class HttpConnectionContext extends pekko.http.javadsl.HttpConnectionContext with ConnectionContext
 
 object HttpConnectionContext extends HttpConnectionContext {
 


### PR DESCRIPTION
## Motivation
`ConnectionContext.defaultPort` was deprecated since Akka HTTP 10.2.0 as an internal method left only for binary compatibility.

## Modification
Removed `defaultPort` from `ConnectionContext` trait and its overrides in `HttpsConnectionContext` and `HttpConnectionContext`. Added MiMa filters.

## Result
Deprecated internal method removed.