### PR TITLE
Update sbt-reproducible-builds plugin version to 0.35 (1.4.x)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.13
+sbt.version=1.12.14

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,7 +24,7 @@ addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.7.0")
 addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
-addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.33")
+addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.35")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.13")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.7")


### PR DESCRIPTION
Needed for improved reproducibility in builds