### PR TITLE
DeflateDecompressor: fix inflater memory leak

### DIFF
--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DeflateSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DeflateSpec.scala
@@ -89,7 +89,6 @@ class DeflateSpec extends CoderSpec {
     }
   }
 
-  @nowarn("msg=deprecated")
   private def decodeWith(inflater: TrackingInflater, bytes: ByteString): ByteString =
     decoderWith(inflater).decode(bytes)(SystemMaterializer(system).materializer).awaitResult(3.seconds.dilated)
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DeflateSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DeflateSpec.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl.coding
 
 import java.io.{ InputStream, OutputStream }
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip._
 
@@ -79,6 +80,10 @@ class DeflateSpec extends CoderSpec {
         .runWith(Sink.ignore)
         .awaitResult(3.seconds.dilated)
 
+      // postStop() (which calls end()) is dispatched to the stage actor after the
+      // Sink.ignore future completes, so we must wait for end() itself rather than
+      // for the stream future to avoid a race.
+      inflater.awaitEnd(3.seconds.dilated)
       inflater.endCalls.get() shouldEqual 1
     }
     "release the inflater when decoding is truncated" in {
@@ -106,9 +111,14 @@ class DeflateSpec extends CoderSpec {
 
   private class TrackingInflater extends java.util.zip.Inflater(false) {
     val endCalls = new AtomicInteger
+    private val endLatch = new CountDownLatch(1)
+
+    def awaitEnd(atMost: FiniteDuration): Unit =
+      endLatch.await(atMost.toMillis, TimeUnit.MILLISECONDS)
 
     override def end(): Unit = {
       endCalls.incrementAndGet()
+      endLatch.countDown()
       super.end()
     }
   }

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DeflateSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DeflateSpec.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl.coding
 
 import java.io.{ InputStream, OutputStream }
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip._
 
 import scala.annotation.nowarn
@@ -25,6 +26,8 @@ import pekko.http.impl.util._
 import pekko.http.scaladsl.model.{ HttpEntity, HttpRequest }
 import pekko.http.scaladsl.model.HttpMethods.POST
 import pekko.http.scaladsl.model.headers.{ `Content-Encoding`, HttpEncodings }
+import pekko.stream.SystemMaterializer
+import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.testkit._
 import pekko.util.ByteString
 
@@ -60,6 +63,54 @@ class DeflateSpec extends CoderSpec {
       Coders.Deflate.decodeMessage(encodeMessage(request, Deflater.NO_COMPRESSION, noWrap = false)).toStrict(
         3.seconds.dilated)
         .awaitResult(3.seconds.dilated) should equal(request)
+    }
+    "release the inflater when decoding completes" in {
+      val inflater = new TrackingInflater
+      decodeWith(inflater, streamEncode(smallTextBytes)) should readAs(smallText)
+      inflater.endCalls.get() shouldEqual 1
+    }
+    "release the inflater when decoding is cancelled early" in {
+      val inflater = new TrackingInflater
+      val compressed = streamEncode(largeTextBytes)
+
+      Source.single(compressed)
+        .via(decoderWith(inflater).withMaxBytesPerChunk(1).decoderFlow)
+        .take(1)
+        .runWith(Sink.ignore)
+        .awaitResult(3.seconds.dilated)
+
+      inflater.endCalls.get() shouldEqual 1
+    }
+    "release the inflater when decoding is truncated" in {
+      val inflater = new TrackingInflater
+      // Truncated deflate streams complete without exception (completeStage on truncation)
+      decodeWith(inflater, streamEncode(smallTextBytes).dropRight(5))
+      inflater.endCalls.get() shouldEqual 1
+    }
+  }
+
+  @nowarn("msg=deprecated")
+  private def decodeWith(inflater: TrackingInflater, bytes: ByteString): ByteString =
+    decoderWith(inflater).decode(bytes)(SystemMaterializer(system).materializer).awaitResult(3.seconds.dilated)
+
+  @nowarn("msg=deprecated")
+  private def decoderWith(inflater: TrackingInflater): StreamDecoder =
+    new StreamDecoder {
+      override val encoding = HttpEncodings.deflate
+
+      override def newDecompressorStage(maxBytesPerChunk: Int) =
+        () =>
+          new DeflateDecompressor(maxBytesPerChunk) {
+            override protected[coding] def createInflater(noWrap: Boolean) = inflater
+          }
+    }
+
+  private class TrackingInflater extends java.util.zip.Inflater(false) {
+    val endCalls = new AtomicInteger
+
+    override def end(): Unit = {
+      endCalls.incrementAndGet()
+      super.end()
     }
   }
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DeflateCompressor.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DeflateCompressor.scala
@@ -103,7 +103,19 @@ private[coding] object DeflateCompressor {
 private[coding] class DeflateDecompressor(
     maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
 
+  protected[coding] def createInflater(noWrap: Boolean): Inflater = new Inflater(noWrap)
+
   override def createLogic(attr: Attributes) = new ParsingLogic {
+    private var currentInflater: Inflater = null
+    private var inflaterEnded = false
+
+    private def cleanupInflater(): Unit =
+      if (!inflaterEnded && currentInflater != null) {
+        inflaterEnded = true
+        currentInflater.end()
+      }
+
+    override def postStop(): Unit = cleanupInflater()
 
     /** Step that probes if the deflate stream contains a zlib wrapper */
     case object ProbeWrapping extends ParseStep[ByteString] {
@@ -111,6 +123,7 @@ private[coding] class DeflateDecompressor(
 
       override def parse(reader: ByteStringParser.ByteReader): ParseResult[ByteString] = {
         val inflater = examineAndBuildInflater(reader.remainingData)
+        currentInflater = inflater
         ParseResult(None, new Inflate(inflater, noPostProcessing = true, ProbeWrapping))
       }
     }
@@ -131,7 +144,7 @@ private[coding] class DeflateDecompressor(
      */
     private def examineAndBuildInflater(bytes: ByteString): Inflater = {
       val wrapped = (bytes.head & 0x0F) == 0x08
-      new Inflater(!wrapped)
+      createInflater(!wrapped)
     }
 
     startWith(ProbeWrapping)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DeflateCompressor.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DeflateCompressor.scala
@@ -123,6 +123,7 @@ private[coding] class DeflateDecompressor(
 
       override def parse(reader: ByteStringParser.ByteReader): ParseResult[ByteString] = {
         val inflater = examineAndBuildInflater(reader.remainingData)
+        cleanupInflater()
         currentInflater = inflater
         ParseResult(None, new Inflate(inflater, noPostProcessing = true, ProbeWrapping))
       }


### PR DESCRIPTION
Motivation:
DeflateDecompressor allocates an Inflater per stream but never explicitly releases its native memory. Under GCs with relaxed off-heap reclamation (e.g. ZGC), repeated request decompression can accumulate unreclaimed native buffers and eventually OOM.

Modification:
- Add createInflater(noWrap) factory method to DeflateDecompressor to allow test injection of a custom Inflater
- Track the current inflater in a var within createLogic
- Add idempotent cleanupInflater() that calls inflater.end()
- Override postStop() to call cleanupInflater(), covering normal completion, failure, and cancellation
- Add focused tests in DeflateSpec verifying the inflater is released on successful decode, early cancellation, and truncation

Result:
The Inflater's native memory is reclaimed promptly when the stage terminates, regardless of termination path.

References:
Refs #1134 and #1133