### PR TITLE
remove inaccurate javadoc on internal method

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
@@ -139,14 +139,6 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
     } else onBadProtocol(input.drop(cursor))
   }
 
-  /**
-   * @param ch connection header
-   * @param clh content-length
-   * @param cth content-type
-   * @param teh transfer-encoding
-   * @param e100c expect 100 continue
-   * @param hh host header seen
-   */
   @tailrec protected final def parseHeaderLines(input: ByteString, lineStart: Int,
       headers: ListBuffer[HttpHeader] = initialHeaderBuffer,
       headerCount: Int = 0, ch: Option[Connection] = None,


### PR DESCRIPTION
* ignores some params and includes a non-existent param `teh`
* this is an internal method
* the doc adds no value and param list is easy to read - and scaladoc tool will generate the html with the param names and types anyway if that is what people are using