### PR TITLE
Remove deprecated UnsupportedRequestContentTypeRejection.apply 1-arg (since Akka HTTP 10.1.9)

### DIFF
--- a/http/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
+++ b/http/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
@@ -98,4 +98,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scalad
 
 # Remove deprecated UnsupportedRequestContentTypeRejection.apply 1-arg (since Akka HTTP 10.1.9)
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.server.UnsupportedRequestContentTypeRejection.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.server.UnsupportedRequestContentTypeRejection.andThen")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.server.UnsupportedRequestContentTypeRejection.compose")
 ProblemFilters.exclude[MissingTypesProblem]("org.apache.pekko.http.scaladsl.server.UnsupportedRequestContentTypeRejection$")

--- a/http/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
+++ b/http/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
@@ -95,3 +95,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scalad
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.unmarshalling.sse.EventStreamUnmarshalling.maxEventSize")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.unmarshalling.sse.EventStreamUnmarshalling.fromEventStream")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.unmarshalling.sse.EventStreamUnmarshalling.$init$")
+
+# Remove deprecated UnsupportedRequestContentTypeRejection.apply 1-arg (since Akka HTTP 10.1.9)
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.server.UnsupportedRequestContentTypeRejection.apply")

--- a/http/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
+++ b/http/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
@@ -98,3 +98,4 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scalad
 
 # Remove deprecated UnsupportedRequestContentTypeRejection.apply 1-arg (since Akka HTTP 10.1.9)
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.scaladsl.server.UnsupportedRequestContentTypeRejection.apply")
+ProblemFilters.exclude[MissingTypesProblem]("org.apache.pekko.http.scaladsl.server.UnsupportedRequestContentTypeRejection$")

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
@@ -157,10 +157,6 @@ object UnsupportedRequestContentTypeRejection
       supported: Set[ContentTypeRange], contentType: Option[ContentType]): UnsupportedRequestContentTypeRejection =
     new UnsupportedRequestContentTypeRejection(supported, contentType)
 
-  @deprecated("for binary compatibility", since = "Akka HTTP 10.1.9")
-  def apply(supported: Set[ContentTypeRange]): UnsupportedRequestContentTypeRejection =
-    new UnsupportedRequestContentTypeRejection(supported, None)
-
   def unapply(rejection: UnsupportedRequestContentTypeRejection): Option[Set[ContentTypeRange]] =
     Some(rejection.supported)
 }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
@@ -20,7 +20,7 @@ import java.util.function.Function
 import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
-import scala.runtime.AbstractFunction1
+import scala.runtime.AbstractFunction2
 
 import org.apache.pekko
 import pekko.http.impl.util.JavaMapping._
@@ -151,7 +151,7 @@ final class UnsupportedRequestContentTypeRejection(
 }
 
 object UnsupportedRequestContentTypeRejection
-    extends AbstractFunction1[Set[ContentTypeRange], UnsupportedRequestContentTypeRejection] {
+    extends AbstractFunction2[Set[ContentTypeRange], Option[ContentType], UnsupportedRequestContentTypeRejection] {
 
   def apply(
       supported: Set[ContentTypeRange], contentType: Option[ContentType]): UnsupportedRequestContentTypeRejection =


### PR DESCRIPTION
## Motivation
The 1-arg `apply` overload was deprecated since Akka HTTP 10.1.9, left only for binary compatibility.

## Modification
Removed `UnsupportedRequestContentTypeRejection.apply(supported: Set[ContentTypeRange])`. Added MiMa filter.

## Result
Deprecated API removed. Users should use the 2-arg `apply(supported, contentType)`.