### PR TITLE
fix: use root locale when looking up a response header by name in RouteTest

### DIFF
--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTest.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTest.scala
@@ -36,6 +36,7 @@ import pekko.stream.{ Materializer, SystemMaterializer }
 import pekko.stream.scaladsl.Source
 import pekko.testkit.TestKit
 import pekko.util.ConstantFun
+import pekko.util.Helpers.toRootLowerCase
 
 import com.typesafe.config.{ Config, ConfigFactory }
 
@@ -96,7 +97,7 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
   def charset: HttpCharset = charsetOption.getOrElse(sys.error("Binary entity does not have charset"))
   def headers: immutable.Seq[HttpHeader] = rawResponse.headers
   def header[T >: Null <: HttpHeader: ClassTag]: Option[T] = rawResponse.header[T](implicitly[ClassTag[T]])
-  def header(name: String): Option[HttpHeader] = rawResponse.headers.find(_.is(name.toLowerCase))
+  def header(name: String): Option[HttpHeader] = rawResponse.headers.find(_.is(toRootLowerCase(name)))
   def status: StatusCode = rawResponse.status
 
   def closingExtension: String = chunks.lastOption match {

--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.http.scaladsl.testkit
 
+import java.util.Locale
+
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -54,6 +56,25 @@ class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRou
         status shouldEqual OK
         responseEntity shouldEqual HttpEntity(ContentTypes.`text/plain(UTF-8)`, "abc")
         header("Fancy") shouldEqual Some(pinkHeader)
+      }
+    }
+
+    "a header lookup by name that is unaffected by the turkish-i problem" in {
+      val previousLocale = Locale.getDefault
+      try {
+        Locale.setDefault(new Locale("tr", "TR"))
+        // in the turkish locale 'I'.toLowerCase is a dotless i, so a default-locale
+        // lowercasing of 'If-Match' would not match the header's lowercaseName
+        val ifMatchHeader = RawHeader("If-Match", "\"xyzzy\"")
+        Get() ~> {
+          respondWithHeader(ifMatchHeader) {
+            complete("abc")
+          }
+        } ~> check {
+          header("If-Match") shouldEqual Some(ifMatchHeader)
+        }
+      } finally {
+        Locale.setDefault(previousLocale)
       }
     }
 


### PR DESCRIPTION
### Motivation
`RouteTest#header(name: String)` in the Scala testkit lowercased the supplied header name using the JVM default locale:

```scala
def header(name: String): Option[HttpHeader] = rawResponse.headers.find(_.is(name.toLowerCase))
```

`HttpHeader#lowercaseName` is built with `toRootLowerCase`, so under a Turkish default locale the two disagree: `"If-Match".toLowerCase` is `ıf-match` (dotless i) while `lowercaseName` is `if-match`. Any header name containing a capital `I` then silently resolves to `None`.

The rest of the code base already guards against this (`Helpers.toRootLowerCase`, `CharUtils.toLowerCase` for the ASCII-only paths, and `HttpCharsets` has a regression test in `TurkishISpec`). The javadsl equivalent, `javadsl/testkit/TestRouteResult`, already uses `toRootLowerCase` — only the scaladsl side was missed.

### Modification
Use `pekko.util.Helpers.toRootLowerCase` in `RouteTest#header(name)`.

### Result
Header lookup by name in the Scala testkit is locale independent and consistent with both `HttpHeader#lowercaseName` and the javadsl testkit.

### Tests
- Added a regression test to `ScalatestRouteTestSpec` that sets the default locale to `tr-TR` (restoring it in a `finally`) and looks up an `If-Match` header by name. It fails with `None was not equal to Some(If-Match: "xyzzy")` before the fix and passes after it.
- `sbt "http-testkit / Test / testOnly org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTestSpec"` - 12 tests passed (JDK 21).
- `scalafmt --mode diff-ref=origin/main` - clean.
- `sbt +mimaReportBinaryIssues` - not run; this is a method body change with no public API or binary shape change.

### References
None - found while auditing the code base for locale sensitive lowercasing