### PR TITLE
Ensure byte string transformers clean up on every stage stop

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -43,8 +43,7 @@ private[http] object StreamUtils {
    * Creates a transformer that will call `f` for each incoming ByteString and output its result. After the complete
    * input has been read it will call `finish` once to determine the final ByteString to post to the output.
    * Empty ByteStrings are discarded.
-   * If the stage is stopped before the input is fully consumed (e.g. on downstream cancellation or upstream failure),
-   * `cleanup` is called to release any resources held by the transformer.
+   * When the stage stops, `cleanup` is called to release any resources held by the transformer.
    */
   def byteStringTransformer(
       f: ByteString => ByteString,
@@ -53,8 +52,6 @@ private[http] object StreamUtils {
     new SimpleLinearGraphStage[ByteString] {
       override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
         new GraphStageLogic(shape) with InHandler with OutHandler {
-          private var finished = false
-
           override def onPush(): Unit = {
             val data = f(grab(in))
             if (data.nonEmpty) push(out, data)
@@ -65,12 +62,11 @@ private[http] object StreamUtils {
 
           override def onUpstreamFinish(): Unit = {
             val data = finish()
-            finished = true
             if (data.nonEmpty) emit(out, data)
             completeStage()
           }
 
-          override def postStop(): Unit = if (!finished) cleanup()
+          override def postStop(): Unit = cleanup()
 
           setHandlers(in, out, this)
         }

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/util/StreamUtilsSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/util/StreamUtilsSpec.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.http.impl.util
 import org.apache.pekko
 import pekko.stream.Attributes
 import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.stream.testkit.scaladsl.TestSink
 import pekko.util.ByteString
 import pekko.testkit._
 import org.scalatest.concurrent.ScalaFutures
@@ -24,6 +25,44 @@ import scala.concurrent.duration._
 import scala.util.Failure
 
 class StreamUtilsSpec extends PekkoSpec with ScalaFutures {
+
+  "byteStringTransformer" should {
+    "clean up after normal completion" in {
+      val events = TestProbe()
+      val transformed = ByteString("transformed")
+      val trailer = ByteString("trailer")
+      val result =
+        Source
+          .single(ByteString("input"))
+          .via(StreamUtils.byteStringTransformer(_ => transformed, () => trailer, () => events.ref ! "cleanup"))
+          .runWith(Sink.seq)
+
+      Await.result(result, 3.seconds.dilated) shouldBe Seq(transformed, trailer)
+      events.expectMsg("cleanup")
+    }
+
+    "clean up if downstream cancels before the final emission" in {
+      val events = TestProbe()
+      val transformed = ByteString("transformed")
+      val trailer = ByteString("trailer")
+      val downstream =
+        Source
+          .single(ByteString("input"))
+          .via(StreamUtils.byteStringTransformer(
+            _ => transformed,
+            () => {
+              events.ref ! "finish"
+              trailer
+            },
+            () => events.ref ! "cleanup"))
+          .runWith(TestSink[ByteString]())
+
+      downstream.request(1).expectNext(transformed)
+      events.expectMsg("finish")
+      downstream.cancel()
+      events.expectMsg("cleanup")
+    }
+  }
 
   "captureTermination" should {
     "signal completion" when {


### PR DESCRIPTION
### Motivation
PR #1142 added cleanup for byte string transformers, but the stage marked itself finished as soon as finish returned. If the final ByteString was waiting for downstream demand and downstream cancelled, postStop observed the finished flag and skipped cleanup.

The current Deflate and Gzip finish path already closes its Deflater before returning, so this follow-up hardens the generic stage lifecycle rather than claiming a second normal-path native leak.

### Modification
Remove the finished flag and invoke the cleanup callback unconditionally from postStop, making cleanup the single finalizer for normal completion, failure, cancellation, and materializer shutdown.

Add directional StreamUtils tests for normal completion and for cancellation while a final emission is pending.

### Result
Transformer resources are finalized on every stage termination path. The only production cleanup callback is idempotent, so normal completion still calls Deflater.end exactly once.



### References
Refs #1133

Refs #1142