### PR TITLE
enable by default - pekko.http.server.http2.frame-type-throttle.frame-types = ["reset"]

### DIFF
--- a/http-core/src/main/resources/reference.conf
+++ b/http-core/src/main/resources/reference.conf
@@ -316,10 +316,11 @@ pekko.http {
 
       frame-type-throttle {
         # Configure the throttle for non-data frame types (https://github.com/apache/pekko-http/issues/332).
-        # The supported frame-types for throttlng are:
+        # The supported frame-types for throttling are:
         # reset, headers, continuation, go-away, priority, ping, push-promise, window-update
-        # If you are concerned about CVE-2023-44487, you could set: pekko.http.server.http2.frame-type-throttle.frame-types = ["reset"]
-        frame-types = []
+        # By default, RST_STREAM frames are throttled to mitigate HTTP/2 Rapid Reset attacks (CVE-2023-44487).
+        # Set to [] to disable throttling.
+        frame-types = ["reset"]
         cost = 100
         burst = 100
         # interval must be a positive duration

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDisableFrameTypeThrottleSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDisableFrameTypeThrottleSpec.scala
@@ -21,10 +21,11 @@ import pekko.http.impl.engine.http2.framing.FrameRenderer
 import pekko.util.ByteStringBuilder
 
 /**
- * This tests the http2 server throttle support for rapid resets is disabled by default.
+ * This tests the http2 server throttle support for rapid resets when explicitly disabled.
  */
 class Http2ServerDisableFrameTypeThrottleSpec extends Http2SpecWithMaterializer("""
     pekko.http.server.http2.log-frames = on
+    pekko.http.server.http2.frame-type-throttle.frame-types = []
   """) {
   override def failOnSevereMessages: Boolean = true
 


### PR DESCRIPTION
In pekko-http 1.x, you have to opt in for this.