### PR TITLE
use java8 in 1.x builds

### DIFF
--- a/.github/workflows/stage-release-candidate.yml
+++ b/.github/workflows/stage-release-candidate.yml
@@ -205,11 +205,11 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Setup Java 17
+      - name: Setup Java 8
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 8
 
       - name: Install sbt
         uses: sbt/setup-sbt@66fb4376e81982c7d92a4074170846fff88e2e30 # v1.5.0


### PR DESCRIPTION
java 17 has become the norm in 2.x builds