### PR TITLE
small optimisation in memory during deflate

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/PerMessageDeflate.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/PerMessageDeflate.scala
@@ -246,16 +246,20 @@ private[http] object PerMessageDeflate {
       try {
         val input = if (appendTail) data ++ EmptyStoredBlock else data
         inflater.setInput(input.toArrayUnsafe())
-        val output = new ByteArrayOutputStream(1024)
+        val maxInitialCapacity =
+          if (settings.maxAllocation > 0) math.min(settings.maxAllocation, 128 * 1024).toInt
+          else 128 * 1024
+        val output = new ByteStringBuilder
+        output.sizeHint(maxInitialCapacity)
         var count = inflater.inflate(buffer)
         while (count > 0) {
           decompressedMessageBytes += count
           if (settings.maxAllocation > 0 && decompressedMessageBytes > settings.maxAllocation)
             throw new ProtocolException("WebSocket decompressed message exceeds configured maximum allocation")
-          output.write(buffer, 0, count)
+          output.putBytes(buffer, 0, count)
           count = inflater.inflate(buffer)
         }
-        ByteString.fromArrayUnsafe(output.toByteArray)
+        output.result()
       } catch {
         case ex: DataFormatException =>
           throw new ProtocolException(s"Invalid WebSocket compressed message: ${ex.getMessage}")


### PR DESCRIPTION
I got Claude AI to analyse this project and its analysis exaggerated the memory impact here.
This change does help a bit but not as much as the original analysis indicated. The existing code is already pretty strong in its protection against memory overallocation.

File: http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/PerMessageDeflate.scala

Replaced ByteArrayOutputStream with ByteStringBuilder in the inflate method of InflaterFlow:

1. ByteArrayOutputStream(1024) → ByteStringBuilder with sizeHint: The old code started with a 1024-byte buffer and doubled on each resize, creating temporary arrays. The new code pre-sizes to min(maxAllocation, 128KB), avoiding excessive reallocations for large messages while not over-allocating for small ones.
2. output.write(buffer, 0, count) → output.putBytes(buffer, 0, count): Uses the Pekko ByteStringBuilder API.
3. ByteString.fromArrayUnsafe(output.toByteArray) → output.result(): The old toByteArray() created a full copy of the internal buffer. ByteStringBuilder.result() avoids this extra copy.

Net effect: Reduces peak memory per decompressed message from ~3x the maxAllocation limit to ~2x (eliminating the extra toByteArray() copy). All 45 existing WebSocket tests pass, including the two max-allocation limit tests.

putBytes calls fillArray which writes into a single _temp array (line 2811-2816). Because we call sizeHint(maxInitialCapacity) before any writes, the _temp array is pre-allocated to the right size. All the putBytes calls write into that single array without resizing.

When result() is called (line 3037-3046):
1. clearTemp() copies _temp into a single ByteString1
2. Since _builder only has one element, it returns bytestrings.head — a single ByteString1

So the result is a ByteString backed by a single contiguous Array[Byte], same as the old code. The difference is the old ByteArrayOutputStream(1024) would resize multiple times (1024→2048→4096→...→262144) before the final toByteArray() copy, while the ByteStringBuilder with sizeHint does one allocation.

The ByteStrings (vector-backed) case only happens if you call addAll with a ByteStrings or if clearTemp() is called multiple times — neither applies here.