### PR TITLE
GzipDecompressor: fix inflater memory leak

### DIFF
--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/GzipSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/GzipSpec.scala
@@ -14,10 +14,16 @@
 package org.apache.pekko.http.scaladsl.coding
 
 import java.io.{ InputStream, OutputStream }
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.{ GZIPInputStream, GZIPOutputStream, ZipException }
+
+import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.http.impl.util._
+import pekko.http.scaladsl.model.HttpEncodings
+import pekko.stream.SystemMaterializer
+import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.util.ByteString
 
 class GzipSpec extends CoderSpec {
@@ -47,9 +53,57 @@ class GzipSpec extends CoderSpec {
       val ex = the[RuntimeException] thrownBy ourDecode(brokenCompress("abcdefghijkl"))
       ex.ultimateCause.getMessage should equal("Truncated GZIP stream")
     }
+    "release the inflater when decoding completes" in {
+      val inflater = new TrackingInflater
+
+      decodeWith(inflater, streamEncode(smallTextBytes)) should readAs(smallText)
+      inflater.endCalls.get() shouldEqual 1
+    }
+    "release the inflater when decoding is cancelled early" in {
+      val inflater = new TrackingInflater
+      val compressed = streamEncode(largeTextBytes)
+
+      Source.single(compressed)
+        .via(decoderWith(inflater).withMaxBytesPerChunk(1).decoderFlow)
+        .take(1)
+        .runWith(Sink.ignore)
+        .awaitResult(3.seconds.dilated)
+
+      inflater.endCalls.get() shouldEqual 1
+    }
+    "release the inflater when decoding fails on truncation" in {
+      val inflater = new TrackingInflater
+
+      val ex = the[RuntimeException] thrownBy decodeWith(inflater, streamEncode(smallTextBytes).dropRight(5))
+      ex.ultimateCause.getMessage should equal("Truncated GZIP stream")
+      inflater.endCalls.get() shouldEqual 1
+    }
     "throw early if header is corrupt" in {
       val cause = (the[RuntimeException] thrownBy ourDecode(ByteString(0, 1, 2, 3, 4))).ultimateCause
       cause should ((be(a[ZipException]) and have).message("Not in GZIP format"))
+    }
+  }
+
+  private def decodeWith(inflater: TrackingInflater, bytes: ByteString): ByteString =
+    decoderWith(inflater).decode(bytes)(SystemMaterializer(system).materializer).awaitResult(3.seconds.dilated)
+
+  private def decoderWith(inflater: TrackingInflater): StreamDecoder =
+    new StreamDecoder {
+      override val encoding = HttpEncodings.gzip
+
+      override def newDecompressorStage(maxBytesPerChunk: Int) =
+        () =>
+          new GzipDecompressor(maxBytesPerChunk) {
+            override protected[coding] def createInflater() = inflater
+          }
+    }
+
+  private class TrackingInflater extends java.util.zip.Inflater(true) {
+    val endCalls = new AtomicInteger
+
+    override def end(): Unit = {
+      endCalls.incrementAndGet()
+      super.end()
     }
   }
 }

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/GzipSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/GzipSpec.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl.coding
 
 import java.io.{ InputStream, OutputStream }
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.{ GZIPInputStream, GZIPOutputStream, ZipException }
 
@@ -21,9 +22,10 @@ import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.http.impl.util._
-import pekko.http.scaladsl.model.HttpEncodings
+import pekko.http.scaladsl.model.headers.HttpEncodings
 import pekko.stream.SystemMaterializer
 import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.testkit.TestDuration
 import pekko.util.ByteString
 
 class GzipSpec extends CoderSpec {
@@ -49,7 +51,8 @@ class GzipSpec extends CoderSpec {
       ex.ultimateCause.getMessage should equal("Truncated GZIP stream")
     }
     "throw an error if compressed data is just missing the trailer at the end" in {
-      def brokenCompress(payload: String) = Coders.Gzip.newCompressor.compress(ByteString(payload, "UTF-8"))
+      def brokenCompress(payload: String) =
+        Coders.Gzip.newCompressor.compress(ByteString(payload, StandardCharsets.UTF_8))
       val ex = the[RuntimeException] thrownBy ourDecode(brokenCompress("abcdefghijkl"))
       ex.ultimateCause.getMessage should equal("Truncated GZIP stream")
     }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
@@ -70,12 +70,26 @@ private[coding] object GzipCompressor {
 @InternalApi
 private[coding] class GzipDecompressor(
     maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
+  protected[coding] def createInflater(): Inflater = new Inflater(true)
+
   override def createLogic(attr: Attributes) = new ParsingLogic {
-    private val inflater = new Inflater(true)
-    private val crc32: CRC32 = new CRC32
+    private[this] val inflater = createInflater()
+    private[this] val crc32: CRC32 = new CRC32
+    private[this] var inflaterEnded = false
+
+    private def cleanupInflater(): Unit =
+      if (!inflaterEnded) {
+        inflaterEnded = true
+        inflater.end()
+      }
+
+    override def postStop(): Unit = cleanupInflater()
 
     trait Step extends ParseStep[ByteString] {
-      override def onTruncation(): Unit = failStage(new ZipException("Truncated GZIP stream"))
+      override def onTruncation(): Unit = {
+        cleanupInflater()
+        failStage(new ZipException("Truncated GZIP stream"))
+      }
     }
     startWith(ReadHeaders)
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/GzipCompressor.scala
@@ -73,9 +73,9 @@ private[coding] class GzipDecompressor(
   protected[coding] def createInflater(): Inflater = new Inflater(true)
 
   override def createLogic(attr: Attributes) = new ParsingLogic {
-    private[this] val inflater = createInflater()
-    private[this] val crc32: CRC32 = new CRC32
-    private[this] var inflaterEnded = false
+    private val inflater = createInflater()
+    private val crc32: CRC32 = new CRC32
+    private var inflaterEnded = false
 
     private def cleanupInflater(): Unit =
       if (!inflaterEnded) {


### PR DESCRIPTION
See #1133 

`GzipDecompressor` allocates a new `Inflater` per gzip stream but did not explicitly release its native memory. Under collectors with relaxed off-heap reclamation such as ZGC, repeated request decompression can accumulate unreclaimed native buffers and eventually OOM.

- **Inflater lifecycle cleanup**
  - Add explicit `Inflater.end()` cleanup for `GzipDecompressor`
  - Make cleanup idempotent so termination paths can safely converge
  - Run cleanup from stage shutdown (`postStop`) to cover normal completion, failure, and cancellation

- **Truncation handling**
  - Release the inflater before failing truncated gzip streams
  - Preserve the existing `Truncated GZIP stream` behavior while ensuring native resources are not left behind

- **Targeted coverage**
  - Add focused tests that verify the inflater is released on:
    - successful decode completion
    - early downstream cancellation
    - truncation failure

```scala
private def cleanupInflater(): Unit =
  if (!inflaterEnded) {
    inflaterEnded = true
    inflater.end()
  }

override def postStop(): Unit = cleanupInflater()

override def onTruncation(): Unit = {
  cleanupInflater()
  failStage(new ZipException("Truncated GZIP stream"))
}
```