### PR TITLE
escape html in FileAndResourceDirectives

### DIFF
--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -535,6 +535,26 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
       shouldReject("..%c1%9c", warnings = 0)
     }
 
+    "escape HTML special characters in file names to prevent XSS" in {
+      // Only test characters that are valid in filenames on all platforms (Windows, macOS, Linux).
+      // Windows forbids " < > | : * ? \ / in filenames.
+      val dir = Files.createTempDirectory("pekko-xss-test").toFile
+      try {
+        writeAllText("ampersand", new File(dir, "a&b.txt"))
+        writeAllText("apostrophe", new File(dir, "a'b.txt"))
+        Get() ~> withSettings(settings)(listDirectoryContents(dir.getAbsolutePath)) ~> check {
+          val body = responseAs[String]
+          body should include("a&amp;b.txt")
+          body should not include "a&b.txt"
+          body should include("a&#39;b.txt")
+          body should not include "a'b.txt"
+        }
+      } finally {
+        dir.listFiles().foreach(_.delete())
+        dir.delete()
+      }
+    }
+
   }
 
   def prep(s: String) = s.stripMarginWithNewline("\n")

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -545,9 +545,9 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
         Get() ~> withSettings(settings)(listDirectoryContents(dir.getAbsolutePath)) ~> check {
           val body = responseAs[String]
           body should include("a&amp;b.txt")
-          body should not include "a&b.txt"
+          (body should not).include("a&b.txt")
           body should include("a&#39;b.txt")
-          body should not include "a'b.txt"
+          (body should not).include("a'b.txt")
         }
       } finally {
         dir.listFiles().foreach(_.delete())

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -400,6 +400,29 @@ object DirectoryListing {
       |</html>
       |""".stripMarginWithNewline("\n").split('$')
 
+  private def escapeHtml(s: String): String = escapeHtml(s, "")
+
+  private def escapeHtml(s1: String, s2: String): String = {
+    val sb = new java.lang.StringBuilder(s1.length + s2.length + 16)
+    def appendEscaped(s: String): Unit = {
+      var i = 0
+      while (i < s.length) {
+        s.charAt(i) match {
+          case '&'  => sb.append("&amp;")
+          case '<'  => sb.append("&lt;")
+          case '>'  => sb.append("&gt;")
+          case '"'  => sb.append("&quot;")
+          case '\'' => sb.append("&#39;")
+          case c    => sb.append(c)
+        }
+        i += 1
+      }
+    }
+    appendEscaped(s1)
+    appendEscaped(s2)
+    sb.toString
+  }
+
   def directoryMarshaller(renderVanityFooter: Boolean): ToEntityMarshaller[DirectoryListing] =
     Marshaller.StringMarshaller.wrap(MediaTypes.`text/html`) { listing =>
       val DirectoryListing(path, isRoot, files) = listing
@@ -412,15 +435,18 @@ object DirectoryListing {
       def maxNameLength(seq: Seq[(File, String)]) = if (seq.isEmpty) 0 else seq.map(_._2.length).max
       val maxNameLen = math.max(maxNameLength(directoryFilesAndNames) + 1, maxNameLength(fileFilesAndNames))
       val sb = new java.lang.StringBuilder
-      sb.append(html(0)).append(path).append(html(1)).append(path).append(html(2))
+      val escapedPath = escapeHtml(path)
+      sb.append(html(0)).append(escapedPath).append(html(1)).append(escapedPath).append(html(2))
       if (!isRoot) {
         val secondToLastSlash = path.lastIndexOf('/', path.lastIndexOf('/', path.length - 1) - 1)
-        sb.append("<a href=\"%s/\">../</a>\n".format(path.substring(0, secondToLastSlash)))
+        sb.append("<a href=\"%s/\">../</a>\n".format(escapeHtml(path.substring(0, secondToLastSlash))))
       }
       def lastModified(file: File) = DateTime(file.lastModified).toIsoLikeDateTimeString
-      def start(name: String) =
-        sb.append("<a href=\"").append(path + name).append("\">").append(name).append("</a>")
+      def start(name: String) = {
+        val escapedName = escapeHtml(name)
+        sb.append("<a href=\"").append(escapeHtml(path, name)).append("\">").append(escapedName).append("</a>")
           .append(" " * (maxNameLen - name.length))
+      }
       def renderDirectory(file: File, name: String) =
         start(name + '/').append("        ").append(lastModified(file)).append('\n')
       def renderFile(file: File, name: String) = {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -400,26 +400,20 @@ object DirectoryListing {
       |</html>
       |""".stripMarginWithNewline("\n").split('$')
 
-  private def escapeHtml(s: String): String = escapeHtml(s, "")
-
-  private def escapeHtml(s1: String, s2: String): String = {
-    val sb = new java.lang.StringBuilder(s1.length + s2.length + 16)
-    def appendEscaped(s: String): Unit = {
-      var i = 0
-      while (i < s.length) {
-        s.charAt(i) match {
-          case '&'  => sb.append("&amp;")
-          case '<'  => sb.append("&lt;")
-          case '>'  => sb.append("&gt;")
-          case '"'  => sb.append("&quot;")
-          case '\'' => sb.append("&#39;")
-          case c    => sb.append(c)
-        }
-        i += 1
+  private def escapeHtml(s: String): String = {
+    val sb = new java.lang.StringBuilder(s.length + 16)
+    var i = 0
+    while (i < s.length) {
+      s.charAt(i) match {
+        case '&'  => sb.append("&amp;")
+        case '<'  => sb.append("&lt;")
+        case '>'  => sb.append("&gt;")
+        case '"'  => sb.append("&quot;")
+        case '\'' => sb.append("&#39;")
+        case c    => sb.append(c)
       }
+      i += 1
     }
-    appendEscaped(s1)
-    appendEscaped(s2)
     sb.toString
   }
 
@@ -444,7 +438,8 @@ object DirectoryListing {
       def lastModified(file: File) = DateTime(file.lastModified).toIsoLikeDateTimeString
       def start(name: String) = {
         val escapedName = escapeHtml(name)
-        sb.append("<a href=\"").append(escapeHtml(path, name)).append("\">").append(escapedName).append("</a>")
+        sb.append("<a href=\"").append(escapeHtml(path)).append(escapedName).append("\">").append(escapedName).append(
+          "</a>")
           .append(" " * (maxNameLen - name.length))
       }
       def renderDirectory(file: File, name: String) =

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -440,7 +440,12 @@ object DirectoryListing {
         val escapedName = escapeHtml(name)
         sb.append("<a href=\"").append(escapeHtml(path)).append(escapedName).append("\">").append(escapedName).append(
           "</a>")
-          .append(" " * (maxNameLen - name.length))
+        var padding = maxNameLen - name.length
+        while (padding > 0) {
+          sb.append(' ')
+          padding -= 1
+        }
+        sb
       }
       def renderDirectory(file: File, name: String) =
         start(name + '/').append("        ").append(lastModified(file)).append('\n')


### PR DESCRIPTION
Added escapeHtml methods to the DirectoryListing object that escape the five HTML special characters (&, <, >, ", '). Applied to all user-controlled strings in the directory listing HTML:

- path in `<title>` and `<h1>` tags
- path in the "../" parent directory link href
- path + name in file/directory link hrefs (via the two-argument overload, avoiding an intermediate string concatenation)
- name as link text content

Pretty unlikely but there is a theoretical chance that filenames could have problematic XSS type names.
Claude AI thinks that we should harden the code as a result.