### PR TITLE
Backport: Fix byte string transformer cleanup on stage stop (1.4.x)

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -44,8 +44,7 @@ private[http] object StreamUtils {
    * Creates a transformer that will call `f` for each incoming ByteString and output its result. After the complete
    * input has been read it will call `finish` once to determine the final ByteString to post to the output.
    * Empty ByteStrings are discarded.
-   * If the stage is stopped before the input is fully consumed (e.g. on downstream cancellation or upstream failure),
-   * `cleanup` is called to release any resources held by the transformer.
+   * When the stage stops, `cleanup` is called to release any resources held by the transformer.
    */
   def byteStringTransformer(
       f: ByteString => ByteString,
@@ -54,8 +53,6 @@ private[http] object StreamUtils {
     new SimpleLinearGraphStage[ByteString] {
       override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
         new GraphStageLogic(shape) with InHandler with OutHandler {
-          private var finished = false
-
           override def onPush(): Unit = {
             val data = f(grab(in))
             if (data.nonEmpty) push(out, data)
@@ -66,12 +63,11 @@ private[http] object StreamUtils {
 
           override def onUpstreamFinish(): Unit = {
             val data = finish()
-            finished = true
             if (data.nonEmpty) emit(out, data)
             completeStage()
           }
 
-          override def postStop(): Unit = if (!finished) cleanup()
+          override def postStop(): Unit = cleanup()
 
           setHandlers(in, out, this)
         }

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/util/StreamUtilsSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/util/StreamUtilsSpec.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.http.impl.util
 import org.apache.pekko
 import pekko.stream.Attributes
 import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.stream.testkit.scaladsl.TestSink
 import pekko.util.ByteString
 import pekko.testkit._
 import org.scalatest.concurrent.ScalaFutures
@@ -24,6 +25,44 @@ import scala.concurrent.duration._
 import scala.util.Failure
 
 class StreamUtilsSpec extends PekkoSpec with ScalaFutures {
+
+  "byteStringTransformer" should {
+    "clean up after normal completion" in {
+      val events = TestProbe()
+      val transformed = ByteString("transformed")
+      val trailer = ByteString("trailer")
+      val result =
+        Source
+          .single(ByteString("input"))
+          .via(StreamUtils.byteStringTransformer(_ => transformed, () => trailer, () => events.ref ! "cleanup"))
+          .runWith(Sink.seq)
+
+      Await.result(result, 3.seconds.dilated) shouldBe Seq(transformed, trailer)
+      events.expectMsg("cleanup")
+    }
+
+    "clean up if downstream cancels before the final emission" in {
+      val events = TestProbe()
+      val transformed = ByteString("transformed")
+      val trailer = ByteString("trailer")
+      val downstream =
+        Source
+          .single(ByteString("input"))
+          .via(StreamUtils.byteStringTransformer(
+            _ => transformed,
+            () => {
+              events.ref ! "finish"
+              trailer
+            },
+            () => events.ref ! "cleanup"))
+          .runWith(TestSink[ByteString]())
+
+      downstream.request(1).expectNext(transformed)
+      events.expectMsg("finish")
+      downstream.cancel()
+      events.expectMsg("cleanup")
+    }
+  }
 
   "captureTermination" should {
     "signal completion" when {


### PR DESCRIPTION
### Motivation
Backport of #1154 to the 1.4.x branch.

On the byte-string transformer, `finished` was set before the pending final emission was delivered. If downstream cancelled in that window, `postStop` skipped `cleanup`, leaking transformer resources.

### Modification
Cherry-pick of commit 18796ca69492bcb84b98b52005161fe18c4a055c from `main`:

- Treat `cleanup` as the stage finalizer by invoking it unconditionally from `postStop`.
- Drop the fragile `finished` flag.
- Add directional tests for normal completion and for cancellation while the final emission is pending.

Existing compressor cleanup is idempotent, so the unconditional call is safe.

### Result
All stage termination paths release transformer resources on 1.4.x without relying on a fragile `finished` flag.

### Tests
- Delegated to CI for the 1.4.x branch (mirrors validation already done on `main` in #1154).
- On `main`: `sbt "http-core / Test / testOnly org.apache.pekko.http.impl.util.StreamUtilsSpec"` (7 passed), `sbt "http-tests / Test / testOnly org.apache.pekko.http.scaladsl.coding.DeflateSpec org.apache.pekko.http.scaladsl.coding.GzipSpec"` (54 passed), `sbt checkCodeStyle`, `sbt headerCreateAll`/`+headerCheckAll`, and `scalafmt --list --mode diff-ref=origin/main` all passed.

### References
- Backport of #1154
- Refs #1133; follow-up to #1142